### PR TITLE
removing iconv binary due to GPL concerns

### DIFF
--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -35,5 +35,5 @@ end
 build do
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
-  command "make install", :env => env
+  command "make install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env
 end


### PR DESCRIPTION
the binary is GPL, the libraries are LGPL.
