### PR TITLE
bumped cacerts version to 2014/09/03

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,11 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2014.08.20"
+default_version "2014.09.03"
+
+version "2014.09.03" do
+  source md5: "d7f7dd7e3ede3e323fc0e09381f16caf"
+end
 
 version "2014.08.20" do
   source md5: "c9f4f7f4d6a5ef6633e893577a09865e"


### PR DESCRIPTION
Fixes #289.

Looks like you'll need to backport it onto 3.2-stable too (as mentioned in #286).

We manage changes to this internally at my company but it must be pretty annoying to keep it up to date on here. Is there a better way that changes can be automatically handled?
