### PR TITLE
Link to omnibus-ruby from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omnibus Software
 
-This repository contains shared software descriptions, for use by any Omnibus project that needs them.
+This repository contains shared software descriptions, for use by any [Omnibus](https://github.com/opscode/omnibus-ruby) project that needs them.
 
 This project is managed by the CHEF Release Engineering team. For more information on the Release Engineering team's contribution, triage, and release process, please consult the [CHEF Release Engineering OSS Management Guide](https://docs.google.com/a/opscode.com/document/d/1oJB0vZb_3bl7_ZU2YMDBkMFdL-EWplW1BJv_FXTUOzg/edit).
 


### PR DESCRIPTION
It took me a little clicking to find more info, after I came across https://github.com/opscode/omnibus-ruby.  This hyperlinks the 'Omnibus' reference to the omnibus-ruby repo, which seems to have the best docs.  Woot!
