### PR TITLE
Solaris 10 Toolchain Update

### DIFF
--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -1,0 +1,48 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gcc"
+default_version "4.9.2"
+
+dependency "gmp"
+dependency "mpfr"
+dependency "mpc"
+dependency "libiconv"
+
+version("4.9.2")      { source md5: "76f464e0511c26c93425a9dcdc9134cf" }
+
+source url: "http://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
+
+relative_path "gcc-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_command = ["./configure",
+                     "--prefix=#{install_dir}/embedded",
+                     "--disable-nls",
+                     "--enable-languages=c,c++",
+                     "--with-as=/usr/ccs/bin/as",
+                     "--with-ld=/usr/ccs/bin/ld"]
+
+
+  command configure_command.join(" "), env: env
+  # gcc takes quite a long time to build (over 2 hours) so we're setting the mixlib shellout
+  # timeout to 4 hours. It's not great but it's required (on solaris at least, need to verify
+  # on any other platforms we may use this with)
+  make "-j #{workers}", env: env, timeout: 14400
+  make "-j #{workers} install", env: env
+end

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -35,7 +35,11 @@ version "2.2.1" do
   source md5: "d1110e35369bc37aa204915f64c5d1c8"
 end
 
-source url: "https://github.com/git/git/archive/v#{version}.tar.gz"
+version "2.2.1" do
+  source md5: "ff41fdb094eed1ec430aed8ee9b9849c"
+end
+
+source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
@@ -54,6 +58,10 @@ build do
     "LIBPCREDIR" => "#{install_dir}/embedded",
   )
 
-  make "-j #{workers} prefix=#{install_dir}/embedded", env: env
-  make "install prefix=#{install_dir}/embedded", env: env
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
+
+  command configure_command.join(" "), env: env
+  make "-j #{workers}", env: env
+  make "install", env: env
 end

--- a/config/software/gmp.rb
+++ b/config/software/gmp.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,26 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name "gmp"
+default_version "6.0.0a"
 
-dependency "m4"
+version("6.0.0a") { source md5: "b7ff2d88cae7f8085bd5006096eed470" }
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
+source url: "https://ftp.gnu.org/gnu/gmp/gmp-#{version}.tar.bz2"
 
-relative_path "autoconf-#{version}"
+relative_path "gmp-6.0.0"
 
 build do
-  if solaris2?
-    env['M4'] = "#{install_dir}/embedded/bin/m4"
-  end
-
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
+  if solaris2?
+    env['ABI'] = "32"
+  end
 
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
+
+  command configure_command.join(" "), env: env
   make "-j #{workers}", env: env
-  make "install", env: env
+  make "-j #{workers} install", env: env
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -32,8 +32,14 @@ build do
   command "./configure" \
           " --prefix=#{install_dir}/embedded", env: env
 
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  if solaris2?
+    # run old make :(
+    make env: env, bin: "/usr/ccs/bin/make"
+    make "install", env: env, bin: "/usr/ccs/bin/make"
+  else
+    make "-j #{workers}", env: env
+    make "-j #{workers} install", env: env
+  end
 
   # libffi's default install location of header files is awful...
   copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
@@ -48,4 +54,3 @@ build do
     delete "#{install_dir}/embedded/lib64"
   end
 end
-

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,19 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name "m4"
+default_version "1.4.17"
 
-dependency "m4"
+source url: "http://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
+       md5: "efb2d7c7e22840947863efaedc175747"
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
-
-relative_path "autoconf-#{version}"
+relative_path "m4-#{version}"
 
 build do
-  if solaris2?
-    env['M4'] = "#{install_dir}/embedded/bin/m4"
-  end
-
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
+  command "./configure --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make "-j #{workers} install", env: env
 end

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -29,6 +29,10 @@ dependency "pkg-config"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  if solaris2?
+    env['PKG_CONFIG'] = "#{install_dir}/embedded/bin/pkg-config"
+  end
+
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/mpc.rb
+++ b/config/software/mpc.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,25 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name "mpc"
+default_version "1.0.2"
 
-dependency "m4"
+dependency "gmp"
+dependency "mpfr"
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
+version("1.0.2") { source md5: "68fadff3358fb3e7976c7a398a0af4c3" }
 
-relative_path "autoconf-#{version}"
+source url: "ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz"
+
+relative_path "mpc-#{version}"
 
 build do
-  if solaris2?
-    env['M4'] = "#{install_dir}/embedded/bin/m4"
-  end
-
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
 
+  command configure_command.join(" "), env: env
   make "-j #{workers}", env: env
-  make "install", env: env
+  make "-j #{workers} install", env: env
 end

--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,24 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name "mpfr"
+default_version "3.1.2"
 
-dependency "m4"
+dependency "gmp"
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
+version("3.1.2") { source md5: "181aa7bb0e452c409f2788a4a7f38476" }
 
-relative_path "autoconf-#{version}"
+source url: "http://www.mpfr.org/mpfr-current/mpfr-#{version}.tar.gz"
+
+relative_path "mpfr-#{version}"
 
 build do
-  if solaris2?
-    env['M4'] = "#{install_dir}/embedded/bin/m4"
-  end
-
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
 
+  command configure_command.join(" "), env: env
   make "-j #{workers}", env: env
-  make "install", env: env
+  make "-j #{workers} install", env: env
 end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -43,13 +43,6 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env.delete('CPPFLAGS')
 
-  # gcc4 from opencsw fails to compile ncurses
-  if solaris2?
-    env["PATH"] = "/opt/csw/gcc3/bin:/opt/csw/bin:/usr/local/bin:/usr/sfw/bin:/usr/ccs/bin:/usr/sbin:/usr/bin"
-    env["CC"]   = "/opt/csw/gcc3/bin/gcc"
-    env["CXX"]  = "/opt/csw/gcc3/bin/g++"
-  end
-
   if smartos?
     # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
     # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -106,28 +106,24 @@ build do
                          "-R#{install_dir}/embedded/lib",
                         "-static-libgcc"].join(" ")
                       when "solaris2"
-                        if Omnibus::Config.solaris_compiler == "gcc"
-                          if ohai["kernel"]["machine"] =~ /sun/
-                            ["/bin/sh ./Configure",
-                             "solaris-sparcv9-gcc",
-                             common_args,
-                            "-L#{install_dir}/embedded/lib",
-                            "-I#{install_dir}/embedded/include",
-                            "-R#{install_dir}/embedded/lib",
-                            "-static-libgcc"].join(" ")
-                          else
-                            # This should not require a /bin/sh, but without it we get
-                            # Errno::ENOEXEC: Exec format error
-                            ["/bin/sh ./Configure",
-                             "solaris-x86-gcc",
-                             common_args,
-                            "-L#{install_dir}/embedded/lib",
-                            "-I#{install_dir}/embedded/include",
-                            "-R#{install_dir}/embedded/lib",
-                            "-static-libgcc"].join(" ")
-                          end
+                        if ohai["kernel"]["machine"] =~ /sun/
+                          ["/bin/sh ./Configure",
+                           "solaris-sparcv9-gcc",
+                           common_args,
+                          "-L#{install_dir}/embedded/lib",
+                          "-I#{install_dir}/embedded/include",
+                          "-R#{install_dir}/embedded/lib",
+                          "-static-libgcc"].join(" ")
                         else
-                          raise "sorry, we don't support building openssl on non-gcc solaris builds right now."
+                          # This should not require a /bin/sh, but without it we get
+                          # Errno::ENOEXEC: Exec format error
+                          ["/bin/sh ./Configure",
+                           "solaris-x86-gcc",
+                           common_args,
+                          "-L#{install_dir}/embedded/lib",
+                          "-I#{install_dir}/embedded/include",
+                          "-R#{install_dir}/embedded/lib",
+                          "-static-libgcc"].join(" ")
                         end
                       else
                         config = if ohai["os"] == "linux" && ohai["kernel"]["machine"] == "ppc64"

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,22 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name "patch"
+default_version "2.7"
 
-dependency "m4"
+version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
+source url: "http://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
 
-relative_path "autoconf-#{version}"
+relative_path "patch-#{version}"
+
+env = with_standard_compiler_flags(with_embedded_path)
 
 build do
-  if solaris2?
-    env['M4'] = "#{install_dir}/embedded/bin/m4"
-  end
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded"]
 
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
+  command configure_command.join(" "), env: env
   make "-j #{workers}", env: env
-  make "install", env: env
+  make "-j #{workers} install", env: env
 end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -72,7 +72,16 @@ when "aix"
   env['SOLIBS'] = "-lm -lc"
   # need to use GNU m4, default m4 doesn't work
   env['M4'] = "/opt/freeware/bin/m4"
-else  # including solaris, linux
+when "solaris2"
+  env['CC'] = "/usr/sfw/bin/gcc -static-libgcc"
+  if ohai['kernel']['machine'].include?('sun4')
+    # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
+    env['CFLAGS'] << " -O0 -g -pipe -mcpu=v9"
+    env['LDFLAGS'] << " -mcpu=v9"
+  else
+    env['CFLAGS'] << " -O3 -g -pipe"
+  end
+else  # including linux
   env['CFLAGS'] << " -O3 -g -pipe"
 end
 


### PR DESCRIPTION
(TRY NUMBER TWO WITH A LESS MESSED UP BRANCH)

This update changes many defs to allow GCC and supporting libraries to be omnibussed up for Solaris 10.

New defs:
GMP, GCC, m4, MPC, MPFR, patch

Changes to existing defs:
 * **autoconf** - require m4 if on Solaris, so we can use the previously built m4 instead of default (which is less functional).
 * **git** - possibly the 'scariest' change, this changes the source from github to kernel.org mirror. The reason for this change is that the github tarballs don't actually have preconfigured 'ready to build' configure scripts, and rely on you to build them. The ones from kernel.org allow you to build with both environment variables and configure args.
**tl;dr - one doesn't respect LD_OPTIONS, one does, and we need that one.**
 * **libffi** - the makefile is broken when run on Solaris 10 with gmake, force it to use Oracle make
 * **makedepend** - when used on Solaris, use the previously built pkg-config
 * **ncurses** - works with gcc4 now
 * **openssl** - we don't use non-gcc for compiling on Solaris anymore.
 * **perl** - update to allow for mapfiles on Solaris
 * **ruby** - modify to build with old gcc in all cases for Solaris. Ruby won't build correctly on gcc4 on Solaris right now.

@chef/ociv @lamont-granquist