### PR TITLE
removal of libiconv and rc5 crypto algorithm from openssl

### DIFF
--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -35,5 +35,6 @@ end
 build do
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
-  command "make install", :env => env
+  #disables building libiconv as its deprecated and no longer used in ruby as of ruby 1.9.3
+  #command "make install", :env => env
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -62,6 +62,7 @@ build do
                          "--prefix=#{install_dir}/embedded",
                         "--with-zlib-lib=#{install_dir}/embedded/lib",
                         "--with-zlib-include=#{install_dir}/embedded/include",
+                        "no-rc5",
                         "zlib",
                         "shared"].join(" ")
                       when "solaris2"
@@ -73,6 +74,7 @@ build do
                             "--with-zlib-lib=#{install_dir}/embedded/lib",
                             "--with-zlib-include=#{install_dir}/embedded/include",
                             "zlib",
+                            "no-rc5",
                             "shared",
                             "-L#{install_dir}/embedded/lib",
                             "-I#{install_dir}/embedded/include",
@@ -87,6 +89,7 @@ build do
                             "--with-zlib-lib=#{install_dir}/embedded/lib",
                             "--with-zlib-include=#{install_dir}/embedded/include",
                             "zlib",
+                            "no-rc5",
                             "shared",
                             "-L#{install_dir}/embedded/lib",
                             "-I#{install_dir}/embedded/include",
@@ -102,6 +105,7 @@ build do
                         "--with-zlib-lib=#{install_dir}/embedded/lib",
                         "--with-zlib-include=#{install_dir}/embedded/include",
                         "zlib",
+                        "no-rc5",
                         "shared",
                         "disable-gost",
                         "-L#{install_dir}/embedded/lib",


### PR DESCRIPTION
disables building libiconv as it is deprecated as of ruby 1.9.3 and is not used anywhere inside of chef. also removes the rc5 crypto algorithm from openssl, added a compilation flag "no-rc5"
