### PR TITLE
Bump chef-client version to 11.12.2

### DIFF
--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -16,7 +16,7 @@
 #
 
 name "chef-gem"
-default_version "11.10.4"
+default_version "11.12.2"
 
 dependency "ruby"
 dependency "rubygems"


### PR DESCRIPTION
I'd like to bump the version of chef-client here to the current latest so it can be included with the upcoming OSC release. If this is a problem for some reason, let me know. 

The reason is that a user is doing something strange that is hitting the embedded chef-client and is encountering a bug that exists in 11.10 but is fixed in 11.12. Should they be doing strangeness? Probably not, but it's not a bad idea to update the client version here.
