### PR TITLE
Make gem install command use #{version}

### DIFF
--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -25,7 +25,7 @@ relative_path "omnibus-ctl"
 
 build do
   gem "build omnibus-ctl.gemspec"
-  gem "install omnibus-ctl-0.0.4.gem"
+  gem "install omnibus-ctl-#{version}.gem"
   command "mkdir -p #{install_dir}/embedded/service/omnibus-ctl"
 end
 


### PR DESCRIPTION
omnibus-ctl definition has gem install command with out-of-sync version
- Use #{verison} in build command to keep in sync
