### PR TITLE
Update Nginx to 1.8.0 (the latest stable)

### DIFF
--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -15,13 +15,17 @@
 #
 
 name "nginx"
-default_version "1.4.4"
+default_version "1.8.0"
 
 dependency "pcre"
 dependency "openssl"
 
-source url: "http://nginx.org/download/nginx-#{version}.tar.gz",
-       md5: "5dfaba1cbeae9087f3949860a02caa9f"
+source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
+
+version("1.4.4") { source md5: "5dfaba1cbeae9087f3949860a02caa9f" }
+version("1.4.7") { source md5: "aee151d298dcbfeb88b3f7dd3e7a4d17" }
+version("1.6.3") { source md5: "ea813aee2c344c2f5b66cdb24a472738" }
+version("1.8.0") { source md5: "3ca4a37931e9fa301964b8ce889da8cb" }
 
 relative_path "nginx-#{version}"
 


### PR DESCRIPTION
I found nginx 1.4.4 to be quite out of date and vulnerable,  so I've updated the default to 1.8.0 (the latest stable release) and also filled in a few other "legacy stable" releases (1.4.7 and 1.6.3)