### PR TITLE
Update for zmq 4

### DIFF
--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -16,16 +16,27 @@
 
 # We use the version in util-linux, and only build the libuuid subdirectory
 name "libzmq"
-default_version "v2.1.11"
+default_version "2.1.11"
 
 dependency "autoconf"
 dependency "automake"
 dependency "libtool"
 dependency "libuuid"
 
-source git: "git://github.com/zeromq/zeromq2-x.git"
 
-relative_path "zeromq2-x"
+
+version "2.1.11" do
+  source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
+end
+version "4.0.4" do
+  source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"
+end
+version "4.0.5" do
+  source md5: "73c39f5eb01b9d7eaf74a5d899f1d03d"
+end
+
+relative_path "zeromq-#{version}"
+source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
Add zeromq 4 versions, and alter zmq 2.1.11 build build to use the same source.

@chef/omnibus-maintainers 