### PR TITLE
add O3 and -g flags for ruby

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -36,7 +36,7 @@ env =
   case platform
   when "mac_os_x"
     {
-      "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+      "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses -O3 -g -pipe",
       "LDFLAGS" => "-arch x86_64 -R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses"
     }
   when "solaris2"
@@ -47,7 +47,7 @@ env =
     }
     elsif Omnibus.config.solaris_compiler == "gcc"
     {
-      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -O3 -g -pipe",
       "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
       "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
     }
@@ -56,7 +56,7 @@ env =
     end
   else
     {
-      "CFLAGS" => "-I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
       "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
     }
   end


### PR DESCRIPTION
Setting any CFLAGS completely disables ruby's default CFLAG settings. On
my mac I have flags like:

```
" -O3 -ggdb -Wextra -Wno-unused-parameter -Wno-parentheses
-Wno-long-long -Wno-missing-field-initializers -Werror=pointer-arith
-Werror=write-strings -Werror=declaration-after-statement
-Werror=shorten-64-to-32 -Werror=implicit-function-declaration  -pipe"
```

But Omnibus currently builds ruby with no optimization and no gdb
support:

```
"-I/opt/chef/embedded/include -fPIC"
```

This patch restores the default flags that ruby normally uses when we're compiling with gcc. Sun studio is left alone.
