### PR TITLE
Remove CPPFLAGS from env when compiling ncurses

### DIFF
--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -41,6 +41,7 @@ relative_path "ncurses-5.9"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env.delete('CPPFLAGS')
 
   # gcc4 from opencsw fails to compile ncurses
   if solaris2?


### PR DESCRIPTION
This was discussed in https://github.com/chef/omnibus/pull/416

In short, if we add `CPPFLAGS` to omnibus's default flags, then building this `ncurses` definition fails (it ends up using the wrong headers to compile). 

However, since adding `CPPFLAGS` is beneficial to other pieces of software, it makes sense to add `CPPFLAGS` as a default, but fix `ncurses.rb` to continue building.