### PR TITLE
Add ability to install into dest_dir that independed of install_dir

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -22,7 +22,14 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  block do
+    env['GEM_HOME'] = dest_dir + `#{dest_dir}/#{install_dir}/embedded/bin/ruby  -r rubygems -e 'p Gem.path.last' | tr -d '"' | tr -d '\n'`
+    env['GEM_PATH'] = env['GEM_HOME']
+    env['BUNDLE_PATH'] = env['GEM_HOME']
+  end
+
   gem "install appbundler" \
       " --version '#{version}'" \
+      " --bindir '#{dest_dir}/#{install_dir}/embedded/bin'" \
       " --no-ri --no-rdoc", env: env
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -25,8 +25,12 @@ end
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  block do
+    env['GEM_HOME'] = dest_dir + `#{dest_dir}/#{install_dir}/embedded/bin/ruby  -r rubygems -e 'p Gem.path.last' | tr -d '"' | tr -d '\n'`
+    env['GEM_PATH'] = env['GEM_HOME']
+  end
 
   gem "install bundler" \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc --bindir #{dest_dir}/#{install_dir}/embedded/bin", env: env
 end

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -44,13 +44,17 @@ source url: "http://curl.haxx.se/ca/cacert.pem"
 relative_path "cacerts-#{version}"
 
 build do
-  mkdir "#{install_dir}/embedded/ssl/certs"
-  copy "#{project_dir}/cacert.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
-
-  # Windows does not support symlinks
-  unless windows?
-    link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
-
-    block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
+  block do
+    FileUtils.mkdir_p("#{dest_dir}/#{install_dir}/embedded/ssl/certs")
+    FileUtils.copy("#{project_dir}/cacert.pem", "#{dest_dir}/#{install_dir}/embedded/ssl/certs/cacert.pem")
+    # Windows does not support symlinks
+    unless windows?
+      Dir.chdir("#{dest_dir}/#{install_dir}/embedded/ssl/") do
+        unless File.symlink?("cert.pem")
+          File.symlink("certs/cacert.pem", "cert.pem")
+        end
+        File.chmod(0644, "certs/cacert.pem")
+      end
+    end
   end
 end

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -23,9 +23,13 @@ dependency "libffi"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  block do
+    env['GEM_HOME'] = dest_dir + `#{dest_dir}/#{install_dir}/embedded/bin/ruby  -r rubygems -e 'p Gem.path.last' | tr -d '"' | tr -d '\n'`
+    env['GEM_PATH'] = env['GEM_HOME']
+  end
 
   gem "install chef" \
       " --version '#{version}'" \
-      " --bindir '#{install_dir}/embedded/bin'" \
+      " --bindir '#{dest_dir}/#{install_dir}/embedded/bin'" \
       " --no-ri --no-rdoc", env: env
 end

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -34,9 +34,15 @@ dependency "bundler"
 
 build do
   env = with_embedded_path()
+  block do
+    env['GEM_HOME'] = dest_dir + `#{dest_dir}/#{install_dir}/embedded/bin/ruby  -r rubygems -e 'p Gem.path.last' | tr -d '"' | tr -d '\n'`
+    env['GEM_PATH'] = env['GEM_HOME']
+    env['BUNDLE_PATH'] = env['GEM_HOME']
 
-  bundle "install --without development_extras", env: env
-  bundle "exec rake gem", env: env
+    bundle "config build.ffi-yajl --global --with-cflags='#{env['CFLAGS']}' --with-ldflags='#{env['LDFLAGS']}'", env: env
+    bundle "install --without development_extras", env: env
+    bundle "exec rake gem", env: env
+  end
 
   delete "pkg/*java*"
 

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -35,7 +35,7 @@ build do
 
   # On 64-bit distro libffi libraries may be placed under /embedded/lib64
   # move them over to lib
-  block {
+  block do
     if File.directory?("#{dest_dir}/#{install_dir}/embedded/lib64")
       # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
       # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.
@@ -46,7 +46,7 @@ build do
 
     # libffi's default install location of header files is awful...
     copy "#{dest_dir}/#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{dest_dir}/#{install_dir}/embedded/include"
-  }
+  end
 
 end
 

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -33,17 +33,20 @@ build do
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 
-  # libffi's default install location of header files is awful...
-  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
-
-  # On 64-bit centos, libffi libraries are places under /embedded/lib64
+  # On 64-bit distro libffi libraries may be placed under /embedded/lib64
   # move them over to lib
-  if rhel? && _64_bit?
-    # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
-    # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.
-    # http://comments.gmane.org/gmane.comp.lang.ruby.cvs/49907
-    copy "#{install_dir}/embedded/lib64/*", "#{install_dir}/embedded/lib/"
-    delete "#{install_dir}/embedded/lib64"
-  end
+  block {
+    if File.directory?("#{dest_dir}/#{install_dir}/embedded/lib64")
+      # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
+      # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.
+      # http://comments.gmane.org/gmane.comp.lang.ruby.cvs/49907
+      copy "#{dest_dir}/#{install_dir}/embedded/lib64/*", "#{dest_dir}/#{install_dir}/embedded/lib/"
+      delete "#{dest_dir}/#{install_dir}/embedded/lib64"
+    end
+
+    # libffi's default install location of header files is awful...
+    copy "#{dest_dir}/#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{dest_dir}/#{install_dir}/embedded/include"
+  }
+
 end
 

--- a/config/software/libgmp.rb
+++ b/config/software/libgmp.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libgmp"
+default_version "5.1.3"
+
+dependency "ncurses"
+
+version "5.1.3" do
+  source md5: "4df82299c8dee6697d22f3bb0d0909b0"
+end
+
+source url: "https://ftp.gnu.org/gnu/gmp/gmp-#{version}.tar.gz"
+
+relative_path "gmp-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+end

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -39,6 +39,6 @@ build do
 
   make "-j #{workers}", env: env
   make "-j #{workers} install-lib" \
-          " libdir=#{install_dir}/embedded/lib" \
-          " includedir=#{install_dir}/embedded/include", env: env
+          " libdir=#{dest_dir}/#{install_dir}/embedded/lib" \
+          " includedir=#{dest_dir}/#{install_dir}/embedded/include", env: env
 end

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -35,10 +35,17 @@ relative_path "ohai"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  block do
+    env['GEM_HOME'] = dest_dir + `#{dest_dir}/#{install_dir}/embedded/bin/ruby  -r rubygems -e 'p Gem.path.last' | tr -d '"' | tr -d '\n'`
+    env['GEM_PATH'] = env['GEM_HOME']
+    env['BUNDLE_PATH'] = env['GEM_HOME']
+  end
 
-  bundle "install --without development", env: env
-
-  rake "gem", env: env
+  block do
+    bundle "config build.ffi '--with-cflags=\"#{env['CFLAGS']}\" --with-ldflags=\"#{env['LDFLAGS']}'\"'", env: env
+    bundle "install --without development", env: env
+    rake "gem", env: env
+  end
 
   delete "pkg/ohai-*-x86-mingw32.gem"
 
@@ -48,7 +55,7 @@ build do
         " --no-ri --no-rdoc", env: env
   else
     gem "install pkg/ohai*.gem" \
-        " --bindir '#{install_dir}/bin'" \
+        " --bindir '#{dest_dir}/#{install_dir}/bin'" \
         " --no-ri --no-rdoc", env: env
   end
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -68,15 +68,16 @@ build do
           }
         else
           {
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "CFLAGS" => "-I#{dest_dir}/#{install_dir}/embedded/include",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -Wl,-rpath-link,#{dest_dir}/#{install_dir}/embedded/lib -L#{dest_dir}/#{install_dir}/embedded/lib",
+            "INSTALL_PREFIX" => "#{dest_dir}",
           }
         end
 
   common_args = [
     "--prefix=#{install_dir}/embedded",
-    "--with-zlib-lib=#{install_dir}/embedded/lib",
-    "--with-zlib-include=#{install_dir}/embedded/include",
+    "--with-zlib-lib=#{dest_dir}/#{install_dir}/embedded/lib",
+    "--with-zlib-include=#{dest_dir}/#{install_dir}/embedded/include",
     "no-idea",
     "no-mdc2",
     "no-rc5",
@@ -133,13 +134,14 @@ build do
                         ["./config",
                         common_args,
                         "disable-gost",  # fixes build on linux, but breaks solaris
-                        "-L#{install_dir}/embedded/lib",
-                        "-I#{install_dir}/embedded/include",
-                        "-Wl,-rpath,#{install_dir}/embedded/lib"].join(" ")
+                        "-L#{dest_dir}/#{install_dir}/embedded/lib",
+                        "-I#{dest_dir}/#{install_dir}/embedded/include",
+                        "-Wl,-rpath,#{install_dir}/embedded/lib",
+                        "-Wl,-rpath-link,#{dest_dir}/#{install_dir}/embedded/lib"].join(" ")
                       end
 
   # openssl build process uses a `makedepend` tool that we build inside the bundle.
-  env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+  env["PATH"] = "#{dest_dir}/#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
   if aix?
     patch_env = env.dup

--- a/config/software/preparation.rb
+++ b/config/software/preparation.rb
@@ -20,8 +20,8 @@ default_version '1.0.0'
 
 build do
   block do
-    touch "#{install_dir}/embedded/lib/.gitkeep"
-    touch "#{install_dir}/embedded/bin/.gitkeep"
-    touch "#{install_dir}/bin/.gitkeep"
+    touch "#{dest_dir}/#{install_dir}/embedded/lib/.gitkeep"
+    touch "#{dest_dir}/#{install_dir}/embedded/bin/.gitkeep"
+    touch "#{dest_dir}/#{install_dir}/bin/.gitkeep"
   end
 end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -21,6 +21,7 @@ dependency "zlib"
 dependency "ncurses"
 dependency "libedit"
 dependency "openssl"
+dependency "libgmp"
 dependency "libyaml"
 dependency "libiconv"
 dependency "libffi"
@@ -87,7 +88,6 @@ build do
                        "--enable-libedit",
                        "--with-ext=psych",
                        "--disable-install-doc",
-                       "--without-gmp",
                        "--disable-dtrace"]
 
   case ohai['platform']

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -47,11 +47,13 @@ end
 relative_path "rubygems-#{version}"
 
 build do
-  env = with_embedded_path
+  block do
+    env = with_embedded_path
 
-  if windows?
-    command "gem update --system #{version} --no-ri --no-rdoc", env: env
-  else
-    ruby "setup.rb --no-ri --no-rdoc", env: env
+    if windows?
+      command "gem update --system #{version} --no-ri --no-rdoc", env: env
+    else
+      ruby "setup.rb --destdir=#{dest_dir} --no-ri --no-rdoc", env: env
+    end
   end
 end

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -20,7 +20,7 @@ default_version "0.0.1"
 
 build do
   block do
-    File.open("#{install_dir}/version-manifest.txt", "w") do |f|
+    File.open("#{dest_dir}/#{install_dir}/version-manifest.txt", "w") do |f|
       f.puts "#{project.name} #{project.build_version}"
       f.puts ""
       f.puts Omnibus::Reports.pretty_version_map(project)

--- a/config/software/yajl.rb
+++ b/config/software/yajl.rb
@@ -26,6 +26,6 @@ build do
 
   gem "install yajl-ruby" \
       " --version '#{version}'" \
-      " --bindir '#{install_dir}/bin'" \
+      " --bindir '#{dest_dir}/#{install_dir}/bin'" \
       " --no-ri --no-rdoc", env: env
 end


### PR DESCRIPTION
Currently omnibus-software install into prefix, that sometimes not needed,
this commit emulates DESTDIR makefile behaviour

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>