### PR TITLE
add patch for linux socket compat on sol11

### DIFF
--- a/config/patches/ruby/ruby-solaris-linux-socket-compat.patch
+++ b/config/patches/ruby/ruby-solaris-linux-socket-compat.patch
@@ -1,0 +1,42 @@
+--- ruby-2.1.5/ext/socket/raddrinfo.c.orig      Fri Mar 20 13:53:18 2015
++++ ruby-2.1.5/ext/socket/raddrinfo.c   Fri Mar 20 13:53:34 2015
+@@ -8,6 +8,39 @@
+
+ ************************************************/
+
++/*  Linux kernel socket model compat defs.
++    AIX/Solaris/HP-UX all use an alternate
++    interface called DLPI. See the below and
++    libpcap's pcap-dlpi.c for more info:
++    http://www.oracle.com/technetwork/server-storage/solaris/solaris-linux-app-139382.html*/
++#define PACKET_HOST         0       /* To us.  */
++#define PACKET_BROADCAST    1       /* To all.  */
++#define PACKET_MULTICAST    2       /* To group.  */
++#define PACKET_OTHERHOST    3       /* To someone else.  */
++#define PACKET_OUTGOING     4       /* Originated by us . */
++#define PACKET_LOOPBACK     5
++#define PACKET_FASTROUTE    6
++
++/* Packet socket options.  */
++
++#define PACKET_ADD_MEMBERSHIP       1
++#define PACKET_DROP_MEMBERSHIP      2
++#define PACKET_RECV_OUTPUT      3
++#define PACKET_RX_RING          5
++#define PACKET_STATISTICS       6
++
++struct packet_mreq
++  {
++    int mr_ifindex;
++    unsigned short int mr_type;
++    unsigned short int mr_alen;
++    unsigned char mr_address[8];
++  };
++
++#define PACKET_MR_MULTICAST 0
++#define PACKET_MR_PROMISC   1
++#define PACKET_MR_ALLMULTI  2
++
+ #include "rubysocket.h"
+
+ #if defined(INET6) && (defined(LOOKUP_ORDER_HACK_INET) || defined(LOOKUP_ORDER_HACK_INET6))

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -88,7 +88,9 @@ end
 build do
   if solaris2? && version.to_f >= 2.1
     patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
-    patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
+    if ohai['platform_version'].to_f >= 11.0
+      patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
+    end
   end
 
   # AIX needs /opt/freeware/bin only for patch

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -88,6 +88,7 @@ end
 build do
   if solaris2? && version.to_f >= 2.1
     patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
+    patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
   end
 
   # AIX needs /opt/freeware/bin only for patch

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -88,7 +88,7 @@ end
 build do
   if solaris2? && version.to_f >= 2.1
     patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
-    if ohai['platform_version'].to_f >= 11.0
+    if ohai['platform_version'].to_f >= 5.11
       patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
     end
   end


### PR DESCRIPTION
Defines a bunch PACKET_* constants that otherwise fail the build during the "make" phase.
@scotthain @schisamo @yzl 