### PR TITLE
Switch ftp:// URLs to http://

### DIFF
--- a/config/software/libpng.rb
+++ b/config/software/libpng.rb
@@ -20,7 +20,7 @@ version "1.5.17"
 
 dependency "zlib"
 
-source :url => "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng15/libpng-#{version}.tar.gz",
+source :url => "http://downloads.sourceforge.net/project/libpng/libpng15/#{version}/libpng-#{version}.tar.gz",
        :md5 => "d2e27dbd8c6579d1582b3f128fd284b4"
 
 relative_path "libpng-#{version}"

--- a/config/software/libwrap.rb
+++ b/config/software/libwrap.rb
@@ -18,7 +18,7 @@
 name "libwrap"
 version "7.6"
 
-source :url => "ftp://ftp.porcupine.org/pub/security/tcp_wrappers_7.6.tar.gz",
+source :url => "http://ftp.porcupine.org/pub/security/tcp_wrappers_7.6.tar.gz",
        :md5 => "e6fa25f71226d090f34de3f6b122fb5a"
 
 relative_path "tcp_wrappers_7.6"

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -21,7 +21,7 @@ version "2.7.8"
 dependency "zlib"
 dependency "libiconv"
 
-source :url => "ftp://xmlsoft.org/libxml2/libxml2-2.7.8.tar.gz",
+source :url => "http://www.xmlsoft.org/sources/libxml2-2.7.8.tar.gz",
        :md5 => "8127a65e8c3b08856093099b52599c86"
 
 relative_path "libxml2-2.7.8"

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -20,7 +20,7 @@ version "1.1.26"
 
 dependency "libxml2"
 
-source :url => "ftp://xmlsoft.org/libxml2/libxslt-1.1.26.tar.gz",
+source :url => "http://www.xmlsoft.org/sources/libxslt-1.1.26.tar.gz",
        :md5 => "e61d0364a30146aaa3001296f853b2b9"
 
 relative_path "libxslt-1.1.26"


### PR DESCRIPTION
FTP requires a range of possible ports to be open for transferring
files, which makes it difficult to use in network environments with
strict firewall rules. HTTP, on the other hand, uses a single port and
doesn't require any special firewall rules.

There are four packages that use ftp:// for their URL. Since all of
them have an equivalent http:// URL, use that instead.
