### PR TITLE
initial openbsd support, tested on 5.7

### DIFF
--- a/config/patches/libedit/openbsd-weak-alias-fix.patch
+++ b/config/patches/libedit/openbsd-weak-alias-fix.patch
@@ -1,0 +1,48 @@
+diff -ur libedit-20120601-3.0.orig/src/strlcat.c libedit-20120601-3.0/src/strlcat.c
+--- libedit-20120601-3.0.orig/src/strlcat.c	Wed May 13 17:47:58 2015
++++ libedit-20120601-3.0/src/strlcat.c	Wed May 13 17:48:14 2015
+@@ -29,7 +29,7 @@
+ 
+ #ifdef _LIBC
+ # ifdef __weak_alias
+-__weak_alias(strlcat, _strlcat)
++//__weak_alias(strlcat, _strlcat)
+ # endif
+ #endif
+ 
+diff -ur libedit-20120601-3.0.orig/src/strlcpy.c libedit-20120601-3.0/src/strlcpy.c
+--- libedit-20120601-3.0.orig/src/strlcpy.c	Wed May 13 17:47:58 2015
++++ libedit-20120601-3.0/src/strlcpy.c	Wed May 13 17:48:14 2015
+@@ -29,7 +29,7 @@
+ 
+ #ifdef _LIBC
+ # ifdef __weak_alias
+-__weak_alias(strlcpy, _strlcpy)
++//__weak_alias(strlcpy, _strlcpy)
+ # endif
+ #endif
+ 
+diff -ur libedit-20120601-3.0.orig/src/unvis.c libedit-20120601-3.0/src/unvis.c
+--- libedit-20120601-3.0.orig/src/unvis.c	Wed May 13 17:47:58 2015
++++ libedit-20120601-3.0/src/unvis.c	Wed May 13 17:48:14 2015
+@@ -50,7 +50,7 @@
+ #include <vis.h>
+ 
+ #ifdef __weak_alias
+-__weak_alias(strnunvisx,_strnunvisx)
++//__weak_alias(strnunvisx,_strnunvisx)
+ #endif
+ 
+ #if !HAVE_VIS
+diff -ur libedit-20120601-3.0.orig/src/vis.c libedit-20120601-3.0/src/vis.c
+--- libedit-20120601-3.0.orig/src/vis.c	Wed May 13 17:47:58 2015
++++ libedit-20120601-3.0/src/vis.c	Wed May 13 17:48:14 2015
+@@ -69,7 +69,7 @@
+ #include <stdlib.h>
+ 
+ #ifdef __weak_alias
+-__weak_alias(strvisx,_strvisx)
++//__weak_alias(strvisx,_strvisx)
+ #endif
+ 
+ #if !HAVE_VIS || !HAVE_SVIS

--- a/config/patches/ncurses/patch-ncurses_tinfo_lib__baudrate.c
+++ b/config/patches/ncurses/patch-ncurses_tinfo_lib__baudrate.c
@@ -1,0 +1,24 @@
+$NetBSD: patch-ncurses_tinfo_lib__baudrate.c,v 1.1 2014/05/11 16:55:17 rodent Exp $
+
+sys/ttydev.h doesn't exist in OpenBSD 5.5
+
+--- ncurses/tinfo/lib_baudrate.c.orig	Sun Dec 19 01:50:50 2010
++++ ncurses/tinfo/lib_baudrate.c
+@@ -39,7 +39,7 @@
+ 
+ #include <curses.priv.h>
+ #include <termcap.h>		/* ospeed */
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__OpenBSD__)
+ #include <sys/param.h>
+ #endif
+ 
+@@ -49,7 +49,7 @@
+  * of the indices up to B115200 fit nicely in a 'short', allowing us to retain
+  * ospeed's type for compatibility.
+  */
+-#if (defined(__FreeBSD__) && (__FreeBSD_version < 700000)) || defined(__NetBSD__) || defined(__OpenBSD__)
++#if (defined(__FreeBSD__) && (__FreeBSD_version < 700000)) || defined(__NetBSD__) || (defined(__OpenBSD__) && (OpenBSD < 201405))
+ #undef B0
+ #undef B50
+ #undef B75

--- a/config/patches/pkg-config/openbsd-charset.patch
+++ b/config/patches/pkg-config/openbsd-charset.patch
@@ -1,0 +1,19 @@
+--- pkg-config-0.28.orig/glib/glib/libcharset/config.charset	Wed May 13 18:21:29 2015
++++ pkg-config-0.28/glib/glib/libcharset/config.charset	Wed May 13 18:21:54 2015
+@@ -398,6 +398,16 @@
+ 	echo "BIG5 BIG5"
+ 	echo "SJIS SHIFT_JIS"
+ 	;;
++    openbsd*)
++    echo "646 ASCII" 
++    echo "ISO8859-1 ISO-8859-1"
++    echo "ISO8859-2 ISO-8859-2"
++    echo "ISO8859-4 ISO-8859-4"
++    echo "ISO8859-5 ISO-8859-5"
++    echo "ISO8859-7 ISO-8859-7"
++    echo "ISO8859-13 ISO-8859-13"
++    echo "ISO8859-15 ISO-8859-15"
++    ;;
+     darwin[56]*)
+ 	# Darwin 6.8 doesn't have nl_langinfo(CODESET); therefore
+ 	# localcharset.c falls back to using the full locale name

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -37,8 +37,12 @@ build do
 
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
-  if freebsd?
+  if freebsd? || openbsd?
     patch source: "freebsd-vi-fix.patch"
+  end
+
+  if openbsd?
+    patch source: "openbsd-weak-alias-fix.patch", plevel: 1
   end
 
   if version == "20120601-3.0" && ppc64le?

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -77,6 +77,10 @@ build do
     patch source: "ncurses-clang.patch"
   end
 
+  if openbsd?
+    patch source: "patch-ncurses_tinfo_lib__baudrate.c", plevel: 0
+  end
+
   if version == "5.9" && ppc64le?
     patch source: "v5.9.ppc64le-configure.patch", plevel: 1
   end

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -34,6 +34,12 @@ build do
     patch source: "v0.28.ppc64le-configure.patch", plevel: 1
   end
 
+  # pkg-config (at least up to 0.28) includes an older version of
+  # libcharset/lib/config.charset that doesn't know about openbsd
+  if openbsd?
+    patch source: "openbsd-charset.patch", plevel: 1
+  end
+
   command "./configure" \
           " --prefix=#{install_dir}/embedded" \
           " --disable-debug" \
@@ -52,4 +58,10 @@ build do
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
+
+  # ensure charset.alias gets installed on openbsd else pkg-config will
+  # exit with byte conversion errors.
+  if openbsd?
+    copy "#{project_dir}/glib/glib/libcharset/charset.alias", "#{install_dir}/embedded/lib/charset.alias"
+  end
 end


### PR DESCRIPTION
I was able to build the omnibus chef client installer with these patches on openbsd 5.7. havent tried the other projects yet (chefdk, etc)