### PR TITLE
bzip2: Added soname_install_path.patch to fix problem building on osx

### DIFF
--- a/config/patches/bzip2/soname_install_path.patch
+++ b/config/patches/bzip2/soname_install_path.patch
@@ -1,0 +1,11 @@
+--- bzip2-1.0.6/Makefile-libbz2_so-orig	2014-07-10 09:51:05.000000000 -0700
++++ bzip2-1.0.6/Makefile-libbz2_so	2014-07-10 09:53:59.000000000 -0700
+@@ -35,7 +35,7 @@
+       bzlib.o
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.6 $(OBJS)
++	$(CC) -shared -Wl,-install_name -Wl,libbz2.so.1.0 -o libbz2.so.1.0.6 $(OBJS)
+ 	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.6
+ 	rm -f libbz2.so.1.0
+ 	ln -s libbz2.so.1.0.6 libbz2.so.1.0

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -40,6 +40,7 @@ env = {
 
 build do
   patch :source => 'makefile_take_env_vars.patch'
+  patch :source => 'soname_install_path.patch' if mac_os_x_mavericks?
   command "make PREFIX=#{prefix} VERSION=#{version}", :env => env
   command "make PREFIX=#{prefix} VERSION=#{version} -f Makefile-libbz2_so", :env => env
   command "make install VERSION=#{version} PREFIX=#{prefix}", :env => env


### PR DESCRIPTION
The change in osx Mavericks from standard gcc to clang has broken the make file for bzip2 as ld on Mavericks does not support the -soname flag. This PR patches the makefile to replace -soname with -install_name which fixes the issue on Mavericks.
