### PR TITLE
Add libiconv dependency to pkg-config on freebsd.

### DIFF
--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -18,6 +18,8 @@
 name "pkg-config"
 default_version "0.28"
 
+dependency "libiconv" if platform == "freebsd"
+
 source :url => 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz',
   :md5 => 'aa3c86e67551adc3ac865160e34a2a0d'
 


### PR DESCRIPTION
@btm / @lamont-granquist this fixes the CI failure we hit last night. Here is the green build: 

http://ci.opscode.us/view/Chef%20Client%20Build%20Pipeline/job/chef-client-build/1354/
