### PR TITLE
Bump dep-selector-libgecode to 1.0.1

### DIFF
--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -16,7 +16,7 @@
 #
 
 name "dep-selector-libgecode"
-default_version "1.0.0"
+default_version "1.0.1"
 
 dependency "bundler"
 


### PR DESCRIPTION
Fixes:
- omnibus builds building both 1.0.1 and 1.0.0 (which makes berks installation slow).
- dep-selector-libgecode 1.0.1 has a patch to clean out intermediate build products, saving over 100MB of space.
