### PR TITLE
fix pkg-config rpath for ubuntu

### DIFF
--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -52,7 +52,7 @@ configure_env =
     }
   else
     {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
       "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end


### PR DESCRIPTION
should violate the omnibus health-checks on ubuntu if we don't do this.

probably really fixes #201 
