### PR TITLE
Fix ChefDK Apps for Windows

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -30,9 +30,9 @@ else
   dependency "libffi"
   dependency "ruby"
   dependency "rubygems"
+  dependency "libarchive"
 end
 dependency "nokogiri"
-dependency "libarchive"
 
 dependency "bundler"
 

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -17,7 +17,6 @@
 
 name 'chef-vault'
 default_version 'v2.2.1'
-always_build true
 
 source :git => 'git://github.com/Nordstrom/chef-vault.git'
 
@@ -26,12 +25,13 @@ relative_path 'chef-vault'
 if platform == 'windows'
   dependency 'ruby-windows'
   dependency 'ruby-windows-devkit'
+  dependency 'chef-windows'
 else
   dependency 'ruby'
   dependency 'rubygems'
+  dependency 'chef'
 end
 
-dependency 'chef'
 
 build_env = {'PATH' => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
 

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -32,16 +32,18 @@ end
 
 dependency "test-kitchen"
 dependency "appbundler"
-dependency "rsync"
 dependency "berkshelf"
 dependency "chef-vault"
+
+sep = File::PATH_SEPARATOR || ":"
+path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
 
 env = {
   # rubocop pulls in nokogiri 1.5.11, so needs PKG_CONFIG_PATH and
   # NOKOGIRI_USE_SYSTEM_LIBRARIES until rubocop stops doing that
   "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
   "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
-  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
+  "PATH" => path
 }
 
 build do
@@ -55,6 +57,9 @@ build do
   end
 
   def appbuilder(app_path, bin_path)
+    sep = File::PATH_SEPARATOR || ":"
+    path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
+
     gemfile = File.join(app_path, "Gemfile.lock")
     command("#{install_dir}/embedded/bin/appbundler #{app_path} #{bin_path}",
             :env => {
@@ -63,14 +68,15 @@ build do
       'BUNDLE_GEMFILE'  => gemfile,
       'GEM_PATH'        => nil,
       'GEM_HOME'        => nil,
+      'PATH'            => path
     })
   end
 
-  bundle "install", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
-  rake "build", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  bundle "install", :env => {"PATH" => path}
+  rake "build", :env => env.merge({"PATH" => path})
 
   gem ["install pkg/chef-dk*.gem",
-      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => path})
 
   auxiliary_gems = []
 
@@ -84,14 +90,14 @@ build do
 
   # do multiple gem installs to better isolate/debug failures
   auxiliary_gems.each do |g|
-    gem "install #{g[:name]} -v #{g[:version]} -n #{install_dir}/bin --no-rdoc --no-ri", :env => env
+    gem "install #{g[:name]} -v #{g[:version]} -n #{install_dir}/bin --no-rdoc --no-ri --verbose", :env => env
   end
 
   block { FileUtils.mkdir_p("#{install_dir}/embedded/apps") }
 
   appbundler_apps = %w[chef berkshelf test-kitchen chef-dk chef-vault]
   appbundler_apps.each do |app_name|
-    command "#{install_dir}/embedded/bin/rsync -a ../#{app_name} #{install_dir}/embedded/apps/"
+    block { FileUtils.cp_r("#{source_dir}/#{app_name}", "#{install_dir}/embedded/apps/") }
     appbuilder("#{install_dir}/embedded/apps/#{app_name}", "#{install_dir}/bin")
   end
 end


### PR DESCRIPTION
Need to rebase and clean up a bit.

Fixes the following:
- Use the correct separator for the PATH environment variable for gem and bundle installs to install gems to the embedded ruby/gems (should we up-factor into omnibus?)
- Update software dependencies to be platform-sepecific where appropriate (this makes some software definitions depend on other definitions that are in omnibus-chef, should we move them?)
- Update the CA bundle's md5
