### PR TITLE
Bump nokogiri version

### DIFF
--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -16,7 +16,7 @@
 #
 
 name "nokogiri"
-default_version "1.6.1"
+default_version "1.6.2"
 
 if platform == 'windows'
   dependency "ruby-windows"


### PR DESCRIPTION
Addresses CVE-2013-2877 and CVE-2014-0191. See https://groups.google.com/forum/#!topic/ruby-security-ann/-qrzZ05vsXY
