### PR TITLE
Take advantage of globbing in windows `gem build` command

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -59,8 +59,7 @@ build do
       copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
     end
 
-    gem("build chef-windows.gemspec", env: env) if File.exist? "#{project_dir}/chef-windows.gemspec"
-    gem("build chef-x86-mingw32.gemspec", env: env) if File.exist? "#{project_dir}/chef-x86-mingw32.gemspec"
+    gem "build chef-{windows,x86-mingw32}.gemspec", env: env
 
     gem "install chef*mingw32.gem" \
         " --no-ri --no-rdoc" \


### PR DESCRIPTION
This is a little long-winded but the explanation is important.

This form of the `gem build` command will build a gemspec named `chef-windows.gemspec` or `chef-x86-mingw32.gemspec`. Previously We used `File.exist?` guards to determine which gemspec to build. The problem with this approach is the guards are evaluated at software definition load time instead of the desired build execution time. If the Chef source code does not exist at the beginning of the build, the Chef Windows gem will not be built as both guards will evaluate to false. This can occur when the build cache was intentionally expired (`EXPIRE_CACHE` parameter) OR a build is being executed on a freshly provisioned Windows build slave. The `File.exist?` guards were also incorrectly evaluated against the  previous build's version of the Chef!

Manhattan CI test build: http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/61/downstreambuildview/

/cc @chef/client-engineers @chef/ociv @ksubrama 
