### PR TITLE
Update for Jan 6th change.

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,7 +16,7 @@
 #
 
 name "cacerts"
-version "2014.01.06-1"  # date of the file is in a comment at the start
+version "2014.01.06"  # date of the file is in a comment at the start, or in the changelog
 
 source :url => "http://curl.haxx.se/ca/cacert.pem",
        :md5 => '6253bb1b6696a190fdf7a2062003b21c'


### PR DESCRIPTION
`These ca cert bundles no longer contain the DigiNotar certificates as Mozilla marks them as untrusted and this script knows the markup for that, but it may contain related certificates that Mozilla (and others) would block using other means. (Like some certs that were cross-signed by Entrust etc). See details in bug #1178.`
