### PR TITLE
Build Chef's subprojects

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -59,13 +59,17 @@ build do
       copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
     end
 
+    bundle "install --without server docgen", env: env
+
+    # Install components that live inside Chef's git repo. For now this is just
+    # 'chef-config'
+    bundle "exec rake install_components", env: env
+
     gem "build chef-{windows,x86-mingw32}.gemspec", env: env
 
     gem "install chef*mingw32.gem" \
         " --no-ri --no-rdoc" \
         " --verbose", env: env
-
-    bundle "install --without server docgen", env: env
 
     block "Build Event Log Dll" do
       Dir.chdir software.project_dir do
@@ -77,6 +81,10 @@ build do
 
     # install the whole bundle first
     bundle "install --without server docgen", env: env
+
+    # Install components that live inside Chef's git repo. For now this is just
+    # 'chef-config'
+    bundle "exec rake install_components", env: env
 
     gem "build chef.gemspec", env: env
 


### PR DESCRIPTION
Update Chef software definition to build the subprojects, which we'll need to make appbundler happy with the change https://github.com/chef/chef/pull/3270

The way I wrote this patch right now, it will break on a version of chef that doesn't have a chef-config subproject (or at least a dummy rake task for `install_components`). Are we building Chef 11 with this or is it cool to just roll forward?

@chef/client-core @chef/omnibus-maintainers 