### PR TITLE
Remove .git dir from embedded/apps

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -100,6 +100,7 @@ build do
   appbundler_apps = %w[chef berkshelf test-kitchen chef-dk chef-vault]
   appbundler_apps.each do |app_name|
     block { FileUtils.cp_r("#{source_dir}/#{app_name}", "#{install_dir}/embedded/apps/") }
+    block { FileUtils.rm_rf("#{install_dir}/embedded/apps/#{app_name}/.git") }
     appbuilder("#{install_dir}/embedded/apps/#{app_name}", "#{install_dir}/bin")
   end
 end


### PR DESCRIPTION
The presence of a .git directory causes git to treat these directories
as submodules, which causes the content to _not_ get cached by the
omnibus git cache, which in turn causes cached builds to have empty
directories where the code was supposed to be. There is some benefit to
keeping the .git directories around, but not enough to justify a more
involved fix/workaround. So, blow the .git directories away during the
build.

**NOTE:** I haven't built this yet, will be kicking off a build shortly.

/cc @opscode/client-eng @opscode/release-engineers 
