### PR TITLE
Add GMP, GNU Multiple Precision Arithmetic library

### DIFF
--- a/config/software/gmp.rb
+++ b/config/software/gmp.rb
@@ -1,0 +1,37 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gmp"
+default_version "4.1.3"
+
+source :url => "http://ftp.gnu.org/gnu/gmp/gmp-4.1.3.tar.gz",
+       :md5 => "bdbb9136fa22a0ccf028d0f87aae1dd2"
+
+relative_path "gmp-4.1.3"
+
+build do
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
+
+  if platform == "freebsd"
+    configure_command << "--with-pic"
+  end
+
+  command configure_command.join(" ")
+  command "make -j #{max_build_jobs}"
+  command "make install"
+end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -33,6 +33,7 @@ end
 
 version "2.1.1" do
   source md5: 'e57fdbb8ed56e70c43f39c79da1654b2'
+  dependency "gmp"
 end
 
 source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"


### PR DESCRIPTION
Create a software configuration for GMP v4.1.3.  I used the GDBM configuration
as a starting point which is how the "platform == freebsd" hunk found it's way
in here, but I don't actually have a FreeBSD machine to test that on.

Also, Ruby 2.1 depends on GMP (see: https://bugs.ruby-lang.org/issues/8796)
so mark the dependency when building Ruby v2.1.1.

Signed-off-by: Kent R. Spillner kspillner@acm.org
