### PR TITLE
Use ruby 2.1.1 as default

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -16,7 +16,7 @@
 #
 
 name "ruby"
-default_version "1.9.3-p484"
+default_version "2.1.1"
 
 dependency "zlib"
 dependency "ncurses"


### PR DESCRIPTION
do this to avoid ASCII/UTF-8 encoding issues with ruby 1.9.3+

if there is an easy way to override this variable value, it's not clear to me from the README
