### PR TITLE
Make git def work on AIX (6.1)

### DIFF
--- a/config/patches/git/aix-strcmp-in-dirc.patch
+++ b/config/patches/git/aix-strcmp-in-dirc.patch
@@ -1,0 +1,12 @@
+diff -ur a/dir.c b/dir.c
+--- a/dir.c	2015-06-10 22:49:21 +0000
++++ b/dir.c	2015-06-10 22:49:49 +0000
+@@ -52,7 +52,7 @@
+ 	return fnmatch(pattern, string, flags | (ignore_case ? FNM_CASEFOLD : 0));
+ }
+ 
+-inline int git_fnmatch(const struct pathspec_item *item,
++int git_fnmatch(const struct pathspec_item *item,
+ 		       const char *pattern, const char *string,
+ 		       int prefix)
+ {

--- a/config/patches/git/aix-use-freeware-install.patch
+++ b/config/patches/git/aix-use-freeware-install.patch
@@ -1,0 +1,12 @@
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	2015-06-11 00:14:37 +0000
++++ b/Makefile	2015-06-11 00:14:49 +0000
+@@ -399,7 +399,7 @@
+ DIFF = diff
+ TAR = tar
+ FIND = find
+-INSTALL = install
++INSTALL = /opt/freeware/bin/install
+ RPMBUILD = rpmbuild
+ TCL_PATH = tclsh
+ TCLTK_PATH = wish

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -42,21 +42,29 @@ end
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
 build do
+
   env = with_standard_compiler_flags(with_embedded_path).merge(
+    "NEEDS_LIBICONV"     => "1",
     "NO_GETTEXT"         => "1",
     "NO_PYTHON"          => "1",
-    "NO_TCLTK"           => "1",
     "NO_R_TO_GCC_LINKER" => "1",
-    "NEEDS_LIBICONV"     => "1",
+    "NO_TCLTK"           => "1",
 
+    "CURLDIR"    => "#{install_dir}/embedded",
+    "EXPATDIR"   => "#{install_dir}/embedded",
+    "ICONVDIR"   => "#{install_dir}/embedded",
+    "LIBPCREDIR" => "#{install_dir}/embedded",
+    "OPENSSLDIR" => "#{install_dir}/embedded",
     "PERL_PATH"  => "#{install_dir}/embedded/bin/perl",
     "ZLIB_PATH"  => "#{install_dir}/embedded",
-    "ICONVDIR"   => "#{install_dir}/embedded",
-    "OPENSSLDIR" => "#{install_dir}/embedded",
-    "EXPATDIR"   => "#{install_dir}/embedded",
-    "CURLDIR"    => "#{install_dir}/embedded",
-    "LIBPCREDIR" => "#{install_dir}/embedded",
   )
+
+  # AIX needs /opt/freeware/bin only for patch
+  patch_env = env.dup
+  patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
+
+  patch source: "aix-use-freeware-install.patch", plevel: 1, env: patch_env if aix?
+  patch source: "aix-strcmp-in-dirc.patch", plevel: 1, env: patch_env if aix?
 
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded"]


### PR DESCRIPTION
"An inline definition of a function with external linkage shall not contain a definition of a modifiable object with static storage duration, and shall not contain a reference to an identifier with internal linkage."

correct patch name
add diff command to git patches
don't allow editor to mangle patches