### PR TITLE
Disable DTrace integration when compiling Ruby

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -77,7 +77,8 @@ build do
                        "--enable-libedit",
                        "--with-ext=psych",
                        "--disable-install-doc",
-                       "--without-gmp"]
+                       "--without-gmp",
+                       "--disable-dtrace"]
 
   case ohai['platform']
   when "aix"


### PR DESCRIPTION
This can cause compilation issues on older Unixes including FreeBSD and Solaris.

/cc @opscode/client-engineers @opscode/release-engineers 
