### PR TITLE
Add fakeroot for building rpm and deb packages on Linux

### DIFF
--- a/config/patches/fakeroot/eglibc-fts-without-LFS
+++ b/config/patches/fakeroot/eglibc-fts-without-LFS
@@ -1,0 +1,26 @@
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -1949,11 +1949,7 @@
+             || r->fts_info == FTS_NS || r->fts_info == FTS_NSOK))
+     r->fts_statp = NULL;  /* Otherwise fts_statp may be a random pointer */
+   if(r && r->fts_statp) {  /* Should we bother checking fts_info here? */
+-# if defined(STAT64_SUPPORT) && !defined(__APPLE__)
+-    SEND_GET_STAT64(r->fts_statp, _STAT_VER);
+-# else
+     SEND_GET_STAT(r->fts_statp, _STAT_VER);
+-# endif
+   }
+ 
+   return r;
+@@ -1972,11 +1968,7 @@
+   first=next_fts_children(ftsp, options);
+   for(r = first; r; r = r->fts_link) {
+     if(r && r->fts_statp) {  /* Should we bother checking fts_info here? */
+-# if defined(STAT64_SUPPORT) && !defined(__APPLE__)
+-      SEND_GET_STAT64(r->fts_statp, _STAT_VER);
+-# else
+       SEND_GET_STAT(r->fts_statp, _STAT_VER);
+-# endif
+     }
+   }
+ 

--- a/config/patches/fakeroot/glibc-xattr-types
+++ b/config/patches/fakeroot/glibc-xattr-types
@@ -1,0 +1,108 @@
+Fix the type of xattr functions to match the glibc headers.
+
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -1570,7 +1570,7 @@
+ #endif /* HAVE_CAPSET */
+ 
+ #if defined(HAVE_SETXATTR) || defined(HAVE_LSETXATTR) || defined(HAVE_FSETXATTR)
+-static size_t common_setxattr(INT_STRUCT_STAT *st, const char *name, void * value, size_t size, int flags)
++static int common_setxattr(INT_STRUCT_STAT *st, const char *name, const void * value, size_t size, int flags)
+ {
+   xattr_args xattr;
+   xattr.name = name;
+@@ -1625,7 +1625,7 @@
+ #endif /* defined(HAVE_LISTXATTR) || defined(HAVE_LLISTXATTR) || defined(HAVE_FLISTXATTR) */
+ 
+ #if defined(HAVE_REMOVEXATTR) || defined(HAVE_LREMOVEXATTR) || defined(HAVE_FREMOVEXATTR)
+-static size_t common_removexattr(INT_STRUCT_STAT *st, const char *name)
++static int common_removexattr(INT_STRUCT_STAT *st, const char *name)
+ {
+   xattr_args xattr;
+   xattr.name = name;
+@@ -1643,7 +1643,7 @@
+ #endif /* defined(HAVE_REMOVEXATTR) || defined(HAVE_LREMOVEXATTR) || defined(HAVE_FREMOVEXATTR) */
+ 
+ #ifdef HAVE_SETXATTR
+-ssize_t setxattr(const char *path, const char *name, void *value, size_t size, int flags)
++int setxattr(const char *path, const char *name, const void *value, size_t size, int flags)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+@@ -1664,7 +1664,7 @@
+ #endif /* HAVE_SETXATTR */
+ 
+ #ifdef HAVE_LSETXATTR
+-ssize_t lsetxattr(const char *path, const char *name, void *value, size_t size, int flags)
++int lsetxattr(const char *path, const char *name, const void *value, size_t size, int flags)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+@@ -1685,7 +1685,7 @@
+ #endif /* HAVE_LSETXATTR */
+ 
+ #ifdef HAVE_FSETXATTR
+-ssize_t fsetxattr(int fd, const char *name, void *value, size_t size, int flags)
++int fsetxattr(int fd, const char *name, const void *value, size_t size, int flags)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+@@ -1832,7 +1832,7 @@
+ #endif /* HAVE_FLISTXATTR */
+ 
+ #ifdef HAVE_REMOVEXATTR
+-ssize_t removexattr(const char *path, const char *name)
++int removexattr(const char *path, const char *name)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+@@ -1853,7 +1853,7 @@
+ #endif /* HAVE_REMOVEXATTR */
+ 
+ #ifdef HAVE_LREMOVEXATTR
+-ssize_t lremovexattr(const char *path, const char *name)
++int lremovexattr(const char *path, const char *name)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+@@ -1874,7 +1874,7 @@
+ #endif /* HAVE_LREMOVEXATTR */
+ 
+ #ifdef HAVE_FREMOVEXATTR
+-ssize_t fremovexattr(int fd, const char *name)
++int fremovexattr(int fd, const char *name)
+ {
+   INT_STRUCT_STAT st;
+   int r;
+--- a/wrapfunc.inp
++++ b/wrapfunc.inp
+@@ -168,22 +168,22 @@
+ fgetxattr;ssize_t;(int fd, const char *name, void *value, size_t size);(fd, name, value, size)
+ #endif /* HAVE_FGETXATTR */
+ #ifdef HAVE_SETXATTR
+-setxattr;ssize_t;(const char *path, const char *name, void *value, size_t size, int flags);(path, name, value, size, flags)
++setxattr;int;(const char *path, const char *name, const void *value, size_t size, int flags);(path, name, value, size, flags)
+ #endif /* HAVE_SETXATTR */
+ #ifdef HAVE_LSETXATTR
+-lsetxattr;ssize_t;(const char *path, const char *name, void *value, size_t size, int flags);(path, name, value, size, flags)
++lsetxattr;int;(const char *path, const char *name, const void *value, size_t size, int flags);(path, name, value, size, flags)
+ #endif /* HAVE_LSETXATTR */
+ #ifdef HAVE_FSETXATTR
+-fsetxattr;ssize_t;(int fd, const char *name, void *value, size_t size, int flags);(fd, name, value, size, flags)
++fsetxattr;int;(int fd, const char *name, const void *value, size_t size, int flags);(fd, name, value, size, flags)
+ #endif /* HAVE_FSETXATTR */
+ #ifdef HAVE_REMOVEXATTR
+-removexattr;ssize_t;(const char *path, const char *name);(path, name)
++removexattr;int;(const char *path, const char *name);(path, name)
+ #endif /* HAVE_REMOVEXATTR */
+ #ifdef HAVE_LREMOVEXATTR
+-lremovexattr;ssize_t;(const char *path, const char *name);(path, name)
++lremovexattr;int;(const char *path, const char *name);(path, name)
+ #endif /* HAVE_LREMOVEXATTR */
+ #ifdef HAVE_FREMOVEXATTR
+-fremovexattr;ssize_t;(int fd, const char *name);(fd, name)
++fremovexattr;int;(int fd, const char *name);(fd, name)
+ #endif /* HAVE_FREMOVEXATTR */
+ 
+ #ifdef HAVE_FSTATAT
+

--- a/config/software/fakeroot.rb
+++ b/config/software/fakeroot.rb
@@ -28,6 +28,12 @@ relative_path "fakeroot-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Patches for debain based platforms
+  if ohai['platform_family'] == "debian"
+    patch source: "eglibc-fts-without-LFS", plevel: 1
+    patch source: "glibc-xattr-types", plevel: 1
+  end
+
   command "./configure" \
           " --prefix=#{install_dir}/embedded", env: env
 

--- a/config/software/fakeroot.rb
+++ b/config/software/fakeroot.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2013-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "fakeroot"
+default_version "1.20.2"
+
+version "1.20.2" do
+  source md5: "a4b4564a75024aa96c86e4d1017ac786"
+end
+
+source url: "http://http.debian.net/debian/pool/main/f/fakeroot/fakeroot_#{version}.orig.tar.bz2"
+
+relative_path "fakeroot-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+end


### PR DESCRIPTION
Fakeroot is provided by the debian (and derivative projects) build-essentials metapackage, but it does not exist in Fedora/RHEL land by default in all releases (Centos/RHEL 6 has it, 7 does not). The omnibus packaging code requires the use of fakeroot for RPM and DEB packages on the Linux platform. There is a Fakeroot available in EPEL, but not for all platforms we (will soon) support. This just adds the ability to build fakeroot as part of omnibus-toolchain for future platforms that are Linux based. Forthcoming PR for omnibus-toolchain will xref this. This defintion was tested on Centos 6,7, Debian 8, OpenSUSE 12, and Ubuntu 14.04. Requires libattr, libcap, and libacl development package installed on the platform, changes to build-essential cookbook coming in a separate PR for all Linux platforms.