### PR TITLE
fix ohai path

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -120,7 +120,9 @@ build do
   # install chef first so that ohai gets installed into /opt/chef/bin/ohai
   rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
-  gem ["install pkg/chef*.gem",
+  command "rm -f pkg/chef-*-x86-mingw32.gem"
+
+  gem ["install pkg/chef-*.gem",
       "-n #{install_dir}/bin",
       "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 


### PR DESCRIPTION
need to install the gem with -n /opt/chef/bin before doing the
bundle install or else ohai winds up in /opt/chef/embedded/bin
