### PR TITLE
Change to use source_dir, remove unzip

### DIFF
--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -28,9 +28,7 @@ end
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "libzmq4x-windows")
-
-  command "7z.exe x #{project_file} -o#{Omnibus::Config.cache_dir}", env: env
+  tmpdir = File.join(Omnibus::Config.source_dir, "libzmq4x-windows")
 
   copy "#{tmpdir}/bin/*", "#{install_dir}/embedded/bin"
   copy "#{tmpdir}/include/*", "#{install_dir}/embedded/include"

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -26,8 +26,6 @@ version("1.0.21") do
 end
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
   tmpdir = File.join(Omnibus::Config.source_dir, "libzmq4x-windows")
 
   copy "#{tmpdir}/bin/*", "#{install_dir}/embedded/bin"


### PR DESCRIPTION
Unzipping into the cache dir doesn't make sense because the fetcher has
already unzipped into the source dir. It also can cause issues where
there is a previously unzipped entry in the cache dir.

Use the perfectly good source dir instead.