### PR TITLE
Building ruby and a bunch of dependent libs on windows

### DIFF
--- a/config/patches/libyaml/v0.1.6.windows-configure.patch
+++ b/config/patches/libyaml/v0.1.6.windows-configure.patch
@@ -1,0 +1,26 @@
+diff --git a/include/yaml.h b/include/yaml.h
+index 5a04d36..70d839e 100644
+--- a/include/yaml.h
++++ b/include/yaml.h
+@@ -29,7 +29,7 @@ extern "C" {
+ #ifdef _WIN32
+ #   if defined(YAML_DECLARE_STATIC)
+ #       define  YAML_DECLARE(type)  type
+-#   elif defined(YAML_DECLARE_EXPORT)
++#   elif defined(YAML_DECLARE_EXPORT) || defined(DLL_EXPORT)
+ #       define  YAML_DECLARE(type)  __declspec(dllexport) type
+ #   else
+ #       define  YAML_DECLARE(type)  __declspec(dllimport) type
+diff --git a/src/Makefile b/src/Makefile
+index b72224d..a413ce0 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -219,7 +219,7 @@ top_srcdir = ..
+ AM_CPPFLAGS = -I$(top_srcdir)/include
+ lib_LTLIBRARIES = libyaml.la
+ libyaml_la_SOURCES = yaml_private.h api.c reader.c scanner.c parser.c loader.c writer.c emitter.c dumper.c
+-libyaml_la_LDFLAGS = -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
++libyaml_la_LDFLAGS = -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE) -no-undefined
+ all: all-am
+ 
+ .SUFFIXES:

--- a/config/patches/openssl-fips/openssl-fips-ar-needs-operation-before-target.patch
+++ b/config/patches/openssl-fips/openssl-fips-ar-needs-operation-before-target.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.fips
++++ b/Makefile.fips
+@@ -64,7 +64,7 @@ PEX_LIBS=
+ EX_LIBS= 
+ EXE_EXT= 
+ ARFLAGS=
+-AR=ar $(ARFLAGS) r
++AR=ar r $(ARFLAGS)
+ RANLIB= ranlib
+ NM= nm
+ PERL= perl

--- a/config/patches/openssl-fips/openssl-fips-fix-compiler-flags-table-for-msys.patch
+++ b/config/patches/openssl-fips/openssl-fips-fix-compiler-flags-table-for-msys.patch
@@ -1,0 +1,11 @@
+--- a/Configure
++++ b/Configure
+@@ -536,7 +536,7 @@ my %table=(
+ "BC-32","bcc32::::WIN32::BN_LLONG DES_PTR RC4_INDEX EXPORT_VAR_AS_FN:${no_asm}:win32",
+ 
+ # MinGW
+-"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL -DOPENSSL_USE_APPLINK:-mno-cygwin:.dll.a",
++"mingw", "gcc:-mno-cygwin -DL_ENDIAN -m32 -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-i386",
+ # As for OPENSSL_USE_APPLINK. Applink makes it possible to use .dll
+ # compiled with one compiler with application compiled with another
+ # compiler. It's possible to engage Applink support in mingw64 build,

--- a/config/patches/openssl-fips/openssl-fips-take-windres-rcflags.patch
+++ b/config/patches/openssl-fips/openssl-fips-take-windres-rcflags.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.shared
++++ b/Makefile.shared
+@@ -293,7 +293,7 @@ link_a.cygwin:
+ 	fi; \
+ 	dll_name=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX; \
+ 	$(PERL) util/mkrc.pl $$dll_name | \
+-		$(CROSS_COMPILE)windres -o rc.o; \
++		$(CROSS_COMPILE)windres $(RCFLAGS) -o rc.o; \
+ 	extras="$$extras rc.o"; \
+ 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
+ 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \

--- a/config/patches/openssl/openssl-1.0.1q-ar-needs-operation-before-target.patch
+++ b/config/patches/openssl/openssl-1.0.1q-ar-needs-operation-before-target.patch
@@ -1,0 +1,11 @@
+--- openssl-1.0.1q/Makefile.org.orig	2015-12-15 17:34:30.000000000 -0500
++++ openssl-1.0.1q/Makefile.org	2015-12-15 18:38:03.000000000 -0500
+@@ -64,7 +64,7 @@
+ EX_LIBS= 
+ EXE_EXT= 
+ ARFLAGS=
+-AR=ar $(ARFLAGS) r
++AR=ar r $(ARFLAGS)
+ RANLIB= ranlib
+ NM= nm
+ PERL= perl

--- a/config/patches/openssl/openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch
+++ b/config/patches/openssl/openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch
@@ -5,7 +5,7 @@
  
  # MinGW
 -"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL -DOPENSSL_USE_APPLINK:-mno-cygwin:.dll.a",
-+"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-i386",
++"mingw", "gcc:-mno-cygwin -DL_ENDIAN -m32 -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-i386",
  # As for OPENSSL_USE_APPLINK. Applink makes it possible to use .dll
  # compiled with one compiler with application compiled with another
  # compiler. It's possible to engage Applink support in mingw64 build,
@@ -14,7 +14,7 @@
  # non-mingw64 run-time environment. And as mingw64 is always consistent
  # with itself, Applink is never engaged and can as well be omitted.
 -"mingw64", "gcc:-mno-cygwin -DL_ENDIAN -O3 -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE::-D_MT:MINGW64:-lws2_32 -lgdi32 -lcrypt32:SIXTY_FOUR_BIT RC4_CHUNK_LL DES_INT EXPORT_VAR_AS_FN:${x86_64_asm}:mingw64:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a",
-+"mingw64", "gcc:-mno-cygwin -DL_ENDIAN -O3 -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE::-D_MT:MINGW64:-lws2_32 -lgdi32 -lcrypt32:SIXTY_FOUR_BIT RC4_CHUNK_LL DES_INT EXPORT_VAR_AS_FN:${x86_64_asm}:mingw64:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-x86-64",
++"mingw64", "gcc:-mno-cygwin -DL_ENDIAN -m64 -O3 -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE::-D_MT:MINGW64:-lws2_32 -lgdi32 -lcrypt32:SIXTY_FOUR_BIT RC4_CHUNK_LL DES_INT EXPORT_VAR_AS_FN:${x86_64_asm}:mingw64:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-x86-64",
  
  # UWIN 
  "UWIN", "cc:-DTERMIOS -DL_ENDIAN -O -Wall:::UWIN::BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${no_asm}:win32",

--- a/config/patches/openssl/openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch
+++ b/config/patches/openssl/openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch
@@ -1,0 +1,20 @@
+--- openssl-1.0.1q/Configure.orig	2015-12-15 17:47:52.000000000 -0500
++++ openssl-1.0.1q/Configure	2015-12-15 18:31:01.000000000 -0500
+@@ -537,7 +537,7 @@
+ "BC-32","bcc32::::WIN32::BN_LLONG DES_PTR RC4_INDEX EXPORT_VAR_AS_FN:${no_asm}:win32",
+ 
+ # MinGW
+-"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL -DOPENSSL_USE_APPLINK:-mno-cygwin:.dll.a",
++"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-i386",
+ # As for OPENSSL_USE_APPLINK. Applink makes it possible to use .dll
+ # compiled with one compiler with application compiled with another
+ # compiler. It's possible to engage Applink support in mingw64 build,
+@@ -545,7 +545,7 @@
+ # handling, one can't seriously consider its binaries for using with
+ # non-mingw64 run-time environment. And as mingw64 is always consistent
+ # with itself, Applink is never engaged and can as well be omitted.
+-"mingw64", "gcc:-mno-cygwin -DL_ENDIAN -O3 -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE::-D_MT:MINGW64:-lws2_32 -lgdi32 -lcrypt32:SIXTY_FOUR_BIT RC4_CHUNK_LL DES_INT EXPORT_VAR_AS_FN:${x86_64_asm}:mingw64:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a",
++"mingw64", "gcc:-mno-cygwin -DL_ENDIAN -O3 -Wall -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE::-D_MT:MINGW64:-lws2_32 -lgdi32 -lcrypt32:SIXTY_FOUR_BIT RC4_CHUNK_LL DES_INT EXPORT_VAR_AS_FN:${x86_64_asm}:mingw64:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a::--target=pe-x86-64",
+ 
+ # UWIN 
+ "UWIN", "cc:-DTERMIOS -DL_ENDIAN -O -Wall:::UWIN::BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${no_asm}:win32",

--- a/config/patches/openssl/openssl-1.0.1q-take-windres-rcflags.patch
+++ b/config/patches/openssl/openssl-1.0.1q-take-windres-rcflags.patch
@@ -1,0 +1,11 @@
+--- openssl-1.0.1q/Makefile.shared.orig	2015-12-15 17:01:08.000000000 -0500
++++ openssl-1.0.1q/Makefile.shared	2015-12-15 17:03:01.000000000 -0500
+@@ -293,7 +293,7 @@
+ 	fi; \
+ 	dll_name=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX; \
+ 	$(PERL) util/mkrc.pl $$dll_name | \
+-		$(CROSS_COMPILE)windres -o rc.o; \
++		$(CROSS_COMPILE)windres $(RCFLAGS) -o rc.o; \
+ 	extras="$$extras rc.o"; \
+ 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
+ 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \

--- a/config/patches/ruby/ruby-take-windres-rcflags.patch
+++ b/config/patches/ruby/ruby-take-windres-rcflags.patch
@@ -1,0 +1,12 @@
+--- a/cygwin/GNUmakefile.in
++++ b/cygwin/GNUmakefile.in
+@@ -2,7 +2,7 @@ include Makefile
+ 
+ ENABLE_SHARED=@ENABLE_SHARED@
+ DLLWRAP = @DLLWRAP@ --target=@target_os@ --driver-name="$(CC)"
+-WINDRES = @WINDRES@ --preprocessor="$(CPP) -xc" -DRC_INVOKED
++WINDRES = @WINDRES@ $(RCFLAGS) --preprocessor="$(CPP) -xc" -DRC_INVOKED
+ 
+ ifeq (@target_os@,cygwin)
+   DLL_BASE_NAME := $(LIBRUBY_SO:.dll=)
+

--- a/config/software/binutils.rb
+++ b/config/software/binutils.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name "binutils"
+default_version "2.25-tdm64-1"
 
-relative_path "expat-2.1.0"
+dependency "msys-base"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-#{version}.tar.lzma"
+version("2.25-tdm64-1") { source sha256: "4722bb7b4d46cef714234109e25e5d1cfd29f4e53365b6d615c8a00735f60e40" }
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  copy "*", "#{install_dir}/embedded"
 end

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -37,8 +37,8 @@ build do
   # The list of arguments to pass to make
   args = "PREFIX='#{install_dir}/embedded' VERSION='#{version}'"
 
-  patch source: 'makefile_take_env_vars.patch'
-  patch source: 'soname_install_dir.patch' if mac_os_x_mavericks?
+  patch source: 'makefile_take_env_vars.patch', env: env
+  patch source: 'soname_install_dir.patch', env: env if mac_os_x_mavericks?
 
   make "#{args}", env: env
   make "#{args} -f Makefile-libbz2_so", env: env

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -30,7 +30,7 @@ build do
 
   if freebsd?
     # from freebsd ports - IPv6 Hostcheck patch
-    patch source: "curl-freebsd-hostcheck.patch", plevel: 1
+    patch source: "curl-freebsd-hostcheck.patch", plevel: 1, env: env
   end
 
   delete "#{project_dir}/src/tool_hugehelp.c"

--- a/config/software/gd.rb
+++ b/config/software/gd.rb
@@ -33,7 +33,7 @@ build do
     "LIBS" => "-liconv",
   )
 
-  patch source: 'gd-2.0.33-configure-libpng.patch'
+  patch source: 'gd-2.0.33-configure-libpng.patch', env: env
 
   command "./configure" \
           " --prefix=#{install_dir}/embedded" \

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -28,12 +28,12 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if version == "1.8.3"
-    patch source: "v1.8.3-Makefile.in.patch", plevel: 0
+    patch source: "v1.8.3-Makefile.in.patch", plevel: 0, env: env
   end
 
   # Update config.guess to support newer platforms (like aarch64)
   if version == "1.8.3"
-    patch source: "config.guess_2015-09-14.patch", plevel: 0
+    patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
   end
 
   if freebsd?

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -39,7 +39,7 @@ build do
   # d384ce8b3492b9d76af23e621a20bed8da9c6016 of keepalived, (master
   # branch), and should be no longer necessary after 1.2.9.
   if version == "1.2.9"
-    patch source: "keepalived-1.2.9_opscode_centos_5.patch"
+    patch source: "keepalived-1.2.9_opscode_centos_5.patch", env: env
   end
 
   command "./configure" \

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -38,15 +38,15 @@ build do
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
   if freebsd? || openbsd?
-    patch source: "freebsd-vi-fix.patch"
+    patch source: "freebsd-vi-fix.patch", env: env
   end
 
   if openbsd?
-    patch source: "openbsd-weak-alias-fix.patch", plevel: 1
+    patch source: "openbsd-weak-alias-fix.patch", plevel: 1, env: env
   end
 
   if version == "20120601-3.0" && ppc64le?
-    patch source: "v20120601-3.0.ppc64le-configure.patch"
+    patch source: "v20120601-3.0.ppc64le-configure.patch", env: env
   end
 
   command "./configure" \

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -45,7 +45,7 @@ build do
     # Patch to disable multi-os-directory via configure flag (don't use /lib64)
     # Works on all platforms, and is compatible on 32bit platforms as well
     if version == "3.2.1"
-      patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1
+      patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1, env: env
       configure_command << "--disable-multi-os-directory"
     end
   end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,13 @@ name "libffi"
 
 default_version "3.2.1"
 
-dependency "libtool"
+if windows?
+  dependency "patch"
+  dependency "mingw"
+else
+  # Is libtool actually necessary? Doesn't configure generate one?
+  dependency "libtool" unless windows?
+end
 
 version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
 version("3.2.1")  { source md5: "83b89587607e3eb65c70d361f13bab43" }
@@ -32,10 +38,7 @@ build do
 
   env['INSTALL'] = "/opt/freeware/bin/install" if aix?
 
-  configure_command = [
-    "./configure",
-    "--prefix=#{install_dir}/embedded",
-  ]
+  configure_command = []
 
   # AIX's old version of patch doesn't like the patch here
   unless aix?
@@ -47,7 +50,7 @@ build do
     end
   end
 
-  command configure_command.join(" "), env: env
+  configure(*configure_command, env: env)
 
   if solaris2?
     # run old make :(

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -23,7 +23,7 @@ if windows?
   dependency "mingw"
 else
   # Is libtool actually necessary? Doesn't configure generate one?
-  dependency "libtool" unless windows?
+  dependency "libtool"
 end
 
 version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
@@ -34,7 +34,7 @@ source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
 relative_path "libffi-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
   env['INSTALL'] = "/opt/freeware/bin/install" if aix?
 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -40,18 +40,18 @@ build do
     patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
     patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: patch_env
   else
-    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
+    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: env
   end
 
   if version == "1.14" && ppc64le?
-    patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1
+    patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1, env: env
   end
 
   # AIX's old version of patch doesn't like the config.guess patch here
   unless aix?
     # Update config.guess to support newer platforms (like aarch64)
     if version == "1.14"
-      patch source: "config.guess_2015-09-14.patch", plevel: 0
+      patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
     end
   end
 

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -33,7 +33,7 @@ build do
   unless aix?
     # Update config.guess to support newer platforms (like aarch64)
     if version == "2.4"
-      patch source: "config.guess_2015-09-14.patch", plevel: 0
+      patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
     end
   end
 

--- a/config/software/libwrap.rb
+++ b/config/software/libwrap.rb
@@ -45,9 +45,9 @@ build do
     "STYLE"   => "-DPROCESS_OPTIONS",
   )
 
-  patch source: "tcp_wrappers-7.6-shared_lib_plus_plus-1.patch"
-  patch source: "tcp_wrappers-7.6-malloc-fix.patch"
-  patch source: "tcp_wrappers-7.6-makefile-dest-fix.patch"
+  patch source: "tcp_wrappers-7.6-shared_lib_plus_plus-1.patch", env: env
+  patch source: "tcp_wrappers-7.6-malloc-fix.patch", env: env
+  patch source: "tcp_wrappers-7.6-makefile-dest-fix.patch", env: env
 
   make "linux", env: env
   make "install-lib", env: env

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@
 name "libyaml"
 default_version '0.1.6'
 
+if windows?
+  dependency "mingw"
+  dependency "patch"
+end
+
 source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
        md5: '5fe00cda18ca5daeb43762b80c38e06e'
 
@@ -29,7 +34,13 @@ build do
     patch source: "v0.1.6.ppc64le-configure.patch", plevel: 1
   end
 
-  command "./configure --prefix=#{install_dir}/embedded --enable-shared", env: env
+  configure "--enable-shared", env: env
+
+  # Windows had worse automake/libtool version issues.
+  # Just patch the output instead.
+  if version == "0.1.6" && windows?
+    patch source: "v0.1.6.windows-configure.patch", plevel: 1
+  end
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -31,7 +31,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
   if version == "0.1.6" && ppc64le?
-    patch source: "v0.1.6.ppc64le-configure.patch", plevel: 1
+    patch source: "v0.1.6.ppc64le-configure.patch", plevel: 1, env: env
   end
 
   configure "--enable-shared", env: env
@@ -39,7 +39,7 @@ build do
   # Windows had worse automake/libtool version issues.
   # Just patch the output instead.
   if version == "0.1.6" && windows?
-    patch source: "v0.1.6.windows-configure.patch", plevel: 1
+    patch source: "v0.1.6.windows-configure.patch", plevel: 1, env: env
   end
 
   make "-j #{workers}", env: env

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -28,7 +28,7 @@ source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
 relative_path "yaml-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
   if version == "0.1.6" && ppc64le?
     patch source: "v0.1.6.ppc64le-configure.patch", plevel: 1

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -46,7 +46,7 @@ build do
   # long long and c++ in pedantic mode
   # This patch is specific to zeromq4
   if version.satisfies?('>= 4')
-    patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch" if el?
+    patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch", env: env if el?
   end
 
   command "./autogen.sh", env: env

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -35,7 +35,7 @@ build do
   env["EXTRA_LDFLAGS"] = env["LDFLAGS"]
   env["EXTRA_CFLAGS"]  = env["CFLAGS"]
 
-  patch source: "logrotate_basedir_override.patch", plevel: 0
+  patch source: "logrotate_basedir_override.patch", plevel: 0, env: env
 
   make "-j #{workers}", env: env
 

--- a/config/software/mingw-get.rb
+++ b/config/software/mingw-get.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name "mingw-get"
+default_version "0.6.2-beta-20131004-1"
 
-relative_path "expat-2.1.0"
-
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+version("0.6.2-beta-20131004-1") do
+  source url: "http://iweb.dl.sourceforge.net/project/mingw/Installer/mingw-get/mingw-get-0.6.2-beta-20131004-1/mingw-get-0.6.2-mingw32-beta-20131004-1-bin.zip",
+         sha256: "2e0e9688d42adc68c5611759947e064156e169ff871816cae52d33ee0655826d"
+end
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  copy "*", "#{install_dir}/embedded"
 end

--- a/config/software/mingw-runtime.rb
+++ b/config/software/mingw-runtime.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name "mingw-runtime"
+default_version "v4-git20150618-gcc5-tdm64-1"
 
-relative_path "expat-2.1.0"
+dependency "msys-base"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-#{version}.tar.lzma"
+
+version("v4-git20150618-gcc5-tdm64-1") { source sha256: "29186e0bb36824b10026d78bdcf238d631d8fc1d90718d2ebbd9ec239b6f94dd" }
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  copy "*", "#{install_dir}/embedded"
 end

--- a/config/software/mingw.rb
+++ b/config/software/mingw.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,17 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name "mingw"
+default_version "5.1.0-tdm64-1"
 
-relative_path "expat-2.1.0"
+dependency "msys-base"
+dependency "binutils"
+dependency "mingw-runtime"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/#{version}/gcc-#{version}-core.tar.lzma"
+
+version("5.1.0-tdm64-1") { source sha256: "29393aac890847089ad1e93f81a28f6744b1609c00b25afca818f3903e42e4bd" }
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  copy "*", "#{install_dir}/embedded"
 end

--- a/config/software/msys-base.rb
+++ b/config/software/msys-base.rb
@@ -23,5 +23,5 @@ env = with_standard_compiler_flags(with_embedded_path)
 
 build do
   command "mingw-get.exe -v install msys-base=#{version}-msys-bin.meta",
-    env: env, cwd: "#{install_dir}/embedded"
+          env: env, cwd: "#{install_dir}/embedded"
 end

--- a/config/software/msys-base.rb
+++ b/config/software/msys-base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name "msys-base"
+default_version "2013072300"
 
-relative_path "expat-2.1.0"
+dependency "mingw-get"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+env = with_standard_compiler_flags(with_embedded_path)
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  command "mingw-get.exe -v install msys-base=#{version}-msys-bin.meta",
+    env: env, cwd: "#{install_dir}/embedded"
 end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -51,27 +51,27 @@ build do
     # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0
     # compatibility:
     # http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/devel/ncurses/patches/
-    patch source: "patch-aa", plevel: 0
-    patch source: "patch-ab", plevel: 0
-    patch source: "patch-ac", plevel: 0
-    patch source: "patch-ad", plevel: 0
-    patch source: "patch-cxx_cursesf.h", plevel: 0
-    patch source: "patch-cxx_cursesm.h", plevel: 0
+    patch source: "patch-aa", plevel: 0, env: env
+    patch source: "patch-ab", plevel: 0, env: env
+    patch source: "patch-ac", plevel: 0, env: env
+    patch source: "patch-ad", plevel: 0, env: env
+    patch source: "patch-cxx_cursesf.h", plevel: 0, env: env
+    patch source: "patch-cxx_cursesm.h", plevel: 0, env: env
 
     # Opscode patches - <someara@opscode.com>
     # The configure script from the pristine tarball detects xopen_source_extended incorrectly.
     # Manually working around a false positive.
-    patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0
+    patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0, env: env
   end
 
   # AIX's old version of patch doesn't like the patches here
   unless aix?
     if version == "5.9"
       # Update config.guess to support platforms made after 2010 (like aarch64)
-      patch source: "config_guess_2015-09-24.patch", plevel: 0
+      patch source: "config_guess_2015-09-24.patch", plevel: 0, env: env
 
       # Patch to add support for GCC 5, doesn't break previous versions
-      patch source: "ncurses-5.9-gcc-5.patch", plevel: 1
+      patch source: "ncurses-5.9-gcc-5.patch", plevel: 1, env: env
     end
   end
 
@@ -85,11 +85,11 @@ build do
     # Patches ncurses for clang compiler. Changes have been accepted into
     # upstream, but occurred shortly after the 5.9 release. We should be able
     # to remove this after upgrading to any release created after June 2012
-    patch source: "ncurses-clang.patch"
+    patch source: "ncurses-clang.patch", env: env
   end
 
   if openbsd?
-    patch source: "patch-ncurses_tinfo_lib__baudrate.c", plevel: 0
+    patch source: "patch-ncurses_tinfo_lib__baudrate.c", plevel: 0, env: env
   end
 
   configure_command = [

--- a/config/software/nrpe.rb
+++ b/config/software/nrpe.rb
@@ -34,7 +34,8 @@ build do
   command "sed -i 's:\\r::g' ./src/nrpe.c"
 
   patch source: "fix_for_runit.patch",
-        target: "./src/nrpe.c"
+        target: "./src/nrpe.c",
+        env: env
 
   # Configure it
   command "./configure" \

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -15,15 +15,25 @@
 #
 
 name "openssl-fips"
-default_version "2.0.9"
+default_version "2.0.10"
+
+if windows?
+  dependency "patch"
+  dependency "mingw"
+  dependency "perl"
+end
 
 version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
+version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
 
-source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz"
+# HAHAHA According to the FIPS manual, you need to "securely" fetch the source
+# such as asking some humans to mail you a CD-ROM or something.
+# You are then supposed to manually verify the PGP signatures.
+# When making an "official" build - make sure you go do that...
+source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
 
 relative_path "openssl-fips-#{version}"
 
-#env = with_standard_compiler_flags(with_embedded_path)
 
 build do
   # According to the FIPS manual, this is the only environment you are allowed
@@ -31,9 +41,33 @@ build do
   env = {}
   env['FIPSDIR'] = "#{install_dir}/embedded"
 
-  configure_command = ["./config"]
 
-  command configure_command.join(" "), env: env
+  if windows?
+    # The cross-toolchain we have won't work out of the box on windows for 32-bit.
+    # This sucks.  Maybe eventually we'll use Visual Studio?
+    env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
+
+    if windows_arch_i386?
+      # Patch Makefile.shared to let us set the bit-ness of the resource compiler.
+      patch source: "openssl-fips-take-windres-rcflags.patch", env: env
+      # Patch Makefile.org to update the compiler flags/options table for mingw.
+      patch source: "openssl-fips-fix-compiler-flags-table-for-msys.patch", env: env
+      # Patch Configure to call ar.exe without anooying it.
+      patch source: "openssl-fips-ar-needs-operation-before-target.patch", env: env
+
+      platform = "mingw"
+    else
+      platform = "mingw64"
+    end
+
+    configure_command = ["perl.exe ./Configure #{platform}"]
+    configure_command << "--prefix=#{install_dir}/embedded"
+  else
+    configure_command = ["./config"]
+  end
+
+  command configure_command.join(" "), env: env, in_msys_bash: true
+
   make env: env
   make "install", env: env
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@ fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) 
 
 dependency "zlib"
 dependency "cacerts"
-dependency "makedepend" unless aix?
-dependency "patch" if solaris2?
+dependency "makedepend" unless aix? || windows?
+dependency "patch" if solaris2? || windows?
+dependency "mingw" if windows?
 dependency "openssl-fips" if fips_enabled
 
 default_version "1.0.1q"
@@ -36,51 +37,12 @@ relative_path "openssl-#{version}"
 
 build do
 
-  env = if freebsd?
-          freebsd_flags = {
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
-            "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-          }
-          # Clang became the default compiler in FreeBSD 10+
-          if ohai['os_version'].to_i >= 1000024
-            freebsd_flags.merge!(
-              "CC" => "clang",
-              "CXX" => "clang++",
-            )
-          end
-          freebsd_flags
-        elsif mac_os_x?
-          {
-            "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
-            "LDFLAGS" => "-arch x86_64 -R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
-          }
-        elsif aix?
-          {
-            "CC" => "xlc -q64",
-            "CXX" => "xlC -q64",
-            "LD" => "ld -b64",
-            "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
-            "CXXFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
-            "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
-            "OBJECT_MODE" => "64",
-            "AR" => "/usr/bin/ar",
-            "ARFLAGS" => "-X64 cru",
-            "M4" => "/opt/freeware/bin/m4",
-          }
-        elsif solaris2?
-          {
-            "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-            "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
-            "LD_OPTIONS" => "-R#{install_dir}/embedded/lib",
-          }
-        else
-          {
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-          }
-        end
+  env = with_standard_compiler_flags(with_embedded_path)
+  if ohai["platform"] == "aix"
+    env["M4"] = "/opt/freeware/bin/m4"
+  end
 
-  common_args = [
+  configure_args = [
     "--prefix=#{install_dir}/embedded",
     "--with-zlib-lib=#{install_dir}/embedded/lib",
     "--with-zlib-include=#{install_dir}/embedded/include",
@@ -89,74 +51,46 @@ build do
     "no-rc5",
     "zlib",
     "shared",
-  ].join(" ")
+    env['LDFLAGS'],
+    env['CFLAGS'],
+  ]
 
   if fips_enabled
-    common_args = [
-      common_args,
-      "--with-fipsdir=#{install_dir}/embedded",
-      "fips",
-    ].join(" ")
+    configure_args << "--with-fipsdir=#{install_dir}/embedded" << "fips"
   end
 
-  configure_command = if aix?
-                        ["perl", "./Configure",
-                         "aix64-cc",
-                         common_args,
-                        "-L#{install_dir}/embedded/lib",
-                        "-I#{install_dir}/embedded/include",
-                        "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib"].join(" ")
-                      elsif mac_os_x?
-                        ["./Configure",
-                         "darwin64-x86_64-cc",
-                         common_args,
-                        ].join(" ")
-                      elsif smartos?
-                        ["/bin/bash ./Configure",
-                         "solaris64-x86_64-gcc",
-                         common_args,
-                         "-L#{install_dir}/embedded/lib",
-                         "-I#{install_dir}/embedded/include",
-                         "-R#{install_dir}/embedded/lib",
-                        "-static-libgcc"].join(" ")
-                      elsif solaris2?
-                        if sparc?
-                          ["/bin/sh ./Configure",
-                           "solaris-sparcv9-gcc",
-                           common_args,
-                          "-L#{install_dir}/embedded/lib",
-                          "-I#{install_dir}/embedded/include",
-                          "-R#{install_dir}/embedded/lib",
-                          "-static-libgcc"].join(" ")
-                        else
-                          # This should not require a /bin/sh, but without it we get
-                          # Errno::ENOEXEC: Exec format error
-                          ["/bin/sh ./Configure",
-                           "solaris-x86-gcc",
-                           common_args,
-                          "-L#{install_dir}/embedded/lib",
-                          "-I#{install_dir}/embedded/include",
-                          "-R#{install_dir}/embedded/lib",
-                          "-static-libgcc"].join(" ")
-                        end
-                      else
-                        config = if linux? && ppc64?
-                                   "./Configure linux-ppc64"
-                                 elsif linux? && ohai["kernel"]["machine"] == "s390x"
-                                   "./Configure linux64-s390x"
-                                 else
-                                   "./config"
-                                 end
-                        [config,
-                        common_args,
-                        "disable-gost",  # fixes build on linux, but breaks solaris
-                        "-L#{install_dir}/embedded/lib",
-                        "-I#{install_dir}/embedded/include",
-                        "-Wl,-rpath,#{install_dir}/embedded/lib"].join(" ")
-                      end
-
-  # openssl build process uses a `makedepend` tool that we build inside the bundle.
-  env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+  configure_cmd =
+    case ohai["platform"]
+    when "aix"
+      "perl ./Configure aix64-cc"
+    when "mac_os_x"
+      "./Configure darwin64-x86_64-cc"
+    when "smartos"
+      "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
+    when "solaris2"
+      # This should not require a /bin/sh, but without it we get
+      # Errno::ENOEXEC: Exec format error
+      platform =
+        if ohai["kernel"]["machine"] =~ /sun/
+          "solaris-sparcv9-gcc"
+        else
+          "solaris-x86-gcc"
+        end
+      "/bin/sh ./Configure #{platform}"
+    when "windows"
+      platform = windows_arch_i386? ? "mingw" : "mingw64"
+      "perl.exe ./Configure #{platform}"
+    else
+      prefix =
+        if ohai["os"] == "linux" && ohai["kernel"]["machine"] == "ppc64"
+          "./Configure linux-ppc64"
+        elsif ohai["os"] == "linux" && ohai["kernel"]["machine"] == "s390x"
+          "./Configure linux64-s390x"
+        else
+          "./config"
+        end
+      "#{prefix} disable-gost"
+    end
 
   if aix?
 
@@ -168,8 +102,10 @@ build do
     patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
   else
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch"
+    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
   end
+
+  configure_command = configure_args.unshift(configure_cmd).join(" ")
 
   command configure_command, env: env
   make "depend", env: env

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -43,6 +43,9 @@ build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
+  elsif freebsd?
+    # Should this just be in standard_compiler_flags?
+    env['LDFLAGS'] += " -Wl,-rpath,#{install_dir}/embedded/lib"
   end
 
   configure_args = [
@@ -53,8 +56,6 @@ build do
     "no-mdc2",
     "no-rc5",
     "shared",
-    env['LDFLAGS'],
-    env['CFLAGS'],
   ]
 
   if fips_enabled
@@ -115,6 +116,10 @@ build do
     # Patch Configure to call ar.exe without anooying it.
     patch source: "openssl-1.0.1q-ar-needs-operation-before-target.patch", env: env
   end
+
+  # Out of abundance of caution, we put the feature flags first and then
+  # the crazy platform specific compiler flags at the end.
+  configure_args << env['CFLAGS'] << env['LDFLAGS']
 
   configure_command = configure_args.unshift(configure_cmd).join(" ")
 

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -31,7 +31,7 @@ env = with_standard_compiler_flags(with_embedded_path)
 build do
   if windows?
     command "mingw-get.exe -v install msys-patch-bin=#{version}-*",
-      env: env, cwd: "#{install_dir}/embedded"
+            env: env, cwd: "#{install_dir}/embedded"
   else
     configure "--disable-xattr", env: env
     make "-j #{workers}", env: env

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,22 +15,26 @@
 #
 
 name "patch"
-default_version "2.7"
 
-version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
-
-source url: "http://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
-
-relative_path "patch-#{version}"
+if windows?
+  default_version "2.6.1"
+  dependency "mingw-get"
+else
+  default_version "2.7"
+  version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
+  source url: "http://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
+  relative_path "patch-#{version}"
+end
 
 env = with_standard_compiler_flags(with_embedded_path)
 
 build do
-  configure_command = ["./configure",
-                       "--prefix=#{install_dir}/embedded",
-                       "--disable-xattr"]
-
-  command configure_command.join(" "), env: env
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  if windows?
+    command "mingw-get.exe -v install msys-patch-bin=#{version}-*",
+      env: env, cwd: "#{install_dir}/embedded"
+  else
+    configure "--disable-xattr", env: env
+    make "-j #{workers}", env: env
+    make "-j #{workers} install", env: env
+  end
 end

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -23,7 +23,7 @@ else
   default_version "5.18.1"
 
   source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz",
-        md5: "304cb5bd18e48c44edd6053337d3386d"
+         md5: "304cb5bd18e48c44edd6053337d3386d"
   relative_path "perl-#{version}"
 end
 
@@ -32,7 +32,7 @@ build do
 
   if windows?
     command "mingw-get.exe -v install msys-perl-bin=#{version}-*",
-      env: env, cwd: "#{install_dir}/embedded"
+            env: env, cwd: "#{install_dir}/embedded"
   else
     solaris_mapfile_path = File.expand_path(Omnibus::Config.solaris_linker_mapfile, Omnibus::Config.project_root)
     if solaris2? && File.exist?(solaris_mapfile_path)

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -15,48 +15,58 @@
 #
 
 name "perl"
-default_version "5.18.1"
 
-source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz",
-       md5: "304cb5bd18e48c44edd6053337d3386d"
+if windows?
+  default_version "5.8.8"
+  dependency "mingw-get"
+else
+  default_version "5.18.1"
 
-relative_path "perl-#{version}"
+  source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz",
+        md5: "304cb5bd18e48c44edd6053337d3386d"
+  relative_path "perl-#{version}"
+end
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  solaris_mapfile_path = File.expand_path(Omnibus::Config.solaris_linker_mapfile, Omnibus::Config.project_root)
-  if solaris2? && File.exist?(solaris_mapfile_path)
-    cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}"
-  elsif aix?
-    cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"
-  elsif freebsd? && ohai['os_version'].to_i >= 1000024
-    cc_command = "-Dcc='clang'"
+  if windows?
+    command "mingw-get.exe -v install msys-perl-bin=#{version}-*",
+      env: env, cwd: "#{install_dir}/embedded"
   else
-    cc_command = "-Dcc='gcc -static-libgcc'"
+    solaris_mapfile_path = File.expand_path(Omnibus::Config.solaris_linker_mapfile, Omnibus::Config.project_root)
+    if solaris2? && File.exist?(solaris_mapfile_path)
+      cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}"
+    elsif aix?
+      cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"
+    elsif freebsd? && ohai['os_version'].to_i >= 1000024
+      cc_command = "-Dcc='clang'"
+    else
+      cc_command = "-Dcc='gcc -static-libgcc'"
+    end
+
+    configure_command = ["sh Configure",
+                        " -de",
+                        " -Dprefix=#{install_dir}/embedded",
+                        " -Duseshrplib",
+                        " -Dusethreads",
+                        " #{cc_command}",
+                        " -Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"]
+
+    if aix?
+      configure_command << "-Dmake=gmake"
+      configure_command << "-Duse64bitall"
+    end
+
+    # On Cisco IOS-XR, we don't want libssp as a dependency
+    if ios_xr?
+      configure_command << "-Accflags=-fno-stack-protector"
+    end
+
+    command configure_command.join(" "), env: env
+    make "-j #{workers}", env: env
+    # using the install.perl target lets
+    # us skip install the manpages
+    make "install.perl", env: env
   end
-
-  configure_command = ["sh Configure",
-                       " -de",
-                       " -Dprefix=#{install_dir}/embedded",
-                       " -Duseshrplib",
-                       " -Dusethreads",
-                       " #{cc_command}",
-                       " -Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"]
-
-  if aix?
-    configure_command << "-Dmake=gmake"
-    configure_command << "-Duse64bitall"
-  end
-
-  # On Cisco IOS-XR, we don't want libssp as a dependency
-  if ios_xr?
-    configure_command << "-Accflags=-fno-stack-protector"
-  end
-
-  command configure_command.join(" "), env: env
-  make "-j #{workers}", env: env
-  # using the install.perl target lets
-  # us skip install the manpages
-  make "install.perl", env: env
 end

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -31,13 +31,13 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if version == "0.28" && ppc64le?
-    patch source: "v0.28.ppc64le-configure.patch", plevel: 1
+    patch source: "v0.28.ppc64le-configure.patch", plevel: 1, env: env
   end
 
   # pkg-config (at least up to 0.28) includes an older version of
   # libcharset/lib/config.charset that doesn't know about openbsd
   if openbsd?
-    patch source: "openbsd-charset.patch", plevel: 1
+    patch source: "openbsd-charset.patch", plevel: 1, env: env
   end
 
   command "./configure" \

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -102,25 +102,25 @@ else  # including linux
 end
 
 build do
+  # AIX needs /opt/freeware/bin only for patch
+  patch_env = env.dup
+  patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
+
   if solaris2? && version.satisfies?('>= 2.1')
-    patch source: "ruby-no-stack-protector.patch", plevel: 1
+    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
     if platform_version.satisfies?('>= 5.11')
-      patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
+      patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1, env: patch_env
     end
   elsif solaris2? && version =~ /^1.9/
-    patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1
+    patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1, env: patch_env
   end
 
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.
   if ios_xr? && version.satisfies?('>= 2.1')
-    patch source: "ruby-no-stack-protector.patch", plevel: 1
+    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
   end
-
-  # AIX needs /opt/freeware/bin only for patch
-  patch_env = env.dup
-  patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
 
   # disable libpath in mkmf across all platforms, it trolls omnibus and
   # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
@@ -183,13 +183,13 @@ build do
   elsif smartos?
     # Opscode patch - someara@opscode.com
     # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
-    patch source: "ruby-openssl-1.0.1c.patch", plevel: 1
+    patch source: "ruby-openssl-1.0.1c.patch", plevel: 1, env: patch_env
 
     # Patches taken from RVM.
     # http://bugs.ruby-lang.org/issues/5384
     # https://www.illumos.org/issues/1587
     # https://github.com/wayneeseguin/rvm/issues/719
-    patch source: "rvm-cflags.patch", plevel: 1
+    patch source: "rvm-cflags.patch", plevel: 1, env: patch_env
 
     # From RVM forum
     # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -33,7 +33,7 @@ relative_path "zlib-#{version}"
 
 build do
   if windows?
-    env = with_standard_compiler_flags(with_embedded_path)
+    env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
     # We can't use the top-level Makefile. Instead, the developers have made
     # an organic, artisanal, hand-crafted Makefile.gcc for us which takes a few
     # variables.

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 name "zlib"
 default_version "1.2.8"
 
+dependency "mingw" if windows?
+
 version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"
 end
@@ -25,28 +27,50 @@ version "1.2.8" do
   source md5: "44d667c142d7cda120332623eab69f40"
 end
 
-source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
+source url: "http://iweb.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
 
 relative_path "zlib-#{version}"
 
 build do
-  # We omit the omnibus path here because it breaks mac_os_x builds by picking
-  # up the embedded libtool instead of the system libtool which the zlib
-  # configure script cannot handle.
-  env = with_standard_compiler_flags
+  if windows?
+    env = with_standard_compiler_flags(with_embedded_path)
+    # We can't use the top-level Makefile. Instead, the developers have made
+    # an organic, artisanal, hand-crafted Makefile.gcc for us which takes a few
+    # variables.
+    env['BINARY_PATH'] = "/bin"
+    env['LIBRARY_PATH'] = "/lib"
+    env['INCLUDE_PATH'] = "/include"
+    env['DESTDIR'] = "#{install_dir}/embedded"
 
-  if solaris?
-    # For some reason zlib needs this flag on solaris (cargocult warning?)
-    env['CFLAGS'] << " -DNO_VIZ" if solaris2?
-  elsif freebsd?
-    # FreeBSD 10+ gets cranky if zlib is not compiled in a
-    # position-independent way.
-    env['CFLAGS'] << " -fPIC"
+    make_args = [
+      "-fwin32/Makefile.gcc",
+      "SHARED_MODE=1",
+      "ARFLAGS='rcs #{env['ARFLAGS']}'",
+      "RCFLAGS='--define GCC_WINDRES #{env['RCFLAGS']}'",
+    ]
+    arch = windows_arch_i386? ? "-m32" : "-m64"
+    make_args << "LOC=\"#{arch}\""
+
+    make(*make_args, env: env)
+    make("install", *make_args, env: env)
+  else
+    # We omit the omnibus path here because it breaks mac_os_x builds by picking
+    # up the embedded libtool instead of the system libtool which the zlib
+    # configure script cannot handle.
+    # TODO: Do other OSes need this?  Is this strictly a mac thing?
+    env = with_standard_compiler_flags
+    if solaris?
+      # For some reason zlib needs this flag on solaris (cargocult warning?)
+      env['CFLAGS'] << " -DNO_VIZ" if solaris2?
+    elsif freebsd?
+      # FreeBSD 10+ gets cranky if zlib is not compiled in a
+      # position-independent way.
+      env['CFLAGS'] << " -fPIC"
+    end
+
+    configure env: env
+
+    make "-j #{workers}", env: env
+    make "-j #{workers} install", env: env
   end
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
 end


### PR DESCRIPTION
This PR modifies the "ruby.rb" software definition to build ruby on windows.  The output of this software definition is currently not used anywhere in the pipeline and current ruby builds will still continue to use ruby from rubyinstaller for now.

Later changes will modify chef client to pull in said ruby.