### PR TITLE
[perl] Don't build `DB_File` extension

### DIFF
--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -19,7 +19,7 @@ build do
             "-Dprefix=#{install_dir}/embedded",
             "-Duseshrplib", ## Compile shared libperl
             "-Dusethreads", ## Compile ithread support
-            "-Dnoextensions='GDBM_File NDBM_File ODBM_File'"
+            "-Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"
            ].join(" "), :env => env
   command "make -j #{max_build_jobs}"
   command "make install", :env => env


### PR DESCRIPTION
This extension likes to link against the `libdb` system library on CentOS 6.

/cc @opscode/release-engineers @opscode/engineering-leads @marcparadise 
