### PR TITLE
OpenResty: remove `LDFLAGS` unknown `-R` option

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -29,7 +29,7 @@ relative_path "ngx_openresty-#{version}"
 
 build do
   env = {
-    "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
   }


### PR DESCRIPTION
GCC 4.6+ rejects unknown options, previously passed to the linker. Fix 
is to remove the `-R` option which is not needed here.

This patch will enable:
- Updating OSC to use OpenResty for it's load balance dep.
- Building OPC on Ubuntu 12.04 LTS.

This fix has been fully tested with the OSC pipeline:
http://andra.ci.opscode.us/job/chef-server-trigger-ad-hoc/63/downstreambuildview/?

/cc @lamont-granquist @hosh @christophermaier @seth 
