### PR TITLE
Ensure `tar` is available for native extension compilation

### DIFF
--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -44,4 +44,7 @@ build do
 
   command "echo - #{install_dir}/embedded > config.yml", cwd: embedded_dir
   ruby "dk.rb install", env: env, cwd: embedded_dir
+
+  # may gems that ship with native extensions assume tar will be available in the PATH
+  copy "#{install_dir}/embedded/mingw/bin/bsdtar.exe", "#{install_dir}/embedded/mingw/bin/tar.exe"
 end


### PR DESCRIPTION
Many gems ship with native extensions that assume `tar` will be available in the PATH during the build process. Although we would hope these native extensions respect environment variables like `TAR` or `PROG_TAR` it’s not always the case. :-(

This issue was uncovered while trying to compile [dep-selector-libgecode](https://github.com/opscode/dep-selector-libgecode) as part of a ChefDK build  [BEFORE the chef software definition copies `bsdtar.exe` over as `tar.exe`](https://github.com/opscode/omnibus-chef/blob/release/chef-11.16.0/config/software/chef-windows.rb#L45-L60). Although we previously thought setting the `PROG_TAR` environment variable to `bsdtar.exe` fixed the issue (see opscode/dep-selector-libgecode#33 and opscode/omnibus-software#298) there are [parts of the Makefile which don't respect `PROG_TAR` and hardcode `tar`](https://github.com/opscode/dep-selector-libgecode/blob/4aab3b7f1390450475ebe94186f0ecb3c282d663/ext/libgecode3/vendor/gecode-3.7.3/Makefile.in#L1499-L1502).

/cc @opscode/release-engineers @opscode/client-engineers 
