### PR TITLE
Remove nokogiri/bundler deps from berks software

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -31,19 +31,11 @@ else
   dependency "libarchive"
 end
 
-dependency "nokogiri"
-dependency "bundler"
 dependency "dep-selector-libgecode"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install" \
-         " --jobs #{workers}" \
-         " --without guard", env: env
-
-  bundle "exec thor gem:build", env: env
-
-  gem "install pkg/berkshelf-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem "build berkshelf.gemspec", env: env
+  gem "install --no-ri --no-rdoc berkshelf-*.gem", env: env
 end


### PR DESCRIPTION
* Since 3.0.0, nokogiri is not a dependency (there is a separate
  software for berkshelf 2, so users of this will be assuming >= 3.)
* Since `bundle exec thor gem:build` just calls `rake gem:build`, and
  `rake gem:build`, just calls `gem build` (but without putting it in a
  pkg directory), we can call it directly, and we don't need to install
  the bundle or have bundler as a dependency.

I was having problems with this software installing its development
dependencies (its RSpec version conflicts with the version from most
recent Chef client.) The bundle command was installing the development
dependencies. I'm not sure how or why installing the dev deps with
bundler before running the build task made it include the dependencies,
but it doesn't do it anymore after this change.

Either way, it makes the build faster and has fewer dependencies.