### PR TITLE
openssl: fix documentation errors with perl 5.18.

### DIFF
--- a/config/patches/openssl/openssl-1.0.1e-do-not-build-docs.patch
+++ b/config/patches/openssl/openssl-1.0.1e-do-not-build-docs.patch
@@ -1,0 +1,101 @@
+--- openssl-1.0.1e/Makefile.org.orig	2013-07-12 15:03:36.208991019 -0500
++++ openssl-1.0.1e/Makefile.org	2013-07-12 15:05:25.837652014 -0500
+@@ -167,7 +167,7 @@
+ 
+ TOP=    .
+ ONEDIRS=out tmp
+-EDIRS=  times doc bugs util include certs ms shlib mt demos perl sf dep VMS
++EDIRS=  times bugs util include certs ms shlib mt demos perl sf dep VMS
+ WDIRS=  windows
+ LIBS=   libcrypto.a libssl.a
+ SHARED_CRYPTO=libcrypto$(SHLIB_EXT)
+@@ -537,7 +537,7 @@
+ dist_pem_h:
+ 	(cd crypto/pem; $(MAKE) -e $(BUILDENV) pem.h; $(MAKE) clean)
+ 
+-install: all install_docs install_sw
++install: all install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
+@@ -602,7 +602,6 @@
+ 			echo 'OpenSSL shared libraries have been installed in:'; \
+ 			echo '  $(INSTALLTOP)'; \
+ 			echo ''; \
+-			sed -e '1,/^$$/d' doc/openssl-shared.txt; \
+ 		fi; \
+ 	fi
+ 	cp libcrypto.pc $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig
+@@ -612,72 +611,4 @@
+ 	cp openssl.pc $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig/openssl.pc
+ 
+-install_html_docs:
+-	here="`pwd`"; \
+-	for subdir in apps crypto ssl; do \
+-		mkdir -p $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir; \
+-		for i in doc/$$subdir/*.pod; do \
+-			fn=`basename $$i .pod`; \
+-			echo "installing html/$$fn.$(HTMLSUFFIX)"; \
+-			cat $$i \
+-			| sed -r 's/L<([^)]*)(\([0-9]\))?\|([^)]*)(\([0-9]\))?>/L<\1|\3>/g' \
+-			| pod2html --podroot=doc --htmlroot=.. --podpath=apps:crypto:ssl \
+-			| sed -r 's/<!DOCTYPE.*//g' \
+-			> $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir/$$fn.$(HTMLSUFFIX); \
+-			$(PERL) util/extract-names.pl < $$i | \
+-				grep -v $$filecase "^$$fn\$$" | \
+-				(cd $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir; \
+-				 while read n; do \
+-					PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$(HTMLSUFFIX) "$$n".$(HTMLSUFFIX); \
+-				 done); \
+-		done; \
+-	done
+-
+-install_docs:
+-	@$(PERL) $(TOP)/util/mkdir-p.pl \
+-		$(INSTALL_PREFIX)$(MANDIR)/man1 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man3 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man5 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man7
+-	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+-	here="`pwd`"; \
+-	filecase=; \
+-	if [ "$(PLATFORM)" = "DJGPP" -o "$(PLATFORM)" = "Cygwin" -o "$(PLATFORM)" = "mingw" ]; then \
+-		filecase=-i; \
+-	fi; \
+-	set -e; for i in doc/apps/*.pod; do \
+-		fn=`basename $$i .pod`; \
+-		sec=`$(PERL) util/extract-section.pl 1 < $$i`; \
+-		echo "installing man$$sec/$$fn.$${sec}$(MANSUFFIX)"; \
+-		(cd `$(PERL) util/dirname.pl $$i`; \
+-		sh -c "$$pod2man \
+-			--section=$$sec --center=OpenSSL \
+-			--release=$(VERSION) `basename $$i`") \
+-			>  $(INSTALL_PREFIX)$(MANDIR)/man$$sec/$$fn.$${sec}$(MANSUFFIX); \
+-		$(PERL) util/extract-names.pl < $$i | \
+-			(grep -v $$filecase "^$$fn\$$"; true) | \
+-			(grep -v "[	]"; true) | \
+-			(cd $(INSTALL_PREFIX)$(MANDIR)/man$$sec/; \
+-			 while read n; do \
+-				PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$${sec}$(MANSUFFIX) "$$n".$${sec}$(MANSUFFIX); \
+-			 done); \
+-	done; \
+-	set -e; for i in doc/crypto/*.pod doc/ssl/*.pod; do \
+-		fn=`basename $$i .pod`; \
+-		sec=`$(PERL) util/extract-section.pl 3 < $$i`; \
+-		echo "installing man$$sec/$$fn.$${sec}$(MANSUFFIX)"; \
+-		(cd `$(PERL) util/dirname.pl $$i`; \
+-		sh -c "$$pod2man \
+-			--section=$$sec --center=OpenSSL \
+-			--release=$(VERSION) `basename $$i`") \
+-			>  $(INSTALL_PREFIX)$(MANDIR)/man$$sec/$$fn.$${sec}$(MANSUFFIX); \
+-		$(PERL) util/extract-names.pl < $$i | \
+-			(grep -v $$filecase "^$$fn\$$"; true) | \
+-			(grep -v "[	]"; true) | \
+-			(cd $(INSTALL_PREFIX)$(MANDIR)/man$$sec/; \
+-			 while read n; do \
+-				PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$${sec}$(MANSUFFIX) "$$n".$${sec}$(MANSUFFIX); \
+-			 done); \
+-	done
+-
+ # DO NOT DELETE THIS LINE -- make depend depends on it.

--- a/config/patches/openssl/openssl-1.0.1e-fix_pod_syntax-1.patch
+++ b/config/patches/openssl/openssl-1.0.1e-fix_pod_syntax-1.patch
@@ -1,0 +1,393 @@
+Submitted By: Martin Ward <macros_the_black at ntlworld dot com>
+Date: 2013-06-18
+Initial Package Version: 1.0.1e
+Upstream Status: Unknown
+Origin: self, based on fedora
+Description: Fixes install with perl-5.18.
+
+diff -Naur openssl-1.0.1e.orig/doc/apps/cms.pod openssl-1.0.1e/doc/apps/cms.pod
+--- openssl-1.0.1e.orig/doc/apps/cms.pod	2013-06-06 14:35:15.867871879 +0100
++++ openssl-1.0.1e/doc/apps/cms.pod	2013-06-06 14:35:25.791747119 +0100
+@@ -450,28 +450,28 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ the operation was completely successfully.
+ 
+-=item 1 
++=item C<1>
+ 
+ an error occurred parsing the command options.
+ 
+-=item 2
++=item C<2>
+ 
+ one of the input files could not be read.
+ 
+-=item 3
++=item C<3>
+ 
+ an error occurred creating the CMS file or when reading the MIME
+ message.
+ 
+-=item 4
++=item C<4>
+ 
+ an error occurred decrypting or verifying the message.
+ 
+-=item 5
++=item C<5>
+ 
+ the message was verified correctly but an error occurred writing out
+ the signers certificates.
+diff -Naur openssl-1.0.1e.orig/doc/apps/smime.pod openssl-1.0.1e/doc/apps/smime.pod
+--- openssl-1.0.1e.orig/doc/apps/smime.pod	2013-06-06 14:35:15.867871879 +0100
++++ openssl-1.0.1e/doc/apps/smime.pod	2013-06-06 14:35:25.794747082 +0100
+@@ -308,28 +308,28 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ the operation was completely successfully.
+ 
+-=item 1 
++=item C<1>
+ 
+ an error occurred parsing the command options.
+ 
+-=item 2
++=item C<2>
+ 
+ one of the input files could not be read.
+ 
+-=item 3
++=item C<3>
+ 
+ an error occurred creating the PKCS#7 file or when reading the MIME
+ message.
+ 
+-=item 4
++=item C<4>
+ 
+ an error occurred decrypting or verifying the message.
+ 
+-=item 5
++=item C<5>
+ 
+ the message was verified correctly but an error occurred writing out
+ the signers certificates.
+diff -Naur openssl-1.0.1e.orig/doc/crypto/X509_STORE_CTX_get_error.pod openssl-1.0.1e/doc/crypto/X509_STORE_CTX_get_error.pod
+--- openssl-1.0.1e.orig/doc/crypto/X509_STORE_CTX_get_error.pod	2013-06-06 14:35:15.874871791 +0100
++++ openssl-1.0.1e/doc/crypto/X509_STORE_CTX_get_error.pod	2013-06-06 14:37:13.826388940 +0100
+@@ -278,6 +278,8 @@
+ an application specific error. This will never be returned unless explicitly
+ set by an application.
+ 
++=back
++
+ =head1 NOTES
+ 
+ The above functions should be used instead of directly referencing the fields
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_accept.pod openssl-1.0.1e/doc/ssl/SSL_accept.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_accept.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_accept.pod	2013-06-06 14:35:25.796747057 +0100
+@@ -44,12 +44,12 @@
+ 
+ =over 4
+ 
+-=item 1
++=item C<1>
+ 
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
++=item C<0>
+ 
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_clear.pod openssl-1.0.1e/doc/ssl/SSL_clear.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_clear.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_clear.pod	2013-06-06 14:35:25.803746969 +0100
+@@ -56,12 +56,12 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The SSL_clear() operation could not be performed. Check the error stack to
+ find out the reason.
+ 
+-=item 1
++=item C<1>
+ 
+ The SSL_clear() operation was successful.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_COMP_add_compression_method.pod openssl-1.0.1e/doc/ssl/SSL_COMP_add_compression_method.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_COMP_add_compression_method.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_COMP_add_compression_method.pod	2013-06-06 14:35:25.806746931 +0100
+@@ -53,11 +53,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The operation succeeded.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation failed. Check the error queue to find out the reason.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_connect.pod openssl-1.0.1e/doc/ssl/SSL_connect.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_connect.pod	2013-06-06 14:35:15.869871854 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_connect.pod	2013-06-06 14:35:25.808746906 +0100
+@@ -41,12 +41,12 @@
+ 
+ =over 4
+ 
+-=item 1
++=item C<1>
+ 
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
++=item C<0>
+ 
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_add_session.pod openssl-1.0.1e/doc/ssl/SSL_CTX_add_session.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_add_session.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_add_session.pod	2013-06-06 14:35:25.816746805 +0100
+@@ -52,13 +52,13 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+  The operation failed. In case of the add operation, it was tried to add
+  the same (identical) session twice. In case of the remove operation, the
+  session was not found in the cache.
+ 
+-=item 1
++=item C<1>
+  
+  The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_load_verify_locations.pod openssl-1.0.1e/doc/ssl/SSL_CTX_load_verify_locations.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_load_verify_locations.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_load_verify_locations.pod	2013-06-06 14:35:25.818746780 +0100
+@@ -100,13 +100,13 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The operation failed because B<CAfile> and B<CApath> are NULL or the
+ processing at one of the locations specified failed. Check the error
+ stack to find out the reason.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_client_CA_list.pod openssl-1.0.1e/doc/ssl/SSL_CTX_set_client_CA_list.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_client_CA_list.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_set_client_CA_list.pod	2013-06-06 14:35:25.821746742 +0100
+@@ -66,11 +66,11 @@
+ 
+ =over 4
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+-=item 0
++=item C<0>
+ 
+ A failure while manipulating the STACK_OF(X509_NAME) object occurred or
+ the X509_NAME could not be extracted from B<cacert>. Check the error stack
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_session_id_context.pod openssl-1.0.1e/doc/ssl/SSL_CTX_set_session_id_context.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_session_id_context.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_set_session_id_context.pod	2013-06-06 14:35:25.828746654 +0100
+@@ -64,13 +64,13 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The length B<sid_ctx_len> of the session id context B<sid_ctx> exceeded
+ the maximum allowed length of B<SSL_MAX_SSL_SESSION_ID_LENGTH>. The error
+ is logged to the error stack.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_ssl_version.pod openssl-1.0.1e/doc/ssl/SSL_CTX_set_ssl_version.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_set_ssl_version.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_set_ssl_version.pod	2013-06-06 14:35:25.831746617 +0100
+@@ -42,11 +42,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The new choice failed, check the error stack to find out the reason.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_CTX_use_psk_identity_hint.pod openssl-1.0.1e/doc/ssl/SSL_CTX_use_psk_identity_hint.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_CTX_use_psk_identity_hint.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_CTX_use_psk_identity_hint.pod	2013-06-06 14:36:42.456783309 +0100
+@@ -81,6 +81,8 @@
+ 
+ Return values from the server callback are interpreted as follows:
+ 
++=over
++
+ =item > 0
+ 
+ PSK identity was found and the server callback has provided the PSK
+@@ -94,9 +96,11 @@
+ connection will fail with decryption_error before it will be finished
+ completely.
+ 
+-=item 0
++=item C<0>
+ 
+ PSK identity was not found. An "unknown_psk_identity" alert message
+ will be sent and the connection setup fails.
+ 
++=back
++
+ =cut
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_do_handshake.pod openssl-1.0.1e/doc/ssl/SSL_do_handshake.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_do_handshake.pod	2013-06-06 14:35:15.869871854 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_do_handshake.pod	2013-06-06 14:35:25.839746516 +0100
+@@ -45,12 +45,12 @@
+ 
+ =over 4
+ 
+-=item 1
++=item C<1>
+ 
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
++=item C<0>
+ 
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_read.pod openssl-1.0.1e/doc/ssl/SSL_read.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_read.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_read.pod	2013-06-06 14:35:25.847746415 +0100
+@@ -86,7 +86,7 @@
+ The read operation was successful; the return value is the number of
+ bytes actually read from the TLS/SSL connection.
+ 
+-=item 0
++=item C<0>
+ 
+ The read operation was not successful. The reason may either be a clean
+ shutdown due to a "close notify" alert sent by the peer (in which case
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_session_reused.pod openssl-1.0.1e/doc/ssl/SSL_session_reused.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_session_reused.pod	2013-06-06 14:35:15.871871829 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_session_reused.pod	2013-06-06 14:35:25.849746390 +0100
+@@ -27,11 +27,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ A new session was negotiated.
+ 
+-=item 1
++=item C<1>
+ 
+ A session was reused.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_set_fd.pod openssl-1.0.1e/doc/ssl/SSL_set_fd.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_set_fd.pod	2013-06-06 14:35:15.869871854 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_set_fd.pod	2013-06-06 14:35:25.852746353 +0100
+@@ -35,11 +35,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The operation failed. Check the error stack to find out why.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_set_session.pod openssl-1.0.1e/doc/ssl/SSL_set_session.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_set_session.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_set_session.pod	2013-06-06 14:35:25.855746315 +0100
+@@ -37,11 +37,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item C<0>
+ 
+ The operation failed; check the error stack to find out the reason.
+ 
+-=item 1
++=item C<1>
+ 
+ The operation succeeded.
+ 
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_shutdown.pod openssl-1.0.1e/doc/ssl/SSL_shutdown.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_shutdown.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_shutdown.pod	2013-06-06 14:35:25.857746290 +0100
+@@ -92,12 +92,12 @@
+ 
+ =over 4
+ 
+-=item 1
++=item C<1>
+ 
+ The shutdown was successfully completed. The "close notify" alert was sent
+ and the peer's "close notify" alert was received.
+ 
+-=item 0
++=item C<0>
+ 
+ The shutdown is not yet finished. Call SSL_shutdown() for a second time,
+ if a bidirectional shutdown shall be performed.
+diff -Naur openssl-1.0.1e.orig/doc/ssl/SSL_write.pod openssl-1.0.1e/doc/ssl/SSL_write.pod
+--- openssl-1.0.1e.orig/doc/ssl/SSL_write.pod	2013-06-06 14:35:15.870871842 +0100
++++ openssl-1.0.1e/doc/ssl/SSL_write.pod	2013-06-06 14:35:25.865746189 +0100
+@@ -79,7 +79,7 @@
+ The write operation was successful, the return value is the number of
+ bytes actually written to the TLS/SSL connection.
+ 
+-=item 0
++=item C<0>
+ 
+ The write operation was not successful. Probably the underlying connection
+ was closed. Call SSL_get_error() with the return value B<ret> to find out,

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -37,6 +37,7 @@ end
 relative_path "openssl-#{version}"
 
 build do
+  patch :source => "openssl-1.0.1e-do-not-build-docs.patch"
 
   env = case platform
         when "mac_os_x"


### PR DESCRIPTION
OpenSSL 1.0.1e doesn't build with Perl 5.18+ because of problems in
OpenSSL's pod files.  Apply the patch found at https://bugs.archlinux.org/task/35868?getfile=10648
(originally from http://www.linuxfromscratch.org/patches/blfs/svn/openssl-1.0.1e-fix_pod_syntax-1.patch)
when Perl v5.18+ is detected.

I'm on the fence about the OHAI["os"] == linux check because I
don't actually know if any other operating systems are affected.
I'm leaving it in to minimize the possible impact of this patch.
If we get any bug reports for the same issue from other systems
in the future we can adjust or remove that check as needed.
