### PR TITLE
add missing libgcc dependency to libraries

### DIFF
--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -19,6 +19,7 @@ name "libedit"
 version "20120601-3.0"
 
 dependency "ncurses"
+dependency "libgcc"
 
 source :url => "http://www.thrysoee.dk/editline/libedit-20120601-3.0.tar.gz",
        :md5 => "e50f6a7afb4de00c81650f7b1a0f5aea"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -18,6 +18,8 @@
 name "libiconv"
 version "1.14"
 
+dependency "libgcc"
+
 source :url => 'http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz',
        :md5 => 'e34509b1623cec449dfeb73d7ce9c6c6'
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -18,6 +18,8 @@
 name "ncurses"
 version "5.9"
 
+dependency "libgcc"
+
 source :url => "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
        :md5 => "8cb9c412e5f2d96bc6f459aa8c6282a1"
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -20,6 +20,7 @@ version "1.0.1c"
 
 dependency "zlib"
 dependency "cacerts"
+dependency "libgcc"
 
 source :url => "http://www.openssl.org/source/openssl-1.0.1c.tar.gz",
        :md5 => "ae412727c8c15b67880aef7bd2999b2e"


### PR DESCRIPTION
This forces libgcc to build before them, which prevents build failure
caused by health check failures. For unknown reasons, the failures tend
to happen on Solaris systems and are nondeterministic.

Example build failure:

```
[health_check] *** The precise failures were:
[health_check]     --> /opt/chef/embedded/lib/libedit.so.0.0.41
[health_check]     DEPENDS ON: libtinfo.so.5
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: (file not found)
[health_check]       FAILED BECAUSE: Unresolved dependency
[health_check]     --> /opt/chef/embedded/lib/libedit.so.0.0.41
[health_check]     DEPENDS ON: libgcc_s.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /opt/csw/lib/libgcc_s.so.1
[health_check]       FAILED BECAUSE: Unsafe dependency
```
