### PR TITLE
Ma/libsodium rebase

### DIFF
--- a/config/patches/libzmq/zeromq-4.0.5_configure-pedantic_centos_5.patch
+++ b/config/patches/libzmq/zeromq-4.0.5_configure-pedantic_centos_5.patch
@@ -1,0 +1,16 @@
+--- a/configure.ac.orig   2015-05-05 23:00:30.000000000 +0000
++++ b/configure.ac        2015-05-05 23:01:58.000000000 +0000
+@@ -103,10 +103,10 @@
+ fi
+ 
+ # Set pedantic
+-libzmq_pedantic="yes"
++libzmq_pedantic="no"
+
+ # By default compiling with -Werror except OSX.
+-libzmq_werror="yes"
++libzmq_werror="no"
+ 
+ # By default use DSO visibility
+ libzmq_dso_visibility="yes"
+

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -17,7 +17,7 @@
 
 # We use the version in util-linux, and only build the libuuid subdirectory
 name "libsodium"
-default_version "0.7.1"
+default_version "1.0.2"
 
 dependency "autoconf"
 dependency "automake"
@@ -25,8 +25,14 @@ dependency "libtool"
 
 
 # perhaps use git https://github.com/jedisct1/libsodium/
-source url: "http://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz",
-       md5: "c224fe3923d1dcfe418c65c8a7246316"
+version "0.7.1" do
+  source md5: "c224fe3923d1dcfe418c65c8a7246316"
+end
+version "1.0.2" do
+  source md5: "dc40eb23e293448c6fc908757738003f"
+end
+
+source url: "http://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
 relative_path "libsodium-#{version}"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# We use the version in util-linux, and only build the libuuid subdirectory
+name "libsodium"
+default_version "0.7.1"
+
+dependency "autoconf"
+dependency "automake"
+dependency "libtool"
+
+
+# perhaps use git https://github.com/jedisct1/libsodium/
+source url: "http://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz",
+       md5: "c224fe3923d1dcfe418c65c8a7246316"
+
+relative_path "libsodium-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
+  make "-j #{workers}", env: env
+  make "install", env: env
+end

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -42,6 +42,10 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
+  # centos 5 has an old version of gcc (4.2.1) that has trouble with
+  # long long and c++ in pedantic mode
+  patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch"
+
   command "./autogen.sh", env: env
   command "./configure --prefix=#{install_dir}/embedded", env: env
 

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -21,11 +21,10 @@ default_version "2.1.11"
 dependency "autoconf"
 dependency "automake"
 dependency "libtool"
-dependency "libuuid"
-
 
 version "2.1.11" do
   source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
+  dependency "libuuid"
 end
 version "4.0.4" do
   source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -24,15 +24,16 @@ dependency "libtool"
 dependency "libuuid"
 
 
-
 version "2.1.11" do
   source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
 end
 version "4.0.4" do
   source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"
+  dependency "libsodium"
 end
 version "4.0.5" do
   source md5: "73c39f5eb01b9d7eaf74a5d899f1d03d"
+  dependency "libsodium"
 end
 
 relative_path "zeromq-#{version}"

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -44,7 +44,7 @@ build do
 
   # centos 5 has an old version of gcc (4.2.1) that has trouble with
   # long long and c++ in pedantic mode
-  patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch"
+  patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch" if el?
 
   command "./autogen.sh", env: env
   command "./configure --prefix=#{install_dir}/embedded", env: env


### PR DESCRIPTION
This adds libsodium and alters libzmq to depend on it.

ZMQ will build with encryption support if libsodium is detected.

This lacks windows support at this time; that relies on a prebuilt zeromq binary that doesn't include libsodium. 

@chef/omnibus-maintainers 