### PR TITLE
Use FileUtils.cp on Windows instead of cp

### DIFF
--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -40,5 +40,5 @@ build do
   # Now extract the files out of tar archive.
   command "7z.exe x #{File.join(temp_directory, "libyaml-0.1.6-x86-windows.tar")} -o#{temp_directory} -r -y"
   # Now copy over libyaml-0-2.dll to the build dir
-  command "cp #{File.join(temp_directory, "bin", "libyaml-0-2.dll")} #{File.join(install_dir, "embedded", "bin", "libyaml-0-2.dll")}"
+  copy("#{temp_directory}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll")
 end

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -42,7 +42,7 @@ build do
 
   rake "gem", :env => env
 
-  command "rm -f pkg/ohai-*-x86-mingw32.gem"
+  delete("pkg/ohai-*-x86-mingw32.gem")
 
   gem_command = "install pkg/ohai*.gem --no-rdoc --no-ri"
 

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -46,6 +46,6 @@ build do
   command "7z.exe x #{File.join(temp_directory, "openssl-#{version}-x86-windows.tar")} -o#{temp_directory} -r -y"
   # Copy over the required dlls into embedded/bin
   ["libeay32.dll", "ssleay32.dll"].each do |dll|
-    command "cp #{File.join(temp_directory, "bin", dll)} #{File.join(install_dir, "embedded", "bin", dll)}"
+    copy("#{temp_directory}/bin/#{dll}", "#{install_dir}/embedded/bin/#{dll}")
   end
 end


### PR DESCRIPTION
Using cp would presume we're running under MinGW, which is not currently
installed on the build slaves by https://github.com/opscode-cookbooks/omnibus

/cc @sersut, @sethvargo 
