### PR TITLE
Fix libiconv build on systems with glibc 2.16+.

### DIFF
--- a/config/patches/libiconv/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
+++ b/config/patches/libiconv/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
@@ -1,0 +1,30 @@
+diff -r -u libiconv-1.14/srclib/stdio.in.h.orig libiconv-1.14/srclib/stdio.in.h
+--- libiconv-1.14/srclib/stdio.in.h.orig	2013-02-22 13:52:46.336327969 -0600
++++ libiconv-1.14/srclib/stdio.in.h	2013-02-22 13:54:27.948207059 -0600
+@@ -679,22 +679,11 @@
+ # endif
+ #endif
+ 
+-#if @GNULIB_GETS@
+-# if @REPLACE_STDIO_READ_FUNCS@ && @GNULIB_STDIO_H_NONBLOCKING@
+-#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
+-#   undef gets
+-#   define gets rpl_gets
+-#  endif
+-_GL_FUNCDECL_RPL (gets, char *, (char *s) _GL_ARG_NONNULL ((1)));
+-_GL_CXXALIAS_RPL (gets, char *, (char *s));
+-# else
+-_GL_CXXALIAS_SYS (gets, char *, (char *s));
+-#  undef gets
+-# endif
+-_GL_CXXALIASWARN (gets);
+ /* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
++   so any use of gets warrants an unconditional warning; besides, C11
++   removed it.  */
++#undef gets
++#if HAVE_RAW_DECL_GETS
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+ #endif
+ 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -42,7 +42,18 @@ if platform == "solaris2"
   env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc", "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
 end
 
+def glibc_dropped_gets?
+  return false unless OHAI["os"] == "linux"
+
+  output = `/usr/bin/env getconf GNU_LIBC_VERSION`
+
+  return false unless output =~ /^glibc/
+
+  output.sub(/glibc /, "").to_f >= 2.16
+end
+
 build do
+  patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch' if glibc_dropped_gets?
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env


### PR DESCRIPTION
Incorporate part of upstream patch (see: lib/stdio.in.h bits from
https://lists.gnu.org/archive/html/bug-gnulib/2012-03/msg00186.html)
to fix libiconv 1.14 build on systems with glibc 2.16+.  Long story
short, glibc dropped support for gets, so we need to remove the
gets declarations from srclib/stdio.in.h.
