### PR TITLE
config/software/mpfr: use version for uri.

### DIFF
--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -20,8 +20,9 @@ default_version "3.1.2"
 dependency "gmp"
 
 version("3.1.2") { source md5: "181aa7bb0e452c409f2788a4a7f38476" }
+version("3.1.3") { source md5: "7b650781f0a7c4a62e9bc8bdaaa0018b" }
 
-source url: "http://www.mpfr.org/mpfr-current/mpfr-#{version}.tar.gz"
+source url: "http://www.mpfr.org/mpfr-#{version}/mpfr-#{version}.tar.gz"
 
 relative_path "mpfr-#{version}"
 


### PR DESCRIPTION
Hi, I wrote update for mpfr.

- use version string for part of url instead of `current`.
- add new version '3.1.3'

`mpfr-3.1.2.tar.gz` is away from /mpmr-current.