### PR TITLE
Suppress already exported symbol warning during ruby build

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -67,7 +67,10 @@ when "freebsd"
 when "aix"
   # this magic per IBM
   env['LDSHARED'] = "xlc -G"
-  env['CFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
+  # -qsuppress=0711-415 improves troubleshooting by suppressing:
+  # ld: 0711-415 WARNING: Symbol strlcat is already exported.
+  # previously accounting for 2/3rds of the ruby build output
+  env['CFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include -qsuppress=0711-415"
   # this magic per IBM
   env['XCFLAGS'] = "-DRUBY_EXPORT"
   # need CPPFLAGS set so ruby doesn't try to be too clever


### PR DESCRIPTION
:tada: 

such as `ld: 0711-415 WARNING: Symbol strlcat is already exported.`

```
-bash-4.2$ echo "$a" | wc -l
    4135
-bash-4.2$ echo "$a" | grep -v "0711-415" | wc -l
    1282
```