### PR TITLE
set encoding to reading cacert.pem

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -60,7 +60,7 @@ build do
 
   # Append the 1024bit Verisign certs so that S3 continues to work
   block do
-    unless File.foreach("#{project_dir}/cacert.pem").grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
+    unless File.foreach("#{project_dir}/cacert.pem", :encoding => 'utf-8').grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
       File.open("#{project_dir}/cacert.pem", "a") { |fd| fd.write(VERISIGN_CERTS) }
     end
   end

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -60,7 +60,7 @@ build do
 
   # Append the 1024bit Verisign certs so that S3 continues to work
   block do
-    unless File.foreach("#{project_dir}/cacert.pem", :encoding => 'utf-8').grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
+    unless File.foreach("#{project_dir}/cacert.pem", encoding: 'utf-8').grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
       File.open("#{project_dir}/cacert.pem", "a") { |fd| fd.write(VERISIGN_CERTS) }
     end
   end


### PR DESCRIPTION
I met `invalid byte sequence` in my docker container which is created for pre-installed omnibus when reading `cacert.pem`.

```
File.foreach("./cacert.pem").grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?                                                                                    [ ArgumentError: invalid byte sequence in US-ASCII
	from (irb):1:in `==='
	from (irb):1:in `foreach'
	from (irb):1:in `each'
	from (irb):1:in `grep'
	from (irb):1
	from /opt/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
```

I have set `:encoding` for avoid this exception.