### PR TITLE
Cleanup rubygems sw def, pull from canonical git

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -26,12 +26,22 @@ end
 
 source git: 'https://github.com/rubygems/rubygems.git'
 
+# NOTE: Originally we always installed rubygems from tarballs, but now we want
+# to default to pulling from git. Rubygems uses the leading "v" in their
+# version tags, e.g., v2.4.4 (instead of just 2.4.4). There are a lot of
+# omnibus projects using this, and we don't want to force everyone to change
+# their version pins to include the leading "v", so we need to set the source
+# URL on a per-version basis.
+tarball_url = "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+
 version "1.8.29" do
-  source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
+  source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269", url: tarball_url
+  source.delete(:git)
 end
 
 version "1.8.24" do
-  source md5: "3a555b9d579f6a1a1e110628f5110c6b"
+  source md5: "3a555b9d579f6a1a1e110628f5110c6b", url: tarball_url
+  source.delete(:git)
 end
 
 # NOTE: this is the last version of rubygems before the 2.2.x change to native gem install location
@@ -40,23 +50,28 @@ end
 #
 # This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
 version "2.1.11" do
-  source md5: "b561b7aaa70d387e230688066e46e448"
+  source md5: "b561b7aaa70d387e230688066e46e448", url: tarball_url
+  source.delete(:git)
 end
 
 version "2.2.1" do
-  source md5: "1f0017af0ad3d3ed52665132f80e7443"
+  source md5: "1f0017af0ad3d3ed52665132f80e7443", url: tarball_url
+  source.delete(:git)
 end
 
 version "2.4.1" do
-  source md5: "7e39c31806bbf9268296d03bd97ce718"
+  source md5: "7e39c31806bbf9268296d03bd97ce718", url: tarball_url
+  source.delete(:git)
 end
 
 version "2.4.4" do
-  source md5: "440a89ad6a3b1b7a69b034233cc4658e"
+  source md5: "440a89ad6a3b1b7a69b034233cc4658e", url: tarball_url
+  source.delete(:git)
 end
 
 version "2.4.5" do
-  source md5: "5918319a439c33ac75fbbad7fd60749d"
+  source md5: "5918319a439c33ac75fbbad7fd60749d", url: tarball_url
+  source.delete(:git)
 end
 
 version "v2.4.4_plus_debug" do

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -82,8 +82,13 @@ version "2.4.4.debug.1" do
   source git: 'git@github.com:danielsdeleo/rubygems.git'
 end
 
-# NOTE: this is only gonna work when pulling from github
-relative_path "rubygems"
+# tarballs get expanded as rubygems-xyz, git repo is always rubygems:
+if source.key?(:url)
+  relative_path "rubygems-#{version}"
+else
+  relative_path "rubygems"
+end
+
 
 build do
   env = with_embedded_path

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -24,6 +24,8 @@ else
   dependency "ruby"
 end
 
+source git: 'https://github.com/rubygems/rubygems.git'
+
 version "1.8.29" do
   source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
 end
@@ -56,10 +58,6 @@ end
 version "2.4.5" do
   source md5: "5918319a439c33ac75fbbad7fd60749d"
 end
-
-# NOTE: overwriting source at the top level seems to be required for this to work.
-source git: 'git@github.com:danielsdeleo/rubygems.git'
-#source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
 
 version "v2.4.4_plus_debug" do
   source git: 'git@github.com:danielsdeleo/rubygems.git'


### PR DESCRIPTION
@chef/omnibus-maintainers everyone +1'd #439 so I merged it but I think it needs a little cleanup. We actually found the cause of the ChefDK test issues, so we don't need to put my patch into chef-dk production builds, but it's nice to build the same way on windows and *nix, plus building from git means we can more easily build with patched versions in the future. So, tl;dr, I'd like to keep most of the changes from #439 but have the default upstream be rubygems' official github repo.