### PR TITLE
Only apply dl.rb patch on Ruby 2.X.

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -41,27 +41,29 @@ build do
   # to turn off the warning message
   # We are only removing dl.rb:8
   # => warn "DL is deprecated, please use Fiddle"
-  block do
-    require 'digest/md5'
+  if version.start_with? "2"
+    block do
+      require 'digest/md5'
 
-    dl_path = File.join(install_dir, "embedded/lib/ruby/2.0.0/dl.rb")
-    if Digest::MD5.hexdigest(File.read(dl_path)) == "78c185a3fcc7b5e2c3db697c85110d8f"
-      File.open(dl_path, "w") do |f|
-        f.print <<-E
-require 'dl.so'
+      dl_path = File.join(install_dir, "embedded/lib/ruby/2.0.0/dl.rb")
+      if Digest::MD5.hexdigest(File.read(dl_path)) == "78c185a3fcc7b5e2c3db697c85110d8f"
+        File.open(dl_path, "w") do |f|
+          f.print <<-E
+  require 'dl.so'
 
-begin
-  require 'fiddle' unless Object.const_defined?(:Fiddle)
-rescue LoadError
-end
-
-module DL
-  # Returns true if DL is using Fiddle, the libffi wrapper.
-  def self.fiddle?
-    Object.const_defined?(:Fiddle)
+  begin
+    require 'fiddle' unless Object.const_defined?(:Fiddle)
+  rescue LoadError
   end
-end
-E
+
+  module DL
+    # Returns true if DL is using Fiddle, the libffi wrapper.
+    def self.fiddle?
+      Object.const_defined?(:Fiddle)
+    end
+  end
+  E
+        end
       end
     end
   end


### PR DESCRIPTION
@lamont-granquist this should fix the breakage of omnibus-software. 

Can you give this a shot?
