### PR TITLE
Revert libiconv removal from ruby def

### DIFF
--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+# CAUTION - although its not used, external libraries such as nokogiri may pick up an optional dep on
+# libiconv such that removal of libiconv will break those libraries on upgrade.  With an better story around
+# external gem handling when chef-client is upgraded libconv could be dropped.
 name "libiconv"
 default_version "1.14"
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -22,6 +22,7 @@ dependency "ncurses"
 dependency "libedit"
 dependency "openssl"
 dependency "libyaml"
+dependency "libiconv" # Removal will break chef_gem installs of (e.g.) nokogiri on upgrades
 dependency "libffi"
 dependency "patch" if solaris2?
 


### PR DESCRIPTION
Removing libiconv from ruby definition causes certain chef_gems to fail at installation. This adds libiconv back to the ruby def

Reverts part of https://github.com/chef/omnibus-software/commit/f19938167a4cfeea0fce2a377ed4ad5f9fcbe91b
