### PR TITLE
add comment that this software defn is deprecated

### DIFF
--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+#
+# NOTE: Instead of depending on this software definition, there is no
+#       reason not to include "-static-libgcc" in your LDFLAGS instead.
+#       That will probably be the best solution going forwards rather than
+#       fuss around with the dynamic linking business here.
+#
 name "libgcc"
 description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
 


### PR DESCRIPTION
i'll add a bit more background in this commit message, with the stated
qualifier for anyone in the public (non-Chef Software, Inc. employees)
stumbling upon this that THIS IS NOT LEGAL ADVICE, IANAL, etc.

discussed with Adam J about dynamically linking vs statically linking
this due to LGPL concerns and we believe that there's no concerns over
statically linking libgcc, and that we've been cargo culting this
particular solution for a few years for no reason.
