### PR TITLE
Use GNU patch on AIX for GDBM vs. IBM patch

### DIFF
--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -28,7 +28,15 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if version == "1.8.3"
-    patch source: "v1.8.3-Makefile.in.patch", plevel: 0
+    if aix?
+      # AIX needs /opt/freeware/bin only for patch
+      patch_env = env.dup
+      patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
+
+      patch source: "v1.8.3-Makefile.in.patch", plevel: 0, env: patch_env
+    else
+      patch source: "v1.8.3-Makefile.in.patch", plevel: 0
+    end
   end
 
   if freebsd?


### PR DESCRIPTION
This was preventing the AIX package for chef 12.5.1 from building correctly on Alluvium; introduced here: https://github.com/chef/omnibus-software/commit/16adc93087491b14ceee941d3396e0e2885a6970

At some point, we should add platform specific default paths to the specific binaries for each DSL method. The method discussed within https://github.com/chef/omnibus/pull/365 (of changing PATH to slurp in the executables you want) is clumsy and results in breaking the Ruby portion of the chef build (although succeeding for the gdbm 1.8.3 portion). And the approach I've taken here is just the tried and true ugly approach from the git def.

Platform-specific defaults would leave software defs more legible.

/cc @chef/omnibus-maintainers 