### PR TITLE
Update md5 checksum for cacert.pem

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,10 +16,10 @@
 #
 
 name "cacerts"
-default_version "2014.01.28"  # date of the file is in a comment at the start, or in the changelog
+default_version "2014.04.22"  # date of the file is in a comment at the start, or in the changelog
 
 source :url => "http://curl.haxx.se/ca/cacert.pem",
-       :md5 => '5d108f8ab86afacc6663aafca8604dd3'
+       :md5 => "9f92a0d9f605e227ae068e605f4c86fa"
 
 relative_path "cacerts-#{version}"
 


### PR DESCRIPTION
The certificate was updated as of 2014/04/22.
