### PR TITLE
Remove extended attribute support from patch

### DIFF
--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -27,7 +27,8 @@ env = with_standard_compiler_flags(with_embedded_path)
 
 build do
   configure_command = ["./configure",
-                       "--prefix=#{install_dir}/embedded"]
+                       "--prefix=#{install_dir}/embedded",
+                       "--disable-xattr"]
 
   command configure_command.join(" "), env: env
   make "-j #{workers}", env: env


### PR DESCRIPTION
When building omnibus build which include patch, extended
attribute support is enabled by default when support libraries
are detected. There is no cross-platform support for these in
a single library and adding whitelist exceptions for every
possible platform seems like an anti-pattern. Also, for the type
of work we do with patch (just source code) extended attribute
support is not necessary so I've disabled it.