### PR TITLE
Backout ncurses default_version change.

### DIFF
--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -15,7 +15,7 @@
 #
 
 name "ncurses"
-default_version "5.9"
+default_version "5.9-20150530"
 
 dependency "libtool" if aix?
 dependency "patch" if solaris2?


### PR DESCRIPTION
The 5.9 version fails to compile. This reverts the default version to ensure compile works again.

Closes #481 