### PR TITLE
Eniforce 0644 permissions on cacert.pem

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -50,5 +50,7 @@ build do
   # Windows does not support symlinks
   unless windows?
     link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
+
+    block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
   end
 end


### PR DESCRIPTION
Otherwise non-root users will get certificate verification failures when
using SSL/TLS.
