### PR TITLE
Build ncurses on OSX

### DIFF
--- a/config/patches/ncurses/ncurses-5.9-macosx-clang.patch
+++ b/config/patches/ncurses/ncurses-5.9-macosx-clang.patch
@@ -1,0 +1,40 @@
+--- c++/cursesf.h.orig	2011-07-23 10:05:34.000000000 +0200
++++ c++/cursesf.h	2011-07-23 10:06:20.000000000 +0200
+@@ -677,7 +677,7 @@
+   }
+ 
+ public:
+-  NCursesUserForm (NCursesFormField Fields[],
++  NCursesUserForm (NCursesFormField* Fields[],
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+@@ -686,7 +686,7 @@
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+ 
+-  NCursesUserForm (NCursesFormField Fields[],
++  NCursesUserForm (NCursesFormField* Fields[],
+ 		   int nlines,
+ 		   int ncols,
+ 		   int begin_y = 0,
+--- c++/cursesm.h.orig	2011-07-23 10:05:50.000000000 +0200
++++ c++/cursesm.h	2011-07-23 10:06:46.000000000 +0200
+@@ -635,7 +635,7 @@
+   }
+ 
+ public:
+-  NCursesUserMenu (NCursesMenuItem Items[],
++  NCursesUserMenu (NCursesMenuItem* Items[],
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+@@ -644,7 +644,7 @@
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+ 
+-  NCursesUserMenu (NCursesMenuItem Items[],
++  NCursesUserMenu (NCursesMenuItem* Items[],
+ 		   int nlines,
+ 		   int ncols,
+ 		   int begin_y = 0,

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -95,6 +95,10 @@ build do
     patch :source => 'patch-aix-configure', :plevel => 0
   end
 
+  if platform == "mac_os_x"
+    patch :source => 'ncurses-5.9-macosx-clang.patch', :plevel => 0
+  end
+
   # build wide-character libraries
   cmd_array = ["./configure",
            "--prefix=#{install_dir}/embedded",


### PR DESCRIPTION
Make ncurses compile on osx. Patch is the one taken from Homebrew: https://github.com/Homebrew/homebrew-dupes/commit/b1e3cb176c32beeada27c543ce921e6d941fc9a2#diff-01913bb69a09fa43b28f664fe9a322e8R15 (https://trac.macports.org/export/103963/trunk/dports/devel/ncurses/files/constructor_types.diff)
