### PR TITLE
Fix reserve stack segmentation fault when building on RHEL5 or below

### DIFF
--- a/config/patches/ruby/ruby-fix-reserve-stack-segfault.patch
+++ b/config/patches/ruby/ruby-fix-reserve-stack-segfault.patch
@@ -1,0 +1,12 @@
+--- a/thread_pthread.c
++++ b/thread_pthread.c
+@@ -686,8 +686,8 @@ reserve_stack(volatile char *limit, size_t size)
+ 	limit -= size;
+ 	if (buf > limit) {
+ 	    limit = alloca(buf - limit);
++	    limit[0] = 0; /* ensure alloca is called */
+ 	    limit -= stack_check_margin;
+-	    limit[0] = 0;
+ 	}
+     }
+ }

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -133,7 +133,7 @@ build do
   # https://redmine.ruby-lang.org/issues/11602
   if ohai['platform_family'] == 'rhel'  &&
      ohai['platform_version'].to_f < 6  &&
-     (version = '2.1.7' || version = '2.2.3')
+     (version == '2.1.7' || version == '2.2.3')
 
      patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -127,6 +127,17 @@ build do
     # be fixed.
   end
 
+  # Fix reserve stack segmentation fault when building on RHEL5 or below
+  # Currently only affects 2.1.7 and 2.2.3. This patch taken from the fix
+  # in Ruby trunk and expected to be included in future point releases.
+  # https://redmine.ruby-lang.org/issues/11602
+  if ohai['platform_family'] == 'rhel'  &&
+     ohai['platform_version'].to_f < 6  &&
+     (version = '2.1.7' || version = '2.2.3')
+
+     patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env
+  end
+
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded",
                        "--with-out-ext=dbm",


### PR DESCRIPTION
Currently only affects 2.1.7 and 2.2.3. This patch taken from the fix
in Ruby trunk and expected to be included in future point releases.

https://redmine.ruby-lang.org/issues/11602