### PR TITLE
Fix libffi for rhel

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -40,6 +40,9 @@ build do
   # On 64-bit centos, libffi libraries are places under /embedded/lib64
   # move them over to lib
   if rhel? && _64_bit?
+    # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
+    # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.
+    # http://comments.gmane.org/gmane.comp.lang.ruby.cvs/49907
     copy "#{install_dir}/embedded/lib64/*", "#{install_dir}/embedded/lib/"
     delete "#{install_dir}/embedded/lib64"
   end


### PR DESCRIPTION
I'm not totally sure this is the right way to solve this, but the commit feac1d01 (moving from shell methods to a pure Ruby implementation) broke this on RHEL.

Basically, a Ruby fileglob-way of copying versus just the shellout to "mv" don't do the same thing: `libffi.so.6` is a symlink to `libffi.so.6.0.1`, and when the latter is atomically moved to `lib`, the move of the former fails because the link is no longer found. I believe `/bin/mv` moves the whole glob as a group so this doesn't occur.
