### PR TITLE
use the /opt/freeware install command.

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -27,6 +27,8 @@ relative_path "libffi-3.0.13"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  env['INSTALL'] = "/opt/freeware/bin/install" if ohai['platform'] == "aix"
+
   command "./configure" \
           " --prefix=#{install_dir}/embedded", env: env
 


### PR DESCRIPTION
To avoid both its built-in install-sh and broken AIX install.