### PR TITLE
remove iconv (GPL) from ruby dependency

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -23,7 +23,6 @@ dependency "ncurses"
 dependency "libedit"
 dependency "openssl"
 dependency "libyaml"
-dependency "libiconv"
 dependency "gdbm" if (platform == "mac_os_x" or platform == "freebsd")
 dependency "libgcc" if (platform == "solaris2" and Omnibus.config.solaris_compiler == "gcc")
 
@@ -65,7 +64,7 @@ build do
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded",
                        "--with-opt-dir=#{install_dir}/embedded",
-                       "--with-out-ext=fiddle",
+                       "--with-out-ext=fiddle,iconv",
                        "--enable-shared",
                        "--enable-libedit",
                        "--with-ext=psych",


### PR DESCRIPTION
requested by <name redacted> to remove GPL software from chef-client.

we still have other dependencies on iconv in private chef which i think are due to nagios.

i believe this will break any chef_gems that do a require 'iconv', but i believe that iconv has been deprecated for quite some time now?
