### PR TITLE
Applying the stack-protector disable patch to wrlinux7

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -100,6 +100,16 @@ build do
     patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1
   end
 
+  # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
+  # disable ruby from linking against it, but Cisco switches will not have the
+  # library.  Disabling it as we do for Solaris.
+  #
+  # This will be changed to use a chef-sugar helper method once
+  # sethvargo/chef-sugar#116 is available in a release.
+  if ohai['platform'] == 'ios_xr' && version.to_f >= 2.1
+    patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
+  end
+
   # AIX needs /opt/freeware/bin only for patch
   patch_env = env.dup
   patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?


### PR DESCRIPTION
Wind River Linux 7 build boxes from Cisco, for use in building
Chef for IOS-XR devices, includes libssp and ruby cannot be convinced
to disable linking against it.  As we do for solaris, this will
apply the patch to ruby's configure script to forcefully disable it.