### PR TITLE
Bump version of openssl to 1.0.1h

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -30,9 +30,9 @@ if platform == "aix"
   source :url => "http://www.openssl.org/source/openssl-1.0.1c.tar.gz",
          :md5 => "ae412727c8c15b67880aef7bd2999b2e"
 else
-  default_version "1.0.1g"
-  source :url => "http://www.openssl.org/source/openssl-1.0.1g.tar.gz",
-         :md5 => "de62b43dfcd858e66a74bee1c834e959"
+  default_version "1.0.1h"
+  source :url => "http://www.openssl.org/source/openssl-1.0.1h.tar.gz",
+         :md5 => "8d6d684a9430d5cc98a62a5d8fbda8cf"
 end
 
 relative_path "openssl-#{version}"


### PR DESCRIPTION
This addresses vuln exposed by https://www.openssl.org/news/secadv_20140606.txt

The patch file still applies cleanly.
