### PR TITLE
Use `project_dir` DSL function in gemspec guards

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -59,8 +59,8 @@ build do
       copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
     end
 
-    gem "build chef-windows.gemspec", env: env if File.exist? "#{software.project_dir}/chef-windows.gemspec"
-    gem "build chef-x86-mingw32.gemspec", env: env if File.exist? "#{software.project_dir}/chef-x86-mingw32.gemspec"
+    gem("build chef-windows.gemspec", env: env) if File.exist? "#{project_dir}/chef-windows.gemspec"
+    gem("build chef-x86-mingw32.gemspec", env: env) if File.exist? "#{project_dir}/chef-x86-mingw32.gemspec"
 
     gem "install chef*mingw32.gem" \
         " --no-ri --no-rdoc" \


### PR DESCRIPTION
This fixes a bug introduced in cc081dc6ed3b353ffe320a9472f8af4bf611cc15. Chef Windows builds are currently failing with:

```
C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-software-b7a4f9341c39/config/software/chef.rb:62:in `block in evaluate': undefined local variable or method `software' for #<Omnibus::Builder (Cleanroom)> (NameError)
```

/cc @ksubrama @chef/omnibus-maintainers 