### PR TITLE
Avoid Errno::ENOENT when building libffi on RHEL 6

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -40,7 +40,7 @@ build do
   # On 64-bit centos, libffi libraries are places under /embedded/lib64
   # move them over to lib
   if rhel? && _64_bit?
-    move "#{install_dir}/embedded/lib64/*", "#{install_dir}/embedded/lib/"
+    copy "#{install_dir}/embedded/lib64/*", "#{install_dir}/embedded/lib/"
     delete "#{install_dir}/embedded/lib64"
   end
 end


### PR DESCRIPTION
On Centos 6.5, I would get the following error during the last 'move'
step in the libffi recipe:

```
lib/ruby/1.9.1/fileutils.rb:1515:in `stat': No such file or directory - /opt/gitlab/embedded/lib64/libffi.so (Errno::ENOENT)
```

Using 'copy' instead of 'move' made this error go away.

I wonder if this has to do with the symlinks in the directory the files
are being moved out of. The following is the state after the ENOENT:

```
$ ls -l /opt/gitlab/embedded/lib64/
total 76
-rw-r--r--. 1 jacobvosmaer jacobvosmaer 71822 Aug 14 12:43 libffi.a
-rwxr-xr-x. 1 jacobvosmaer jacobvosmaer   956 Aug 14 12:43 libffi.la
lrwxrwxrwx. 1 jacobvosmaer jacobvosmaer    15 Aug 14 12:43 libffi.so ->
libffi.so.6.0.1
lrwxrwxrwx. 1 jacobvosmaer jacobvosmaer    15 Aug 14 12:43 libffi.so.6
-> libffi.so.6.0.1
```
