### PR TITLE
Configure Window’s environments to use `bsdtar`

### DIFF
--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -31,6 +31,9 @@ build do
     env["CXX"] = "g++44"
   end
 
+  # Ruby DevKit ships with BSD Tar
+  env["PROG_TAR"] = "bsdtar" if windows?
+
   gem "install dep-selector-libgecode" \
       " --version '#{version}'" \
       " --no-ri --no-rdoc", env: env


### PR DESCRIPTION
The Ruby DevKit ships with `bsdtar` instead of `tar`. This change just  ensures the environment is configured to use it.

Up until this point we have gotten lucky as our ChefDK builds Chef first which in turn copies `bsdtar.exe` over to `tar.exe`:
https://github.com/opscode/omnibus-chef/blob/master/config/software/chef.rb#L61

A similar fix has been applied in the upstream project: opscode/dep-selector-libgecode#33

/cc @opscode/client-engineers @opscode/release-engineers 
