### PR TITLE
Force git caching to preserve nginx log dir.

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -64,4 +64,5 @@ build do
 
   command "make -j #{max_build_jobs}", :env => env
   command "make install"
+  command "touch /opt/opscode/embedded/nginx/logs/.gitkeep"
 end


### PR DESCRIPTION
This is a short term fix to an error where the nginx log directory would not
recreated during the re-run of a build.
