### PR TITLE
compile ncurses with xlc, remove libtool dep

### DIFF
--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -19,7 +19,6 @@ name "ncurses"
 default_version "5.9"
 
 dependency "libgcc"
-dependency "libtool" if Ohai['platform'] == "aix"
 
 source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
        md5: "8cb9c412e5f2d96bc6f459aa8c6282a1"
@@ -27,7 +26,7 @@ source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
 relative_path "ncurses-5.9"
 
 env = with_embedded_path()
-env = with_standard_compiler_flags(env, aix: { use_gcc: true })
+env = with_standard_compiler_flags(env)
 
 if Ohai['platform'] == "solaris2"
   # gcc4 from opencsw fails to compile ncurses
@@ -77,6 +76,8 @@ build do
 
   if Ohai['platform'] == "aix"
     patch source: 'patch-aix-configure', plevel: 0
+    # hack stolen from bullfreeware's src rpm spec file
+    command "find . -name Makefile.in -exec /opt/freeware/bin/sed -i 's/@OBJEXT@/lo/' {} \\;"
   end
 
   if Ohai['platform'] == "mac_os_x"
@@ -97,10 +98,10 @@ build do
            "--with-termlib",
            "--without-debug",
            "--without-normal", # AIX doesn't like building static libs
+           "--without-ada",
            "--enable-overwrite",
            "--enable-widec"]
-
-  cmd_array << "--with-libtool" if Ohai['platform'] == 'aix'
+  cmd_array << "--without-cxx-binding" if Ohai['platform'] == 'aix'
   command(cmd_array.join(" "),
           env: env)
   command "make -j #{max_build_jobs}", env: env
@@ -114,8 +115,9 @@ build do
            "--with-termlib",
            "--without-debug",
            "--without-normal",
+           "--without-ada",
            "--enable-overwrite"]
-  cmd_array << "--with-libtool" if Ohai['platform'] == 'aix'
+  cmd_array << "--without-cxx-binding" if Ohai['platform'] == 'aix'
   command(cmd_array.join(" "),
           env: env)
   command "make -j #{max_build_jobs}", env: env


### PR DESCRIPTION
This omits building the ncurses c++ bindings on AIX, which we do not
link against in the client.  The Makefiles for the c++ bindings
could probably be fixed since the root cause is that it uses ar instead
of xlc with -qmkshrobj like the rest of them and probably just needs
fixing, but tl;dr: we don't need it.

Also disables the Ada bindings as a bonus because I don't think we
have any Ada code.
