### PR TITLE
[berkshelf2] Lock celluloid to `~> 0.16.0`

### DIFF
--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -29,6 +29,14 @@ dependency "libffi"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  gem "install celluloid" \
+      " --version '~> 0.16.0'" \
+      " --no-ri --no-rdoc", env: env
+
+  gem "install celluloid-io" \
+      " --version '~> 0.16.1'" \
+      " --no-ri --no-rdoc", env: env
+
   gem "install hashie" \
       " --version '~> 2.0.0'" \
       " --no-ri --no-rdoc", env: env


### PR DESCRIPTION
This ensures the newly released celluloid `0.17.0.pre7` isn’t pulled in accidentally. The proper fix for this issue is to move your project over to using the `berkself` software definition which installs Berkshelf 3+.

/cc @chef/omnibus-maintainers @gregdurham 

Heads up @chef/lob you will probably need this for chef-server builds.

__FINALLY...PLEASE UPGRADE TO BERKSHELF 3+__