### PR TITLE
Use IBM makedepend in openssl def on AIX

### DIFF
--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -35,6 +35,10 @@ end
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  if aix?
+    env['AWK'] = '/usr/bin/awk'
+  end
+
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
   if freebsd? || openbsd?

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -149,6 +149,11 @@ build do
   env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
   if aix?
+
+    # This enables omnibus to use 'makedepend'
+    # from fileset 'X11.adt.imake' (AIX install media)
+    env['PATH'] = '/usr/lpp/X11/bin:' + ENV["PATH"]
+
     patch_env = env.dup
     patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env


### PR DESCRIPTION
Otherwise failing pretty spectacularly with:

```
    ../util/domd[30]: makedepend:  not found
mv: cannot rename Makefile.new to Makefile: 
No such file or directory
gmake[1]: *** [local_depend] Error 127
gmake: *** [depend] Error 1
```

/cc @chef/omnibus-maintainers @chef/engineering-services 