### PR TITLE
Add openssl dependency

### DIFF
--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -19,6 +19,7 @@ name "keepalived"
 version "1.1.20"
 
 dependency "popt"
+dependency "openssl"
 
 source :url => "http://www.keepalived.org/software/keepalived-1.1.20.tar.gz",
        :md5 => "6c3065c94bb9e2187c4b5a80f6d8be31"


### PR DESCRIPTION
keepalived will not pass health_check stage without openssl libraries

``` text
[health_check] Executing `find /opt/chef-server/ -type f | xargs ldd >
ldd.out 2>/dev/null`
[health_check] *** Health Check Failed, Summary follows:
[health_check] *** The following Omnibus-built libraries have unsafe or
unmet dependencies:
[health_check] *** The following Omnibus-built binaries have unsafe or
unmet dependencies:
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check] *** The following libraries cannot be guaranteed to be
on target systems:
[health_check]     --> /usr/lib64/libssl.so.10 (0x00007f2e98253000)
[health_check]     --> /usr/lib64/libcrypto.so.10 (0x00007f2e97eb9000)
[health_check]     --> /lib64/libgssapi_krb5.so.2 (0x00007f2e978e1000)
[health_check]     --> /lib64/libkrb5.so.3 (0x00007f2e975fb000)
[health_check]     --> /lib64/libcom_err.so.2 (0x00007f2e973f7000)
[health_check]     --> /lib64/libk5crypto.so.3 (0x00007f2e971ca000)
[health_check]     --> /lib64/libkrb5support.so.0 (0x00007f2e96b9f000)
[health_check]     --> /lib64/libkeyutils.so.1 (0x00007f2e9699c000)
[health_check]     --> /lib64/libselinux.so.1 (0x00007f2e96345000)
[health_check]     --> /usr/lib64/libssl.so.10 (0x00007fdaf4eea000)
[health_check]     --> /usr/lib64/libcrypto.so.10 (0x00007fdaf4b50000)
[health_check]     --> /lib64/libgssapi_krb5.so.2 (0x00007fdaf4374000)
[health_check]     --> /lib64/libkrb5.so.3 (0x00007fdaf408e000)
[health_check]     --> /lib64/libcom_err.so.2 (0x00007fdaf3e89000)
[health_check]     --> /lib64/libk5crypto.so.3 (0x00007fdaf3c5d000)
[health_check]     --> /lib64/libkrb5support.so.0 (0x00007fdaf3836000)
[health_check]     --> /lib64/libkeyutils.so.1 (0x00007fdaf3633000)
[health_check]     --> /lib64/libselinux.so.1 (0x00007fdaf2fdc000)
[health_check] *** The precise failures were:
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libssl.so.10
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /usr/lib64/libssl.so.10
(0x00007f2e98253000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libcrypto.so.10
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /usr/lib64/libcrypto.so.10
(0x00007f2e97eb9000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libgssapi_krb5.so.2
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libgssapi_krb5.so.2
(0x00007f2e978e1000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libkrb5.so.3
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkrb5.so.3
(0x00007f2e975fb000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libcom_err.so.2
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libcom_err.so.2
(0x00007f2e973f7000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libk5crypto.so.3
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libk5crypto.so.3
(0x00007f2e971ca000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libkrb5support.so.0
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkrb5support.so.0
(0x00007f2e96b9f000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libkeyutils.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkeyutils.so.1
(0x00007f2e9699c000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/bin/genhash
[health_check]     DEPENDS ON: libselinux.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libselinux.so.1
(0x00007f2e96345000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libssl.so.10
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /usr/lib64/libssl.so.10
(0x00007fdaf4eea000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libcrypto.so.10
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /usr/lib64/libcrypto.so.10
(0x00007fdaf4b50000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libgssapi_krb5.so.2
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libgssapi_krb5.so.2
(0x00007fdaf4374000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libkrb5.so.3
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkrb5.so.3
(0x00007fdaf408e000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libcom_err.so.2
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libcom_err.so.2
(0x00007fdaf3e89000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libk5crypto.so.3
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libk5crypto.so.3
(0x00007fdaf3c5d000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libkrb5support.so.0
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkrb5support.so.0
(0x00007fdaf3836000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libkeyutils.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libkeyutils.so.1
(0x00007fdaf3633000)
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef-server/embedded/sbin/keepalived
[health_check]     DEPENDS ON: libselinux.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /lib64/libselinux.so.1
(0x00007fdaf2fdc000)
[health_check]       FAILED BECAUSE: Unsafe dependency
```
