### PR TITLE
[CC-49] Handle both chef-dk and chef-client pipelines

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -107,17 +107,41 @@ build do
     end
   end
 
-  # install the whole bundle, so that we get dev gems (like rspec) and can later test in CI
-  # against all the exact gems that we ship (we will run rspec unbundled in the test phase).
-  bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  # The way we install chef is different between chefdk and chef projects
+  # due to the fact that chefdk project has appbundler enabled.
+  # Two differences are:
+  #   1-) Order of bundle install & rake gem
+  #   2-) "-n #{install_dir}/bin" option for gem install
+  # We don't expect any side effects from (1) other than not creating
+  # link to erubis binary (which is not needed other than ruby 1.8.7 due to
+  # change that switched the template syntax checking to native ruby code.
+  # Not having (2) does not create symlinks for binaries under
+  # #{install_dir}/bin which gets created by appbundler later on.
+  if project.name == "chef"
+    # install chef first so that ohai gets installed into /opt/chef/bin/ohai
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
-  # install chef first so that ohai gets installed into /opt/chef/bin/ohai
-  rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+    command "rm -f pkg/chef-*-x86-mingw32.gem"
 
-  command "rm -f pkg/chef-*-x86-mingw32.gem"
-
-  gem ["install pkg/chef-*.gem",
+    gem ["install pkg/chef-*.gem",
+      "-n #{install_dir}/bin",
       "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    # install the whole bundle, so that we get dev gems (like rspec) and can later test in CI
+    # against all the exact gems that we ship (we will run rspec unbundled in the test phase).
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  else
+    # install the whole bundle first
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    command "rm -f pkg/chef-*-x86-mingw32.gem"
+
+    # Don't use -n #{install_dir}/bin. Appbundler will take care of them later
+    gem ["install pkg/chef-*.gem",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  end
 
   auxiliary_gems = []
   auxiliary_gems << "ruby-shadow" unless platform == "aix"


### PR DESCRIPTION
Branch out chef installation based on the project to handle the existance of appbundler.

Tested both in chef-dk & chef-client pipelines.
