### PR TITLE
libiconv: always apply patch removing gets decl

### DIFF
--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -49,7 +49,7 @@ if Ohai['platform'] == "solaris2"
 end
 
 build do
-  # patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
+  patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make -j #{max_build_jobs} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env


### PR DESCRIPTION
Commit af02c68709 was intended to always remove the gets declaration
but accidentally commented out the line that actually applied the
patch.  Unfortunately, this breaks the build with omnibux v3.1.1 on
systems using glibc v2.16+.  Add back the explicit patch to work
around the issue.
