### PR TITLE
Add openssl 1.0.1m for windows

### DIFF
--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -36,6 +36,10 @@ source url: "http://dl.bintray.com/oneclick/OpenKnapsack/x86/openssl-#{version}-
 version('1.0.0n') { source md5: "9506530353f3b984680ec27b7270874a" }
 version('1.0.0q') { source md5: "577dbe528415c6f178a9431fd0554df4" }
 version('1.0.0r') { source md5: "25402ddce541aa54eb5e114721926e72" }
+version('1.0.1m') do
+  source url: "https://github.com/jdmundrawala/knapsack-recipes/releases/download/openssl-1.0.1m/openssl-1.0.1m-x86-windows.tar.lzma",
+         md5: "789c307a560386a55e14f3e04cd69865"
+end
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
This will probably fix CI (when used with chefdk)
cc @danielsdeleo @schisamo @chef/omnibus-maintainers 