### PR TITLE
make world so postgresql extensions are installed

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -47,6 +47,6 @@ build do
           " --with-openssl --with-includes=#{install_dir}/embedded/include" \
           " --with-libraries=#{install_dir}/embedded/lib", env: env
 
-  make "-j #{workers}", env: env
+  make "world -j #{workers}", env: env
   make "install", env: env
 end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -48,5 +48,5 @@ build do
           " --with-libraries=#{install_dir}/embedded/lib", env: env
 
   make "world -j #{workers}", env: env
-  make "install", env: env
+  make "install-world", env: env
 end


### PR DESCRIPTION
The default install only installs the pgpsql extension. You need to `make world` for the other extensions in contrib to be installed.

These are mostly SQL files, so shouldn't be much of a problem wrt file size.

Hey, it could happen.

[![MCWORLD!!!!](http://dl.dropboxusercontent.com/s/m09hx4x7nkkbnt1/2014-10-17%20at%2011.12%20PM.png)](http://www.youtube.com/watch?v=z8h7J1XIc0E#t=15)