### PR TITLE
Bump appbundler to 0.3.0

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -15,7 +15,7 @@
 #
 
 name "appbundler"
-default_version "0.2.0"
+default_version "0.3.0"
 
 dependency "bundler"
 


### PR DESCRIPTION
This will provide relative paths support for appbundled binstubs on windows (when we pull it into omnibus-chef, of course).

Fixes https://github.com/opscode/omnibus-software/issues/334

/cc @opscode/client-engineers @opscode/release-engineers 
