### PR TITLE
Add gdbm dependency to Python.

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -18,6 +18,7 @@
 name "python"
 default_version "2.7.5"
 
+dependency "gdbm"
 dependency "ncurses"
 dependency "zlib"
 dependency "openssl"
@@ -36,7 +37,8 @@ env = {
 build do
   command ["./configure",
            "--prefix=#{install_dir}/embedded",
-           "--enable-shared"].join(" "), :env => env
+           "--enable-shared",
+           "--with-dbmliborder=gdbm"].join(" "), :env => env
   command "make", :env => env
   command "make install", :env => env
 


### PR DESCRIPTION
Python depends on dbm.  Add explicit dependency on gdbm so the build
doesn't accidentally pick up some other locally installed dbm library.
Prevent Python from picking up gdbm_compat since it isn't strictly
required, and the default gdbm package on some platforms includes
gdbm_compat by default which causes health_check to fail later.
