### PR TITLE
The official remote for rebar is now rebar, not basho

### DIFF
--- a/config/software/rebar.rb
+++ b/config/software/rebar.rb
@@ -20,7 +20,7 @@ default_version "2.0.0"
 
 dependency "erlang"
 
-source :git => "https://github.com/basho/rebar.git"
+source :git => "https://github.com/rebar/rebar.git"
 
 relative_path "rebar"
 


### PR DESCRIPTION
Same tags should be there, but the rebar remote has more recent releases
that projects may wish to use via override (saving update of default
version for a later commit).

ping: @sdelano 
@schisamo 
@opscode/delivery 
