### PR TITLE
OC-10470: pcc status

### DIFF
--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -16,7 +16,7 @@
 #
 
 name "omnibus-ctl"
-version "0.0.7"
+version "0.1.0"
 
 dependency "ruby"
 dependency "rubygems"


### PR DESCRIPTION
Use omnibus-ctl 0.1.0 (--verbose)

This software component has been tested with:
- EC 11.1.beta (private-chef-ctl)
- Reporting (opscode-reporting-ctl)
- Pushy (opscode-push-jobs-ctl)
- Manage (opscode-manage-ctl)

This merge is pending EC 11.1 release.
