### PR TITLE
convert ssh git urls to https

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -80,11 +80,11 @@ version "2.4.8" do
 end
 
 version "v2.4.4_plus_debug" do
-  source git: 'git@github.com:danielsdeleo/rubygems.git'
+  source git: 'https://github.com/danielsdeleo/rubygems'
 end
 
 version "2.4.4.debug.1" do
-  source git: 'git@github.com:danielsdeleo/rubygems.git'
+  source git: 'https://github.com/danielsdeleo/rubygems'
 end
 
 # This is the 2.4.8 release with a fix for
@@ -92,7 +92,7 @@ end
 # work
 #
 version "jdm/2.4.8-patched" do
-  source git: 'git@github.com:jaym/rubygems.git'
+  source git: 'https://github.com/jaym/rubygems'
 end
 
 # tarballs get expanded as rubygems-xyz, git repo is always rubygems:


### PR DESCRIPTION
Consistently using http based urls for git repos makes it simpler to create an omnibus build environment. In my case, I'm using Hyper-V which does not use a NATed network so vagrant's SSH forwarding will not work. While I have customized my [vagrant file](https://github.com/mwrock/vagrantfile/blob/master/WinOmnibus) to setup SSH on the windows box mainly via installing posh-git, that was just one more yak I had to shave to get this to work and I still have to manually add the key to the ssh agent.

Moving to https removes this complexity.