### PR TITLE
Lcg/ruby 2.1.3 windows

### DIFF
--- a/config/patches/ruby/ruby-solaris-no-stack-protector.patch
+++ b/config/patches/ruby/ruby-solaris-no-stack-protector.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.dist b/configure
+index d83c15a..bd4813c 100755
+--- a/configure.dist
++++ b/configure
+@@ -7491,7 +7491,7 @@ main ()
+ }
+ _ACEOF
+ if ac_fn_c_try_compile "$LINENO"; then :
+-  stack_protector=yes
++  stack_protector=no
+ 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+ else

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -15,14 +15,13 @@
 #
 
 name "nokogiri"
-default_version "1.6.2.1"
+default_version "1.6.3.1"
 
 if windows?
   dependency "ruby-windows"
   dependency "ruby-windows-devkit"
 else
   dependency "ruby"
-  dependency "rubygems"
   dependency "libxml2"
   dependency "libxslt"
   dependency "libiconv"
@@ -30,20 +29,28 @@ else
   dependency "zlib"
 end
 
+dependency "rubygems"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # Tell nokogiri to use the system libraries instead of compiling its own
-  env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
+  if windows?
+    # use the 'fat' precompiled binary bundled with nokogiri
+    gem "install nokogiri" \
+      " --version '#{version}'", env: env
+  else
+    # Tell nokogiri to use the system libraries instead of compiling its own
+    env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 
-  gem "install nokogiri" \
-       " --version '#{version}'" \
-       " --" \
-       " --use-system-libraries" \
-       " --with-xml2-lib=#{install_dir}/embedded/lib" \
-       " --with-xml2-include=#{install_dir}/embedded/include/libxml2" \
-       " --with-xslt-lib=#{install_dir}/embedded/lib" \
-       " --with-xslt-include=#{install_dir}/embedded/include/libxslt" \
-       " --with-iconv-dir=#{install_dir}/embedded" \
-       " --with-zlib-dir=#{install_dir}/embedded", env: env
+    gem "install nokogiri" \
+      " --version '#{version}'" \
+      " --" \
+      " --use-system-libraries" \
+      " --with-xml2-lib=#{install_dir}/embedded/lib" \
+      " --with-xml2-include=#{install_dir}/embedded/include/libxml2" \
+      " --with-xslt-lib=#{install_dir}/embedded/lib" \
+      " --with-xslt-include=#{install_dir}/embedded/include/libxslt" \
+      " --with-iconv-dir=#{install_dir}/embedded" \
+      " --with-zlib-dir=#{install_dir}/embedded", env: env
+  end
 end

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -19,15 +19,28 @@ default_version "4.5.2-20111229-1559"
 
 dependency "ruby-windows"
 
-source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
-       md5: "4bf8f2dd1d582c8733a67027583e19a6"
+version "4.5.2-20111229-1559" do
+  source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
+         md5: "4bf8f2dd1d582c8733a67027583e19a6"
+end
+
+version "4.7.2-20130224-1151" do
+  source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-mingw64-32-#{version}-sfx.exe",
+         md5: "9383f12958aafc425923e322460a84de"
+end
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   embedded_dir = "#{install_dir}/embedded"
 
-  command "DevKit-tdm-32-#{version}-sfx.exe -y -o#{windows_safe_path(embedded_dir)}", env: env
+  version "4.5.2-20111229-1559" do
+    command "DevKit-tdm-32-#{version}-sfx.exe -y -o#{windows_safe_path(embedded_dir)}", env: env
+  end
+
+  version "4.7.2-20130224-1151" do
+    command "DevKit-mingw64-32-#{version}-sfx.exe -y -o#{windows_safe_path(embedded_dir)}", env: env
+  end
 
   command "echo - #{install_dir}/embedded > config.yml", cwd: embedded_dir
   ruby "dk.rb install", env: env, cwd: embedded_dir

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -27,6 +27,10 @@ version "2.0.0-p451" do
   source md5: "37feadb0230e7f475a8591d1807ecfec"
 end
 
+version "2.1.3" do
+  source md5: "60e39aaab140c3a22abdc04ec2017968"
+end
+
 source url: "http://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
 
 build do
@@ -43,7 +47,9 @@ build do
     block do
       require 'digest/md5'
 
-      dl_path = File.join(install_dir, "embedded/lib/ruby/2.0.0/dl.rb")
+      ABI_ver = version[/(^\d+\.\d+)/] + '.0'
+      dl_path = File.join(install_dir, "embedded/lib/ruby", ABI_ver, "dl.rb")
+
       if Digest::MD5.hexdigest(File.read(dl_path)) == "78c185a3fcc7b5e2c3db697c85110d8f"
         File.open(dl_path, "w") do |f|
           f.print <<-E

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,12 +25,14 @@ dependency "libyaml"
 dependency "libiconv"
 dependency "libffi"
 dependency "gdbm"
+
 dependency "libgcc" if solaris2?
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
 version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
 version("2.1.1")      { source md5: "e57fdbb8ed56e70c43f39c79da1654b2" }
 version("2.1.2")      { source md5: "a5b5c83565f8bd954ee522bd287d2ca1" }
+version("2.1.3")      { source md5: "74a37b9ad90e4ea63c0eed32b9d5b18f" }
 
 source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
@@ -64,6 +66,10 @@ else  # including solaris, linux
 end
 
 build do
+  if solaris2? && version.to_f >= 2.1
+    patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
+  end
+
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded",
                        "--with-out-ext=dbm",

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -17,30 +17,41 @@
 name "rubygems"
 default_version "1.8.24"
 
-dependency "ruby"
-
-version "1.8.29" do
-  source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
 end
 
-version "1.8.24" do
-  source md5: "3a555b9d579f6a1a1e110628f5110c6b"
-end
+unless windows?
+  version "1.8.29" do
+    source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
+  end
 
-version "2.2.1" do
-  source md5: "1f0017af0ad3d3ed52665132f80e7443"
-end
+  version "1.8.24" do
+    source md5: "3a555b9d579f6a1a1e110628f5110c6b"
+  end
 
-version "2.4.1" do
-  source md5: "7e39c31806bbf9268296d03bd97ce718"
-end
+  version "2.2.1" do
+    source md5: "1f0017af0ad3d3ed52665132f80e7443"
+  end
 
-source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+  version "2.4.1" do
+    source md5: "7e39c31806bbf9268296d03bd97ce718"
+  end
+
+  source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+end
 
 relative_path "rubygems-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_embedded_path
 
-  ruby "setup.rb", env: env
+  if windows?
+    command "gem update --system #{version}", env: env
+  else
+    ruby "setup.rb", env: env
+  end
 end


### PR DESCRIPTION
- bump default nokogiri
- install pre-built nokogiri binaries on windows (compiling it is broken, the internet will yell at you if you try)
- add widows support to rubygems since rubygems has a bug in 2.2.2 that breaks the mingw platform detection and at a minimum breaks installing nokogiri binaries
- add 2.1.3 binaries for ruby and devkit
- add md5 for ruby 2.1.3 for unix as well
