### PR TITLE
Ensure that logrotate actually installs

### DIFF
--- a/config/patches/logrotate/logrotate_basedir_override.patch
+++ b/config/patches/logrotate/logrotate_basedir_override.patch
@@ -1,12 +1,17 @@
---- Makefile  2013-06-10 08:02:36.000000000 -0400
-+++ Makefile  2013-07-01 15:26:41.000000000 -0400
-@@ -90,6 +90,10 @@
-     CFLAGS += -DSTATEFILE=\"$(STATEFILE)\"
+--- Makefile	2014-05-05 17:45:06.000000000 -0400
++++ Makefile	2014-05-05 17:47:03.000000000 -0400
+@@ -1,3 +1,5 @@
++BASEDIR ?=
++
+ VERSION = $(shell awk '/Version:/ { print $$2 }' logrotate.spec)
+ OS_NAME = $(shell uname -s)
+ LFS = $(shell echo `getconf LFS_CFLAGS 2>/dev/null`)
+@@ -64,7 +66,7 @@
+ # Red Hat Linux
+ ifeq ($(OS_NAME),Linux)
+     INSTALL = install
+-    BASEDIR = /usr
++    BASEDIR ?= /usr
  endif
 
-+ifneq ($(BASEDIR),)
-+    BASEDIR = $BASEDIR
-+endif
-+
- BINDIR = $(BASEDIR)/sbin
- MANDIR ?= $(BASEDIR)/man
+ # FreeBSD

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -28,14 +28,24 @@ relative_path "logrotate-#{version}"
 env = {
   # Patch allows this to be set manually
   "BASEDIR" => "#{install_dir}/embedded",
+
   # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS
   # and CFLAGS
   "EXTRA_LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
   "EXTRA_CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+
+  # Needed to find libpopt
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   patch :source => "logrotate_basedir_override.patch", :plevel => 0
   command "make -j #{max_build_jobs}", :env => env
-  command "make install"
+
+  # Yes, this is horrible.  Due to how the makefile is structured, we
+  # need to specify PREFIX, *but not BASEDIR* in order to get this
+  # installed into #{install_dir}/embedded/sbin
+  #
+  # :(
+  command "make install", :env => {"PREFIX" => "#{install_dir}/embedded"}
 end


### PR DESCRIPTION
Due to how the makefile for logrotate is structured, we weren't
actually installing the executable in the omnibus-controlled
installation directory!

For reference, check out the original [Makefile](http://svn.fedorahosted.org/svn/logrotate/tags/r3-8-5/Makefile).
