### PR TITLE
[berkshelf] bump version to 2.0.12

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -16,7 +16,7 @@
 #
 
 name "berkshelf"
-version "1.4.3"
+version "2.0.12"
 
 dependency "ruby"
 dependency "rubygems"


### PR DESCRIPTION
`berkshelf` 1.4.3 was VERY old and began pulling in an incompatible 
`faraday` 0.9.0. The 2.0.x series of `berkshelf` should remain 
compatible with existing 1.4.x Berksfiles.
