### PR TITLE
Update md5 sums and ruby versions

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -27,12 +27,12 @@ dependency "libffi"
 dependency "gdbm"
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
-version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
-version("2.0.0-p576") { source md5: "2e1f4355981b754d92f7e2cc456f843d" }
+version("1.9.3-p550") { source md5: "e05135be8f109b2845229c4f47f980fd" }
+version("2.0.0-p594") { source md5: "a9caa406da5d72f190e28344e747ee74" }
 version("2.1.1")      { source md5: "e57fdbb8ed56e70c43f39c79da1654b2" }
 version("2.1.2")      { source md5: "a5b5c83565f8bd954ee522bd287d2ca1" }
 version("2.1.3")      { source md5: "74a37b9ad90e4ea63c0eed32b9d5b18f" }
-version("2.1.4")      { source md5: "e05135be8f109b2845229c4f47f980fd" }
+version("2.1.4")      { source md5: "89b2f4a197621346f6724a3c35535b19" }
 
 source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 


### PR DESCRIPTION
Update package md5 sums, and ruby 1.9.3 and 2.0.0 versions to latest
