### PR TITLE
Updated defs for Solaris 10 system gcc usage

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -27,6 +27,10 @@ dependency "perl"
 
 relative_path "git-#{version}"
 
+version "1.9.0" do
+  source md5: "0e00839539fc43cd2c350589744f254a"
+end
+
 version "1.9.5" do
   source md5: "a50979e98068f7dae8ad34492d0ef5a8"
 end

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -17,6 +17,8 @@
 name "libiconv"
 default_version "1.14"
 
+dependency "patch" if solaris2?
+
 source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
 

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "make"
+default_version "4.1"
+
+source url: "http://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
+       md5: "654f9117957e6fa6a1c49a8f08270ec9"
+
+relative_path "make-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
+
+  make "-j #{workers}", env: env
+  make "install", env: env
+
+  # We are very prescriptive. We made make, we will make all the things use it!
+  link "#{install_dir}/embedded/bin/make", "#{install_dir}/embedded/bin/gmake"
+end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -18,6 +18,7 @@ name "ncurses"
 default_version "5.9"
 
 dependency "libtool" if aix?
+dependency "patch" if solaris2?
 
 source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
        md5: "8cb9c412e5f2d96bc6f459aa8c6282a1"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -19,6 +19,7 @@ name "openssl"
 dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix?
+dependency "patch" if solaris2?
 
 default_version "1.0.1m"
 source url: "https://www.openssl.org/source/openssl-1.0.1m.tar.gz",

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,6 +25,7 @@ dependency "libyaml"
 dependency "libiconv"
 dependency "libffi"
 dependency "gdbm"
+dependency "patch" if solaris2?
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
 version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
@@ -73,13 +74,12 @@ when "aix"
   # need to use GNU m4, default m4 doesn't work
   env['M4'] = "/opt/freeware/bin/m4"
 when "solaris2"
-  env['CC'] = "/usr/sfw/bin/gcc -static-libgcc"
   if ohai['kernel']['machine'].include?('sun4')
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env['CFLAGS'] << " -O0 -g -pipe -mcpu=v9"
+    env['CFLAGS'] << " -std=c99 -O0 -g -pipe -mcpu=v9"
     env['LDFLAGS'] << " -mcpu=v9"
   else
-    env['CFLAGS'] << " -O3 -g -pipe"
+    env['CFLAGS'] << " -std=c99 -O3 -g -pipe"
   end
 else  # including linux
   env['CFLAGS'] << " -O3 -g -pipe"


### PR DESCRIPTION
Forcing ruby to build with c99 spec means that gems with native extensions that are installed later will be built correctly if they depend on things like stdbool.h (for example ffi).

This also adds the git 1.9.0 as a backwards compat version

Also include gnu make because it's more reliable than system on solaris 10.