### PR TITLE
Security: Update PostgreSQL version definitions and change default 9.2.9 -> 9.2.10

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.2.9"
+default_version "9.2.10"
 
 dependency "zlib"
 dependency "openssl"
@@ -27,12 +27,20 @@ version "9.1.9" do
   source md5: "6b5ea53dde48fcd79acfc8c196b83535"
 end
 
+version "9.1.15" do
+  source md5: "6ac52cf13ecf6b09c7d42928d1219cae"
+end
+
 version "9.2.8" do
   source md5: "c5c65a9b45ee53ead0b659be21ca1b97"
 end
 
 version "9.2.9" do
   source md5: "38b0937c86d537d5044c599273066cfc"
+end
+
+version "9.2.10" do
+  source md5: "7b81646e2eaf67598d719353bf6ee936"
 end
 
 version "9.3.4" do
@@ -43,8 +51,16 @@ version "9.3.5" do
   source md5: "5059857c7d7e6ad83b6d55893a121b59"
 end
 
+version "9.3.6" do
+  source md5: "0212b03f2835fdd33126a2e70996be8e"
+end
+
 version "9.4.0" do
   source md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b"
+end
+
+version "9.4.1" do
+  source md5: "2cf30f50099ff1109d0aa517408f8eff"
 end
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"


### PR DESCRIPTION
Add definitions for Postgres 9.1.15, 9.2.10, 9.3.6 and 9.4.1. Update the default to 9.2.10. 