### PR TITLE
Disable stack protection in perl on the Cisco IOS-XR platform

### DIFF
--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -49,6 +49,11 @@ build do
     configure_command << "-Duse64bitall"
   end
 
+  # On Cisco IOS-XR, we don't want libssp as a dependency
+  if ohai['platform'] == 'ios_xr'
+    configure_command << "-Accflags=-fno-stack-protector"
+  end
+
   command configure_command.join(" "), env: env
   make "-j #{workers}", env: env
   # using the install.perl target lets


### PR DESCRIPTION
breaks omnibus healthchecks (links against libssp). This will remove the dependency on
libssp for the ios_xr platform only.