### PR TITLE
Add gecode as a dependency of berks.

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -34,6 +34,11 @@ end
 dependency "nokogiri"
 dependency "libarchive"
 
+# NOTE: Berkshelf is integrating the 'dep-selector' gem, which requires gecode
+# ~> 3.5. Gecode 4.x is available, but 'dep-selector' is not compatible with
+# that. Therefore berkshelf needs gecode 3.x until dep-selector is updated.
+dependency "gecode"
+
 build do
   bundle "install --without guard", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
   bundle "exec thor gem:build", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}


### PR DESCRIPTION
I guess we could make it a dependency of chefdk the project instead, but this made the most sense to me. Builds fine on OS X at least.
