### PR TITLE
update to bundler 1.7.3

### DIFF
--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -15,7 +15,7 @@
 #
 
 name "bundler"
-default_version "1.5.3"
+default_version "1.7.3"
 
 if windows?
   dependency "ruby-windows"


### PR DESCRIPTION
The `git_source` method was added in 1.6.0. We use this [in Supermarket](https://github.com/opscode/supermarket/blob/f569b1c7abee52ba3fce5e928557cdbc39de0fab/Gemfile#L4-L9) to make sure we pull GitHub repos from HTTPS.
