### PR TITLE
Don't depend on 'rubygems' on windows

### DIFF
--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -18,7 +18,11 @@
 name "bundler"
 default_version "1.5.3"
 
-dependency "rubygems" unless platform == 'windows'
+if platform == 'windows'
+  dependency "ruby-windows"
+else
+  dependency "rubygems"
+end
 
 build do
   gem "install bundler --no-rdoc --no-ri -v '#{version}'"


### PR DESCRIPTION
Rubygems depends on ruby, not ruby-windows, so a dependency on rubygems means you'll try to compile ruby. It would probably be better to move the windows-specific logic into fewer places, but I don't want to boil the ocean just yet.
