### PR TITLE
Apply ncurses patch to support clang compiler.

### DIFF
--- a/config/patches/ncurses/ncurses-clang.patch
+++ b/config/patches/ncurses/ncurses-clang.patch
@@ -1,0 +1,43 @@
+diff -ruNp ncurses-5.9.orig/c++/cursesf.h ncurses-5.9/c++/cursesf.h
+--- ncurses-5.9.orig/c++/cursesf.h	2005-08-13 21:08:24.000000000 +0300
++++ ncurses-5.9/c++/cursesf.h	2011-04-03 18:29:29.000000000 +0300
+@@ -681,7 +681,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, with_frame, autoDelete_Fields) {
++    : NCursesForm (&Fields, with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -694,7 +694,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, nlines, ncols, begin_y, begin_x,
++    : NCursesForm (&Fields, nlines, ncols, begin_y, begin_x,
+ 		   with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+diff -ruNp ncurses-5.9.orig/c++/cursesm.h ncurses-5.9/c++/cursesm.h
+--- ncurses-5.9.orig/c++/cursesm.h	2005-08-13 21:10:36.000000000 +0300
++++ ncurses-5.9/c++/cursesm.h	2011-04-03 18:31:42.000000000 +0300
+@@ -639,7 +639,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+-    : NCursesMenu (Items, with_frame, autoDelete_Items) {
++    : NCursesMenu (&Items, with_frame, autoDelete_Items) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -651,7 +651,7 @@ public:
+ 		   int begin_x = 0,
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE)
+-    : NCursesMenu (Items, nlines, ncols, begin_y, begin_x, with_frame) {
++    : NCursesMenu (&Items, nlines, ncols, begin_y, begin_x, with_frame) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -96,6 +96,17 @@ build do
     patch :source => 'patch-aix-configure', :plevel => 0
   end
 
+  if platform == "mac_os_x"
+    # References:
+    # https://github.com/Homebrew/homebrew-dupes/issues/43
+    # http://invisible-island.net/ncurses/NEWS.html#t20110409
+    #
+    # Patches ncurses for clang compiler. Changes have been accepted into
+    # upstream, but occurred shortly after the 5.9 release. We should be able
+    # to remove this after upgrading to any release created after June 2012
+    patch :source => 'ncurses-clang.patch'
+  end
+
   # build wide-character libraries
   cmd_array = ["./configure",
            "--prefix=#{install_dir}/embedded",


### PR DESCRIPTION
Using apple's command line tools, now that they are available independently of Xcode, seems to be the path forward for installing compilers on Mac. Therefore we need to be able to compile using clang. All of our current software works except for ncurses, which has accepted a patch to trunk but has not released since accepting the patch. I've added this patch and provided some references so we'll know it can be removed when the upstream fix is available.
