### PR TITLE
Removing unecessary test-kitchen development dependencies

### DIFF
--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -33,7 +33,7 @@ dependency "nokogiri"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without guard", env: env
+  bundle "install --without guard development test", env: env
   bundle "exec rake build", env: env
 
   gem "install pkg/test-kitchen-*.gem" \


### PR DESCRIPTION
This removes quite a few gems from ChefDK