### PR TITLE
add libffi dep for debian to chefdk

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -28,6 +28,7 @@ else
   dependency "chef"
 end
 
+dependency "libffi" if debian?
 dependency "test-kitchen"
 dependency "appbundler"
 dependency "berkshelf"


### PR DESCRIPTION
Building chefdk on debian fails the [health check](https://gist.github.com/jordane/a3b75da42d0a0c4ca410) with a dependency on libffi. I'm not entirely sure why -- I tried playing around with some of the gem commands in the builds, but the only thing that worked for me was adding a direct dep on libffi (even though chefdk depends on berkshelf which depends on libffi).
