### PR TITLE
Update OpenSSL to v1.0.1e.

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -16,16 +16,16 @@
 #
 
 name "openssl"
-version "1.0.1c"
+version "1.0.1e"
 
 dependency "zlib"
 dependency "cacerts"
 dependency "libgcc"
 
-source :url => "http://www.openssl.org/source/openssl-1.0.1c.tar.gz",
-       :md5 => "ae412727c8c15b67880aef7bd2999b2e"
+source :url => "http://www.openssl.org/source/openssl-1.0.1e.tar.gz",
+       :md5 => "66bf6f10f060d561929de96f9dfe5b8c"
 
-relative_path "openssl-1.0.1c"
+relative_path "openssl-1.0.1e"
 
 build do
   env = case platform


### PR DESCRIPTION
OpenSSL versions 1.0.1d and 1.0.1e were released in February 2013
with several bug and security fixes.  See http://www.openssl.org
for details.
