### PR TITLE
Add missing 'openssl' dependency to 'nginx'

### DIFF
--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -19,6 +19,7 @@ name "nginx"
 version "1.2.3"
 
 dependency "pcre"
+dependency "openssl"
 
 source :url => "http://nginx.org/download/nginx-1.2.3.tar.gz",
        :md5 => "0a986e60826d9e3b453dbefc36bf8f6c"


### PR DESCRIPTION
In building nginx in a separate omnibus project I noticed this missing dependency.  With 'openssl', nginx builds fine with no further dependencies needed. (I am an opscode contributor)
