### PR TITLE
fix libiconv failing to build on glibc 2.16

### DIFF
--- a/config/patches/libiconv/gets-undefined-in-C11.patch
+++ b/config/patches/libiconv/gets-undefined-in-C11.patch
@@ -1,0 +1,27 @@
+--- libiconv-1.14.orig/srclib/stdio.in.h	2011-08-07 13:42:06.000000000 +0000
++++ libiconv-1.14/srclib/stdio.in.h	2013-01-09 19:56:21.115819812 +0000
+@@ -680,22 +680,7 @@
+ #endif
+ 
+ #if @GNULIB_GETS@
+-# if @REPLACE_STDIO_READ_FUNCS@ && @GNULIB_STDIO_H_NONBLOCKING@
+-#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
+-#   undef gets
+-#   define gets rpl_gets
+-#  endif
+-_GL_FUNCDECL_RPL (gets, char *, (char *s) _GL_ARG_NONNULL ((1)));
+-_GL_CXXALIAS_RPL (gets, char *, (char *s));
+-# else
+-_GL_CXXALIAS_SYS (gets, char *, (char *s));
+-#  undef gets
+-# endif
+-_GL_CXXALIASWARN (gets);
+-/* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
+-_GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#undef gets
+ #endif
+ 
+ 
+

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -33,6 +33,8 @@ if platform == "solaris2"
 end
 
 build do
+  patch :source => "gets-undefined-in-C11.patch",
+        :target => "./srclib/stdio.in.h"
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make install", :env => env


### PR DESCRIPTION
gets was removed in glibc 2.16, and should be never used
libiconv would require gnulib updating (as gnulib is patched)
but until then just undef gets

see http://savannah.gnu.org/bugs/?37171
