### PR TITLE
Fistful of Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm: 2.1.2
 
 bundler_args: --jobs 7
 
+before_install: gem install bundler
+
 script: bundle exec rake travis:ci
 
 notifications:

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -30,7 +30,7 @@
 # series for those rubies.
 
 name "openssl-windows"
-default_version "1.0.1p"
+default_version "1.0.1q"
 
 dependency "ruby-windows"
 
@@ -58,10 +58,20 @@ if windows_arch_i386?
     source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1p/openssl-1.0.1p-x86-windows.tar.lzma",
            md5: "013c0f27c4839c89e33037acc72f17c5"
   end
+
+  version('1.0.1q') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1q/openssl-1.0.1q-x86-windows.tar.lzma",
+           md5: "3970fb1323b89c068525d60211670528"
+  end
 else
   version('1.0.1p') do
     source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1p/openssl-1.0.1p-x64-windows.tar.lzma",
            md5: "ffdcef3e4fd1eca457a2e9a08cdd5aa1"
+  end
+
+  version('1.0.1q') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1q/openssl-1.0.1q-x64-windows.tar.lzma",
+           md5: "c9a05a9dfed1b91674ccfbb0b9e731c9"
   end
 end
 

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -65,35 +65,18 @@ else
   end
 end
 
-build do
-  env = with_standard_compiler_flags(with_embedded_path)
+relative_path 'bin'
 
+build do
   # Make sure the OpenSSL version is suitable for our path:
   # OpenSSL version is something like
   # OpenSSL 1.0.0k 5 Feb 2013
   ruby "-e \"require 'openssl'; puts 'OpenSSL patch version check expecting <= #{version}'; puts 'Current version : ' + OpenSSL::OPENSSL_VERSION; exit(1) if OpenSSL::OPENSSL_VERSION.split(' ')[1] >= '#{version}'\""
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "openssl-cache")
-
-  if windows_arch_i386?
-    tar_filename = "openssl-#{version}-x86-windows.tar"
-  else
-    tar_filename = "openssl-#{version}-x64-windows.tar"
-  end
-
-  # Ensure the directory exists
-  mkdir tmpdir
-
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{tmpdir} -r -y", env: env
-
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(tmpdir, tar_filename)} -o#{tmpdir} -r -y", env: env
-
   # Copy over the required dlls into embedded/bin
-  copy "#{tmpdir}/bin/libeay32.dll", "#{install_dir}/embedded/bin/"
-  copy "#{tmpdir}/bin/ssleay32.dll", "#{install_dir}/embedded/bin/"
+  copy "libeay32.dll", "#{install_dir}/embedded/bin/"
+  copy "ssleay32.dll", "#{install_dir}/embedded/bin/"
 
   # Also copy over the openssl executable for debugging
-  copy "#{tmpdir}/bin/openssl.exe", "#{install_dir}/embedded/bin/"
+  copy "bin/openssl.exe", "#{install_dir}/embedded/bin/"
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -21,12 +21,13 @@ dependency "cacerts"
 dependency "makedepend" unless aix?
 dependency "patch" if solaris2?
 
-default_version "1.0.1p"
+default_version "1.0.1q"
 
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz"
 
 version("1.0.1m") { source md5: "d143d1555d842a069cb7cc34ba745a06" }
 version("1.0.1p") { source md5: "7563e92327199e0067ccd0f79f436976" }
+version("1.0.1q") { source md5: "54538d0cdcb912f9bc2b36268388205e" }
 
 relative_path "openssl-#{version}"
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -150,6 +150,11 @@ build do
   env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
   if aix?
+
+    # This enables omnibus to use 'makedepend'
+    # from fileset 'X11.adt.imake' (AIX install media)
+    env['PATH'] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+
     patch_env = env.dup
     patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -22,15 +22,11 @@ dependency "ruby-windows-devkit"
 source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
        md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"
 
+relative_path 'bin'
+
 build do
-  temp_directory = File.join(Omnibus::Config.cache_dir, "bash-cache")
-  mkdir temp_directory
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{temp_directory} -r -y"
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(temp_directory, "bash-#{version}-bin.tar")} -o#{temp_directory} -r -y"
   # Copy over the required bins into embedded/bin
   ["bash.exe", "sh.exe"].each do |exe|
-    copy "#{temp_directory}/bin/#{exe}", "#{install_dir}/embedded/bin/#{exe}"
+    copy "#{exe}", "#{install_dir}/embedded/bin/#{exe}"
   end
 end


### PR DESCRIPTION
There's a reason I'm likening this to a Spaghetti Western..
- `openssl-windows` 1.0.1p -> 1.0.1q
- use `makedepend` at `/usr/lpp/X11/bin` on AIX
- download and extract .tar.lzma on Windows
- avoid extracting to a temp dir for `ruby-windows-devkit-bash` and `openssl-windows`

This does at least build Angrychef: http://manhattan.ci.chef.co/view/Angrychef/job/angrychef-build/25/
/cc @chef/client-aix @chef/client-core @chef/engineering-services @jaym @chefsalim @scotthain 

*whew*