### PR TITLE
Update libyaml

### DIFF
--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -16,10 +16,10 @@
 #
 
 name "libyaml"
-default_version "0.1.5"
+default_version '0.1.6'
 
 source :url => "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
-       :md5 => "24f6093c1e840ca5df2eb09291a1dbf1"
+       :md5 => '5fe00cda18ca5daeb43762b80c38e06e'
 
 relative_path "yaml-#{version}"
 


### PR DESCRIPTION
Add libyaml 0.1.6.

This addresses the newly-released [CVE-2014-2525](https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/).
