### PR TITLE
add software config for berkshelf2

### DIFF
--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -1,0 +1,29 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log.deprecated('berkshelf2') { 'Please upgrade to Berkshelf 3. Continued use of Berkshelf 2 will not be supported in the future.' }
+
+name "berkshelf2"
+default_version "2.0.15"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "nokogiri"
+
+build do
+  gem "install #{name} -n #{install_dir}/bin --no-rdoc --no-ri -v #{version}"
+end


### PR DESCRIPTION
The berkshelf software config is now tailored to build from master and berkshelf > 3. Some projects are using older versions of berks, and do not need the complexity of building and shipping another version of gecode. This software definition allows those projects to include a simplified version of berkshelf, berkshelf2.

/cc @opscode/release-engineers @danielsdeleo @oferrigni 
