### PR TITLE
Update git def to kernel.org checksums only

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -32,11 +32,7 @@ version "1.9.0" do
 end
 
 version "1.9.5" do
-  source md5: "a50979e98068f7dae8ad34492d0ef5a8"
-end
-
-version "2.2.1" do
-  source md5: "d1110e35369bc37aa204915f64c5d1c8"
+  source md5: "e9c82e71bec550e856cccd9548902885"
 end
 
 version "2.2.1" do


### PR DESCRIPTION
```
$ md5 ~/Downloads/git-*
MD5 (/Users/isa/Downloads/git-1.9.0.tar.gz) = 0e00839539fc43cd2c350589744f254a
MD5 (/Users/isa/Downloads/git-1.9.5.tar.gz) = e9c82e71bec550e856cccd9548902885
MD5 (/Users/isa/Downloads/git-2.2.1.tar.gz) = ff41fdb094eed1ec430aed8ee9b9849c
```