### PR TITLE
Use python26 on redhat < 6 to configure node.js

### DIFF
--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -23,8 +23,15 @@ source :url => "http://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz",
 
 relative_path "node-v#{version}"
 
+# Ensure we run with Python 2.6 on Redhats < 6
+if OHAI['platform_family'] == "rhel" && OHAI['platform_version'].to_f < 6
+  python = 'python26'
+else
+  python = 'python'
+end
+
 build do
-  command "./configure --prefix=#{install_dir}/embedded"
+  command "#{python} ./configure --prefix=#{install_dir}/embedded"
   command "make -j #{max_build_jobs}"
   command "make install"
 end


### PR DESCRIPTION
Node.js requires at least Python 2.6 to compile. The default version of `/usr/bin/python` on rhels < 6 is 2.4. Use the `python26` binary on these platforms to run `configure`
