### PR TITLE
Python 2.7.5 -> 2.7.9

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -15,7 +15,7 @@
 #
 
 name "python"
-default_version "2.7.5"
+default_version "2.7.9"
 
 dependency "gdbm"
 dependency "ncurses"
@@ -23,8 +23,10 @@ dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
 
-source url: "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-       md5: 'b4f01a1d0ba0b46b05c73b2ac909b1df'
+version("2.7.5") { source md5: "b4f01a1d0ba0b46b05c73b2ac909b1df" }
+version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }
+
+source url: "http://python.org/ftp/python/#{version}/Python-#{version}.tgz"
 
 relative_path "Python-#{version}"
 


### PR DESCRIPTION
Changes default Python to 2.7.9, backwards compatibility for applications pinned to 2.7.5