### PR TITLE
Porting python fix over from opscode-omnibus

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -42,8 +42,10 @@ build do
   command "make", :env => env
   command "make install", :env => env
 
-  # There exists no configure flag to tell Python to not compile readline support :(
   block do
+    # There exists no configure flag to tell Python to not compile readline support :(
     FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"))
+    # Remove unused extension which is known to make health checks fail on CentOS 6.
+    FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/_bsddb.*"))
   end
 end


### PR DESCRIPTION
Otherwise health checks fail when building Python on CentOS 6.

See https://github.com/opscode/opscode-omnibus/blob/1.4-stable/config/software/python.rb#L48-L49 for original.
