### PR TITLE
fixes for [CHEF-4177]

### DIFF
--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -38,6 +38,8 @@ if platform == "solaris2"
   env.merge!({"PATH" => "/opt/csw/gcc3/bin:/opt/csw/bin:/usr/local/bin:/usr/sfw/bin:/usr/ccs/bin:/usr/sbin:/usr/bin"})
   env.merge!({"CC" => "/opt/csw/gcc3/bin/gcc"})
   env.merge!({"CXX" => "/opt/csw/gcc3/bin/g++"})
+elsif platform == "smartos"
+  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib "})
 end
 
 ########################################################################


### PR DESCRIPTION
- remove -R/-rpath from ncurses LDFLAGS - Recent versions of GCC have gotten cranky when passed unrecognized options. We don't need to set `-R` or `-Wl,-rpath` in LDFLAGS as we already set a a path in the LD_RUN_PATH environment variable.
- set ncurses LD_OPTIONS on SmartOS - This environment variable is specific to Solaris flavored *nix and ensures the linker finds and links against other Omnibus dependencies.
