### PR TITLE
gdbm: enable compat

### DIFF
--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -27,6 +27,7 @@ relative_path "gdbm-1.9.1"
 
 build do
   configure_command = ["./configure",
+                       "--enable-libgdbm-compat",
                        "--prefix=#{install_dir}/embedded"]
 
   if platform == "freebsd"


### PR DESCRIPTION
Build Gdbm's compatibility layer by default.  Nothing in an Omnibus
installer should actually require it, but it works around issues with
some other builds (e.g. Python) that automatically pick up the compat
layer on systems where it's installed by default (e.g. Arch).

Signed-off-by: Kent R. Spillner kspillner@acm.org
