### PR TITLE
Set PKG_CONFIG_PATH when building ruby

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -93,7 +93,8 @@ env =
   else
     {
       "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
-      "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+      "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+      "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig"
     }
   end
 


### PR DESCRIPTION
The ruby openssl module build invokes `pkg-config --libs openssl` to
find libs to link against, e.g., `-lssl -lcrypto`. If the openssl dev
package is _not_ installed on the system, ruby still builds
successfully but skips the openssl module, so the Omnibus build fails
later on `bundle install` ("Could not load OpenSSL.")

If the openssl dev package _is_ installed on the system, it will use
those `.pc` files and everything will probably work, even though this
is technically incorrect.

So let's tell `pkg-config` to use the `.pc` files from the Omnibus
openssl component by setting `PKG_CONFIG_PATH` to

```
#{install_dir}/embedded/lib/pkgconfig
```

Other Omnibus software definitions may need to set `PKG_CONFIG_PATH`,
too, but since I was able to build omnibus-chef-server successfully
with this patch I stopped here.
