### PR TITLE
Add space near zlib flag for curl configure

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -30,22 +30,26 @@ build do
 
   delete "#{project_dir}/src/tool_hugehelp.c"
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-manual" \
-          " --disable-debug" \
-          " --enable-optimize" \
-          " --disable-ldap" \
-          " --disable-ldaps" \
-          " --disable-rtsp" \
-          " --enable-proxy" \
-          " --disable-dependency-tracking" \
-          " --enable-ipv6" \
-          " --without-libidn" \
-          " --without-gnutls" \
-          " --without-librtmp" \
-          " --with-ssl=#{install_dir}/embedded" \
-           "--with-zlib=#{install_dir}/embedded", env: env
+  configure_command = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    "--disable-manual",
+    "--disable-debug",
+    "--enable-optimize",
+    "--disable-ldap",
+    "--disable-ldaps",
+    "--disable-rtsp",
+    "--enable-proxy",
+    "--disable-dependency-tracking",
+    "--enable-ipv6",
+    "--without-libidn",
+    "--without-gnutls",
+    "--without-librtmp",
+    "--with-ssl=#{install_dir}/embedded",
+    "--with-zlib=#{install_dir}/embedded",
+  ]
+
+  command configure_command.join(" "), env: env
 
   make "-j #{workers}", env: env
   make "install", env: env


### PR DESCRIPTION
Noticed this line go by during curl configure on --log-level debug:
```
D | configure: PKG_CONFIG_LIBDIR will be set to "/opt/omnibus-toolchain/embedded--with-zlib=/opt/omnibus-toolchain/embedded/lib/pkgconfig"
```

Previously:
```
          " --without-librtmp" \
          " --with-ssl=#{install_dir}/embedded" \
           "--with-zlib=#{install_dir}/embedded", env: env
```