### PR TITLE
python: Fix configure when building on Mavericks

### DIFF
--- a/config/software/jre.rb
+++ b/config/software/jre.rb
@@ -25,7 +25,7 @@ whitelist_file "jre/bin/policytool"
 whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 
-if Ohai.kernel['machine'] =~ /x86_64/
+if Ohai['kernel']['machine'] =~ /x86_64/
   # TODO: download x86 version on x86 machines
   source :url => "http://download.oracle.com/otn-pub/java/jdk/7u3-b04/jre-7u3-linux-x64.tar.gz",
          :md5 => "3d3e206cea84129f1daa8e62bf656a28",

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -23,6 +23,7 @@
 #
 name "libgcc"
 description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
+version "0.0.1"
 
 libgcc_file =
   case Ohai['platform']

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -23,7 +23,7 @@
 #
 name "libgcc"
 description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
-version "0.0.1"
+default_version "0.0.1"
 
 libgcc_file =
   case Ohai['platform']

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -49,7 +49,7 @@ if Ohai['platform'] == "solaris2"
 end
 
 build do
-  # patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
+  patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make -j #{max_build_jobs} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -29,15 +29,25 @@ source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
 
 relative_path "Python-#{version}"
 
+extra_cflags = ''
+extra_configure_options = '--enable-shared'
+
+if mac_os_x_mavericks?
+  extra_cflags = '-std=gnu89 -fheinous-gnu-extensions'
+  extra_configure_options = '--without-gcc'
+end
+
 env = {
-  "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+  "CC" => "gcc -fPIC",
+  "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe #{extra_cflags}",
   "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
 }
+env.merge!('MACOSX_DEPLOYMENT_TARGET' => '10.9') if mac_os_x_mavericks?
 
 build do
   command ["./configure",
            "--prefix=#{install_dir}/embedded",
-           "--enable-shared",
+           extra_configure_options,
            "--with-dbmliborder=gdbm"].join(" "), :env => env
   command "make", :env => env
   command "make install", :env => env

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -26,7 +26,7 @@ whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
 
-if Ohai.kernel['machine'] =~ /x86_64/
+if Ohai['kernel']['machine'] =~ /x86_64/
   # TODO: download x86 version on x86 machines
   source :url => "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
          :md5 => "7164bd8619d731a2e8c01d0c60110f80",

--- a/config/software/spidermonkey.rb
+++ b/config/software/spidermonkey.rb
@@ -52,7 +52,7 @@ build do
           :env => env,
           :cwd => working_dir)
 
-  if Ohai.kernel['machine'] =~ /x86_64/
+  if Ohai['kernel']['machine'] =~ /x86_64/
     command "mv #{install_dir}/embedded/lib64/libjs.a #{install_dir}/embedded/lib"
     command "mv #{install_dir}/embedded/lib64/libjs.so #{install_dir}/embedded/lib"
   end

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -17,6 +17,7 @@
 
 name "version-manifest"
 description "generates a version manifest file"
+default_version "0.0.1"
 
 build do
   block do


### PR DESCRIPTION
This fixes the following configure error when running on mavericks.

    configure: error: cannot compute sizeof (size_t)