### PR TITLE
Add fiddle back in to ruby

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -41,7 +41,7 @@ source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[
 relative_path "ruby-#{version}"
 
 env = with_embedded_path()
-env = with_standard_compiler_flags()
+env = with_standard_compiler_flags(env)
 
 case platform
 when "mac_os_x"


### PR DESCRIPTION
mostly this is to add the fiddle extension back in which I need for ffi-yajl related stuff.

this got taken out because 2 years ago we didn't have libffi as a dependency to use i think.

added libffi as a dep because we need it now to link fiddle against.

the refactoring of the flags is also both cleanup and necessary to fix a health-check issue on solaris.
