### PR TITLE
[perl] generate an Omnibus-friendly CPAN config

### DIFF
--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -22,4 +22,26 @@ build do
            ].join(" "), :env => env
   command "make -j #{max_build_jobs}"
   command "make install", :env => env
+
+  # Ensure we have a sane omnibus-friendly CPAN config. This should be passed
+  # to cpan any commands with the `-j` option.
+  omnibus_cpan_home = File.join(cache_dir, 'cpan')
+  command "mkdir -p #{omnibus_cpan_home}", :env => env
+  block do
+    open("#{omnibus_cpan_home}/OmnibusConfig.pm", "w") do |file|
+      file.print <<-EOH
+
+$CPAN::Config = {
+  'build_dir' => q[#{omnibus_cpan_home}/build],
+  'cpan_home' => q[#{omnibus_cpan_home}],
+  'histfile' => q[#{omnibus_cpan_home}/histfile],
+  'keep_source_where' => q[#{omnibus_cpan_home}/sources],
+  'prefs_dir' => q[#{omnibus_cpan_home}/prefs],
+  'urllist' => [q[http://cpan.llarian.net/], q[http://cpan.mirror.vexxhost.com/], q[http://noodle.portalus.net/CPAN/]],
+};
+1;
+__END__
+       EOH
+    end
+  end
 end


### PR DESCRIPTION
This will ensure CPAN can use the Omnibus cache directory for building.  Invocations of Perl will need to be updated to pass the `-j` option for this to have any effect, though.

This PR configures the CPAN home to `/var/cache/omnibus/cache/cpan`. Previously the CPAN home leaked out into `$HOME/.cpan` and could cause build slaves to run out of inodes as this directory was never cleaned up!

(@schisamo did the work; I'm just the messenger.)
