### PR TITLE
remove autoconf - its not doing anything other than breaking AIX builds

### DIFF
--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -18,6 +18,8 @@
 name "gdbm"
 version "1.9.1"
 
+dependency "libgcc"
+
 source :url => "http://ftp.gnu.org/gnu/gdbm/gdbm-1.9.1.tar.gz",
        :md5 => "59f6e4c4193cb875964ffbe8aa384b58"
 


### PR DESCRIPTION
this would have passed CI if github wasn't trolling the macosx builds:  http://ci.opscode.us/job/chef-client-build/621
