### PR TITLE
Bump lib version to 3.2.1

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -16,7 +16,7 @@
 
 name "libffi"
 
-default_version "3.0.13"
+default_version "3.2.1"
 
 dependency "libtool"
 


### PR DESCRIPTION
This newer version is required to compile libffi on the power arch.

/cc @chef/ociv @chef/omnibus-maintainers 