### PR TITLE
add `logrotate` software definition

### DIFF
--- a/config/patches/logrotate/logrotate_basedir_override.patch
+++ b/config/patches/logrotate/logrotate_basedir_override.patch
@@ -1,0 +1,12 @@
+--- Makefile  2013-06-10 08:02:36.000000000 -0400
++++ Makefile  2013-07-01 15:26:41.000000000 -0400
+@@ -90,6 +90,10 @@
+     CFLAGS += -DSTATEFILE=\"$(STATEFILE)\"
+ endif
+
++ifneq ($(BASEDIR),)
++    BASEDIR = $BASEDIR
++endif
++
+ BINDIR = $(BASEDIR)/sbin
+ MANDIR ?= $(BASEDIR)/man

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "logrotate"
+version "3.8.5"
+
+dependency "popt"
+
+source :url => "https://fedorahosted.org/releases/l/o/logrotate/logrotate-#{version}.tar.gz",
+       :md5 => "d3c13e2a963a55c584cfaa83e96b173d"
+
+relative_path "logrotate-#{version}"
+
+env = {
+  # Patch allows this to be set manually
+  "BASEDIR" => "#{install_dir}/embedded",
+  # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS
+  # and CFLAGS
+  "EXTRA_LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "EXTRA_CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+}
+
+build do
+  patch :source => "logrotate_basedir_override.patch", :plevel => 0
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end


### PR DESCRIPTION
A simple patch is required since `logrotate` does not ship with a 
configure script. The only way to set the effective prefix is to 
manually override `BASEDIR`, which is exactly what the patch does!
