### PR TITLE
Get Chef building with latest omnibus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm: 2.1.2
 
 bundler_args: --jobs 7
 
+before_install: gem install bundler
+
 script: bundle exec rake travis:ci
 
 notifications:

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -65,35 +65,18 @@ else
   end
 end
 
-build do
-  env = with_standard_compiler_flags(with_embedded_path)
+relative_path 'bin'
 
+build do
   # Make sure the OpenSSL version is suitable for our path:
   # OpenSSL version is something like
   # OpenSSL 1.0.0k 5 Feb 2013
   ruby "-e \"require 'openssl'; puts 'OpenSSL patch version check expecting <= #{version}'; puts 'Current version : ' + OpenSSL::OPENSSL_VERSION; exit(1) if OpenSSL::OPENSSL_VERSION.split(' ')[1] >= '#{version}'\""
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "openssl-cache")
-
-  if windows_arch_i386?
-    tar_filename = "openssl-#{version}-x86-windows.tar"
-  else
-    tar_filename = "openssl-#{version}-x64-windows.tar"
-  end
-
-  # Ensure the directory exists
-  mkdir tmpdir
-
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{tmpdir} -r -y", env: env
-
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(tmpdir, tar_filename)} -o#{tmpdir} -r -y", env: env
-
   # Copy over the required dlls into embedded/bin
-  copy "#{tmpdir}/bin/libeay32.dll", "#{install_dir}/embedded/bin/"
-  copy "#{tmpdir}/bin/ssleay32.dll", "#{install_dir}/embedded/bin/"
+  copy "libeay32.dll", "#{install_dir}/embedded/bin/"
+  copy "ssleay32.dll", "#{install_dir}/embedded/bin/"
 
   # Also copy over the openssl executable for debugging
-  copy "#{tmpdir}/bin/openssl.exe", "#{install_dir}/embedded/bin/"
+  copy "bin/openssl.exe", "#{install_dir}/embedded/bin/"
 end

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -22,15 +22,11 @@ dependency "ruby-windows-devkit"
 source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
        md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"
 
+relative_path 'bin'
+
 build do
-  temp_directory = File.join(Omnibus::Config.cache_dir, "bash-cache")
-  mkdir temp_directory
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{temp_directory} -r -y"
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(temp_directory, "bash-#{version}-bin.tar")} -o#{temp_directory} -r -y"
   # Copy over the required bins into embedded/bin
   ["bash.exe", "sh.exe"].each do |exe|
-    copy "#{temp_directory}/bin/#{exe}", "#{install_dir}/embedded/bin/#{exe}"
+    copy "#{exe}", "#{install_dir}/embedded/bin/#{exe}"
   end
 end


### PR DESCRIPTION
The latest version of omnibus unpacks `tar.lzma` files automatically. We no longer should be doing it manually. This patch resolves the incompatibilites when building chef client.

Requires https://github.com/chef/omnibus/pull/578

cc @chef/omnibus-maintainers @chefsalim 