### PR TITLE
Lock down the version of the rake-compiler being used.

### DIFF
--- a/config/software/mysql2.rb
+++ b/config/software/mysql2.rb
@@ -34,7 +34,7 @@ dependency "ruby"
 dependency "bundler"
 
 build do
-  gem "install rake-compiler"
+  gem "install rake-compiler --version 0.8.3"
   command "mkdir -p #{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
   versions_to_install.each do |ver|
     gem "fetch mysql2 --version #{ver}", :cwd => "#{install_dir}/embedded/service/gem/ruby/1.9.1/cache"


### PR DESCRIPTION
The recent 9.0.0 release of the rake-compiler gem requires rubygems
1.8.25 or greater.  This simply locks down what we were using before.
