### PR TITLE
Migrate ChefDK component software definitions from omnibus-chef

### DIFF
--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-provisioning-aws"
+default_version "master"
+
+source git: "git://github.com/chef/chef-provisioning-aws.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-provisioning-aws.gemspec", env: env
+  gem "install chef-provisioning-aws-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-provisioning-azure"
+default_version "master"
+
+source git: "git://github.com/chef/chef-provisioning-azure.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-provisioning-azure.gemspec", env: env
+  gem "install chef-provisioning-azure-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -1,0 +1,43 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-provisioning-fog"
+default_version "master"
+
+source git: "git://github.com/chef/chef-provisioning-fog.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "nokogiri"
+dependency "bundler"
+dependency "chef"
+
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-provisioning-fog.gemspec", env: env
+  gem "install chef-provisioning-fog-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-provisioning-vagrant"
+default_version "master"
+
+source git: "git://github.com/chef/chef-provisioning-vagrant.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-provisioning-vagrant.gemspec", env: env
+  gem "install chef-provisioning-vagrant-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-provisioning"
+default_version "master"
+
+source git: "git://github.com/chef/chef-provisioning.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-provisioning.gemspec", env: env
+  gem "install chef-provisioning-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -1,0 +1,43 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-vault"
+default_version "v2.6.1"
+
+source git: "git://github.com/Nordstrom/chef-vault.git"
+
+relative_path "chef-vault"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chef-vault.gemspec", env: env
+  gem "install chef-vault-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chefspec"
+default_version "master"
+
+source git: "https://github.com/sethvargo/chefspec"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+dependency "fauxhai"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build chefspec.gemspec", env: env
+  gem "install chefspec-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "fauxhai"
+default_version "master"
+
+source git: "https://github.com/customink/fauxhai"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build fauxhai.gemspec", env: env
+  gem "install fauxhai-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "foodcritic"
+default_version "v5.0.0"
+
+source git: "git://github.com/acrmp/foodcritic.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "nokogiri"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build foodcritic.gemspec", env: env
+  gem "install foodcritic-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "inspec"
+default_version "master"
+
+source git: "git://github.com/chef/inspec.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --with test integration --without tools maintenance", env: env
+
+  gem "build inspec.gemspec", env: env
+  gem "install inspec-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "kitchen-inspec"
+default_version "master"
+
+source git: "https://github.com/chef/kitchen-inspec.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "test-kitchen"
+dependency "inspec"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development guard test", env: env
+
+  gem "build kitchen-inspec.gemspec", env: env
+  gem "install kitchen-inspec-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "kitchen-vagrant"
+default_version "master"
+
+source git: "git://github.com/test-kitchen/kitchen-vagrant.git"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "test-kitchen"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development guard test", env: env
+
+  gem "build kitchen-vagrant.gemspec", env: env
+  gem "install kitchen-vagrant-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "knife-spork"
+default_version "master"
+
+source git: "https://github.com/jonlives/knife-spork"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build knife-spork.gemspec", env: env
+  gem "install knife-spork-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "knife-windows"
+default_version "master"
+
+source git: "https://github.com/chef/knife-windows"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+dependency "chef"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without test development", env: env
+
+  gem "build knife-windows.gemspec", env: env
+  gem "install knife-windows-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubocop"
+default_version "v0.35.0"
+
+source git: "git://github.com/bbatsov/rubocop"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development test", env: env
+
+  gem "build rubocop.gemspec", env: env
+  gem "install rubocop-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -15,9 +15,9 @@
 #
 
 name "rubocop"
-default_version "v0.35.0"
+default_version "master"
 
-source git: "git://github.com/bbatsov/rubocop.git"
+source git: "https://github.com/bbatsov/rubocop"
 
 if windows?
   dependency "ruby-windows"

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "rubocop"
-default_version "v0.35.0"
+name "winrm-transport"
+default_version "v1.0.2"
 
-source git: "git://github.com/bbatsov/rubocop.git"
+source git: "git://github.com/test-kitchen/winrm-transport.git"
 
 if windows?
   dependency "ruby-windows"
@@ -32,9 +32,9 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development test", env: env
+  bundle "install --without development test guard", env: env
 
-  gem "build rubocop.gemspec", env: env
-  gem "install rubocop-*.gem" \
+  gem "build winrm-transport.gemspec", env: env
+  gem "install winrm-transport-*.gem" \
       " --no-ri --no-rdoc", env: env
 end

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -15,9 +15,9 @@
 #
 
 name "winrm-transport"
-default_version "v1.0.2"
+default_version "master"
 
-source git: "git://github.com/test-kitchen/winrm-transport.git"
+source git: "https://github.com/test-kitchen/winrm-transport"
 
 if windows?
   dependency "ruby-windows"


### PR DESCRIPTION
So we don't need to `gem install` these in the ChefDK

Related PR: https://github.com/chef/omnibus-chef/pull/542

\cc @schisamo 