### PR TITLE
Add debug enabled rubygems to track down nil spec issue

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -24,51 +24,63 @@ else
   dependency "ruby"
 end
 
-unless windows?
-  version "1.8.29" do
-    source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
-  end
-
-  version "1.8.24" do
-    source md5: "3a555b9d579f6a1a1e110628f5110c6b"
-  end
-
-  # NOTE: this is the last version of rubygems before the 2.2.x change to native gem install location
-  #
-  #  https://github.com/rubygems/rubygems/issues/874
-  #
-  # This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
-  version "2.1.11" do
-    source md5: "b561b7aaa70d387e230688066e46e448"
-  end
-
-  version "2.2.1" do
-    source md5: "1f0017af0ad3d3ed52665132f80e7443"
-  end
-
-  version "2.4.1" do
-    source md5: "7e39c31806bbf9268296d03bd97ce718"
-  end
-
-  version "2.4.4" do
-    source md5: "440a89ad6a3b1b7a69b034233cc4658e"
-  end
-
-  version "2.4.5" do
-    source md5: "5918319a439c33ac75fbbad7fd60749d"
-  end
-
-  source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+version "1.8.29" do
+  source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
 end
 
-relative_path "rubygems-#{version}"
+version "1.8.24" do
+  source md5: "3a555b9d579f6a1a1e110628f5110c6b"
+end
+
+# NOTE: this is the last version of rubygems before the 2.2.x change to native gem install location
+#
+#  https://github.com/rubygems/rubygems/issues/874
+#
+# This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
+version "2.1.11" do
+  source md5: "b561b7aaa70d387e230688066e46e448"
+end
+
+version "2.2.1" do
+  source md5: "1f0017af0ad3d3ed52665132f80e7443"
+end
+
+version "2.4.1" do
+  source md5: "7e39c31806bbf9268296d03bd97ce718"
+end
+
+version "2.4.4" do
+  source md5: "440a89ad6a3b1b7a69b034233cc4658e"
+end
+
+version "2.4.5" do
+  source md5: "5918319a439c33ac75fbbad7fd60749d"
+end
+
+# NOTE: overwriting source at the top level seems to be required for this to work.
+source git: 'git@github.com:danielsdeleo/rubygems.git'
+#source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+
+version "v2.4.4_plus_debug" do
+  source git: 'git@github.com:danielsdeleo/rubygems.git'
+end
+
+version "2.4.4.debug.1" do
+  source git: 'git@github.com:danielsdeleo/rubygems.git'
+end
+
+# NOTE: this is only gonna work when pulling from github
+relative_path "rubygems"
 
 build do
   env = with_embedded_path
 
+  ruby "setup.rb --no-ri --no-rdoc", env: env
+
   if windows?
-    command "gem update --system #{version} --no-ri --no-rdoc", env: env
-  else
-    ruby "setup.rb --no-ri --no-rdoc", env: env
+    # After installing ruby, we need to rerun the command that patches devkit
+    # functionality into rubygems.
+    embedded_dir = "#{install_dir}/embedded"
+    ruby "dk.rb install", env: env, cwd: embedded_dir
   end
 end


### PR DESCRIPTION
We've been having no success in tracking down this rubygems bug with just ad-hoc builds, so I would like to switch ChefDK to my patched branch until we can figure out what's going on.