### PR TITLE
openssl to 1.0.1j

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -29,9 +29,9 @@ if aix?
   source url: "http://www.openssl.org/source/openssl-1.0.1c.tar.gz",
          md5: "ae412727c8c15b67880aef7bd2999b2e"
 else
-  default_version "1.0.1i"
-  source url: "http://www.openssl.org/source/openssl-1.0.1i.tar.gz",
-         md5: "c8dc151a671b9b92ff3e4c118b174972"
+  default_version "1.0.1j"
+  source url: "http://www.openssl.org/source/openssl-1.0.1j.tar.gz",
+         md5: "f7175c9cd3c39bb1907ac8bba9df8ed3"
 end
 
 relative_path "openssl-#{version}"


### PR DESCRIPTION
Cherry-pick openssl 1.0.1j changes into master from stable-3.2 branch
