### PR TITLE
Remove -R linker option on Mac OS X

### DIFF
--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -40,7 +40,7 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
       "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -45,7 +45,7 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
       "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"


### PR DESCRIPTION
This option has apparently been completely ignored by the linker ever
since OS X switched to clang; in a recent update to clang/xcode tools,
this is now a warning that triggers compilation errors.

/cc @opscode/release-engineers @opscode/client-eng 
