### PR TITLE
Remove the old version tag from various softwares

### DIFF
--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -18,8 +18,6 @@
 name "chef-gem"
 default_version "11.12.2"
 
-version "11.4.0"
-
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -22,8 +22,6 @@ dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 
-version "0.0.6"
-
 source :git => "git://github.com/opscode/omnibus-ctl.git"
 
 relative_path "omnibus-ctl"


### PR DESCRIPTION
/cc @opscode/release-engineers 

I'm not sure how these got back in here... Do we need them for older Omnibuses @sdelano @sersut?
