### PR TITLE
Add .gitkeep to empty dirs for omnibus-ctl and runit

### DIFF
--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -30,5 +30,6 @@ build do
   gem "build omnibus-ctl.gemspec"
   gem "install omnibus-ctl-#{version}.gem"
   command "mkdir -p #{install_dir}/embedded/service/omnibus-ctl"
+  command "touch #{install_dir}/embedded/service/omnibus-ctl/.gitkeep"
 end
 

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -106,9 +106,13 @@ runsvdir -P #{install_path}/service 'log: ......................................
   command "chmod 755 #{install_dir}/embedded/bin/runsvdir-start"
 
   # set up service directories
-  ["#{install_dir}/service",
-   "#{install_dir}/sv",
-   "#{install_dir}/init"].each do |dir|
-    command "mkdir -p #{dir}"
+  block do
+    ["#{install_dir}/service",
+     "#{install_dir}/sv",
+     "#{install_dir}/init"].each do |dir|
+      FileUtils.mkdir_p(dir)
+      # make sure cached builds include this dir
+      FileUtils.touch(File.join(dir, '.gitkeep'))
+    end
   end
 end


### PR DESCRIPTION
The git based build caching mechanism ignores empty
directories. Software configs that create empty directories need to add
a placeholder file (here .gitkeep) so that the directory will be in
place when the build is restored from cache.
