### PR TITLE
Add rebar 2.6.0, which includes my fix for port variable expansion

### DIFF
--- a/config/software/rebar.rb
+++ b/config/software/rebar.rb
@@ -17,7 +17,10 @@
 name "rebar"
 # Current version (2.3.0) suffers from a pretty bad bug that breaks tests.
 # (see https://github.com/rebar/rebar/pull/279 and https://github.com/rebar/rebar/pull/251)
+# Version 2.3.1 Fixes this; we should switch to that if later versions aren't workable.
 default_version "93621d0d0c98035f79790ffd24beac94581b0758"
+
+version "2.6.0"
 
 dependency "erlang"
 


### PR DESCRIPTION
This is needed to build erlzmq with the omnibus-software libsodium/zmq.
This should be pretty safe; it doesn't alter the default rebar, and omnibus-push-jobs-server builds with this change.
@chef/omnibus-maintainers 