### PR TITLE
Bump appbundler to 0.4.0.

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -15,7 +15,7 @@
 #
 
 name "appbundler"
-default_version "0.3.0"
+default_version "0.4.0"
 
 dependency "bundler"
 


### PR DESCRIPTION
Fixes the following appbundler issues:
- Fixes issues with relative paths when symlinked #9
- Revert platform-specific executable creation #10 (didn't work with git
  caching)

@opscode/client-engineers @opscode/release-engineers 
