### PR TITLE
Upgrade default_version of chef-gem to 11.12.2

### DIFF
--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -16,7 +16,10 @@
 #
 
 name "chef-gem"
-default_version "11.10.4"
+
+default_version "11.12.2"
+
+version "11.10.4"
 
 dependency "ruby"
 dependency "rubygems"


### PR DESCRIPTION
Previous version still available via override at 11.10.4
