### PR TITLE
Add 7u25 server-jre configuration for backwards compatibility

### DIFF
--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -16,6 +16,7 @@
 
 name "server-jre"
 default_version "8u31"
+raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
 
 whitelist_file "jre/bin/javaws"
 whitelist_file "jre/bin/policytool"
@@ -23,18 +24,23 @@ whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
 
-if _64_bit?
-  # TODO: download x86 version on x86 machines
+version "8u31" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/8u31-b13/server-jre-8u31-linux-x64.tar.gz",
          md5:     "9d69cdc00c536b8c9f5b26a3128bd2a1",
          cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
          warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
          unsafe:  true
-else
-  raise "Server-jre can only be installed on x86_64 systems."
+  relative_path "jdk1.8.0_31"
 end
 
-relative_path "jdk1.8.0_31"
+version "7u25" do
+  source url:     "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
+         md5:     "7164bd8619d731a2e8c01d0c60110f80",
+         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
+         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         unsafe:  true
+  relative_path "jdk1.7.0_25"
+end
 
 build do
   mkdir "#{install_dir}/embedded/jre"


### PR DESCRIPTION
Because of the difference in relative_path, users can't stay on 7u25
solely via an override.