### PR TITLE
removing some algs due to patent concerns, and rearranging

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -55,23 +55,28 @@ build do
           }
         end
 
+  common_args = [
+    "--prefix=#{install_dir}/embedded",
+    "--with-zlib-lib=#{install_dir}/embedded/lib",
+    "--with-zlib-include=#{install_dir}/embedded/include",
+    "no-idea",
+    "no-mdc2",
+    "no-rc5",
+    "zlib",
+    "shared",
+    "disable-gost",
+  ].join(" ")
+
   configure_command = case platform
                       when "mac_os_x"
                         ["./Configure",
                          "darwin64-x86_64-cc",
-                         "--prefix=#{install_dir}/embedded",
-                        "--with-zlib-lib=#{install_dir}/embedded/lib",
-                        "--with-zlib-include=#{install_dir}/embedded/include",
-                        "zlib",
-                        "shared"].join(" ")
+                         common_args,
+                        ].join(" ")
                       when "smartos"
                         ["/bin/bash ./Configure",
                          "solaris64-x86_64-gcc",
-                         "--prefix=#{install_dir}/embedded",
-                         "--with-zlib-lib=#{install_dir}/embedded/lib",
-                         "--with-zlib-include=#{install_dir}/embedded/include",
-                        "zlib",
-                        "shared",
+                         common_args,
                          "-L#{install_dir}/embedded/lib",
                          "-I#{install_dir}/embedded/include",
                          "-R#{install_dir}/embedded/lib",
@@ -81,11 +86,7 @@ build do
                           if architecture == "sparc"
                             ["/bin/sh ./Configure",
                              "solaris-sparcv9-gcc",
-                             "--prefix=#{install_dir}/embedded",
-                            "--with-zlib-lib=#{install_dir}/embedded/lib",
-                            "--with-zlib-include=#{install_dir}/embedded/include",
-                            "zlib",
-                            "shared",
+                             common_args,
                             "-L#{install_dir}/embedded/lib",
                             "-I#{install_dir}/embedded/include",
                             "-R#{install_dir}/embedded/lib",
@@ -95,11 +96,7 @@ build do
                             # Errno::ENOEXEC: Exec format error
                             ["/bin/sh ./Configure",
                              "solaris-x86-gcc",
-                             "--prefix=#{install_dir}/embedded",
-                            "--with-zlib-lib=#{install_dir}/embedded/lib",
-                            "--with-zlib-include=#{install_dir}/embedded/include",
-                            "zlib",
-                            "shared",
+                             common_args,
                             "-L#{install_dir}/embedded/lib",
                             "-I#{install_dir}/embedded/include",
                             "-R#{install_dir}/embedded/lib",
@@ -110,12 +107,7 @@ build do
                         end
                       else
                         ["./config",
-                         "--prefix=#{install_dir}/embedded",
-                        "--with-zlib-lib=#{install_dir}/embedded/lib",
-                        "--with-zlib-include=#{install_dir}/embedded/include",
-                        "zlib",
-                        "shared",
-                        "disable-gost",
+                        common_args,
                         "-L#{install_dir}/embedded/lib",
                         "-I#{install_dir}/embedded/include",
                         "-Wl,-rpath,#{install_dir}/embedded/lib"].join(" ")


### PR DESCRIPTION
disabling RC5 at _redacted_'s request, also removing IDEA and MDC2 since the openssl FAQ on patents mentions those and we are not using them.

rearranged the code slightly to remove duplication, and added disable-gost to all of the compiles (i added that to one of them to get 1.0.1c to compile awhile back, and in the interests of uniformity it should be removed from them all).
