### PR TITLE
Move 64bitall flag to aix only

### DIFF
--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -41,11 +41,13 @@ build do
                        " -Dprefix=#{install_dir}/embedded",
                        " -Duseshrplib",
                        " -Dusethreads",
-                       " -Duse64bitall",
                        " #{cc_command}",
                        " -Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"]
 
-  configure_command << "-Dmake=gmake" if aix?
+  if aix?
+    configure_command << "-Dmake=gmake"
+    configure_command << "-Duse64bitall"
+  end
 
   command configure_command.join(" "), env: env
   make "-j #{workers}", env: env


### PR DESCRIPTION
Forcing the 64bitall flag on all platform causes issues. On 64bit platforms (other than AIX and possibly Solaris10?), Perl will still build 64bit without the flag.

This reverts the flag from the behavior introduced in https://github.com/chef/omnibus-software/pull/438