### PR TITLE
fix the libffi directory on Wind River Linux

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -49,6 +49,8 @@ build do
 
   # On 64-bit centos, libffi libraries are places under /embedded/lib64
   # move them over to lib
+  # wrlinux support is merged to chef-sugar master, waiting on 3.1.2 release
+  # https://github.com/sethvargo/chef-sugar/pull/116
   if (rhel? || suse? || ohai['platform_family'] == 'wrlinux') && _64_bit?
     # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
     # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -49,7 +49,7 @@ build do
 
   # On 64-bit centos, libffi libraries are places under /embedded/lib64
   # move them over to lib
-  if (rhel? || suse?) && _64_bit?
+  if (rhel? || suse? || ohai['platform_family'] == 'wrlinux') && _64_bit?
     # Can't use 'move' here since that uses FileUtils.mv, which on < Ruby 2.2.0-dev
     # returns ENOENT on moving symlinks with broken (in this case, already moved) targets.
     # http://comments.gmane.org/gmane.comp.lang.ruby.cvs/49907


### PR DESCRIPTION
libffi on WRL5 needs the same fix that RHEL and SUSE use. Did not use a Chef Sugar helper because there aren't any for Wind River Linux and I'm not sure there's a need.