### PR TITLE
Updated CA Certs bundle.

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,10 +16,10 @@
 #
 
 name "cacerts"
-version "2012.12.19"  # date of the file is in a comment at the start
+version "2012.12.19-1"  # date of the file is in a comment at the start
 
 source :url => "http://curl.haxx.se/ca/cacert.pem",
-       :md5 => '47961e7ef15667c93cd99be01b51f00a'
+       :md5 => '349ba2d6964db9ca558c9e1daf38e428'
 
 relative_path "cacerts-#{version}"
 


### PR DESCRIPTION
Note the version number did not change in the file, so we just appended a -1 on the version.

From http://curl.haxx.se/ca/ :

August 4th, 2013 -
The cacert.pem output now only contains certificates that are explicity
marked as trusted. The script was updated in commit 51f0b798fa as a
response to the 1.84 revision update of certdata.txt from June 2012.
