### PR TITLE
Updating ruby software def to use ios_xr sugar

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -30,7 +30,7 @@ relative_path "libffi-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  env['INSTALL'] = "/opt/freeware/bin/install" if ohai['platform'] == "aix"
+  env['INSTALL'] = "/opt/freeware/bin/install" if aix?
 
   configure_command = [
     "./configure",

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -33,10 +33,9 @@ description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
 default_version "0.0.1"
 
 build do
-  libgcc_file = case ohai['platform']
-                when "solaris2"
+  libgcc_file = if solaris2?
                   "/opt/csw/lib/libgcc_s.so.1"
-                when "freebsd"
+                elsif freebsd?
                   "/lib/libgcc_s.so.1"
                 else
                   nil

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require 'chef/sugar/constraints'
+
 # We use the version in util-linux, and only build the libuuid subdirectory
 name "libzmq"
 default_version "2.1.11"
@@ -45,7 +47,7 @@ build do
   # centos 5 has an old version of gcc (4.2.1) that has trouble with
   # long long and c++ in pedantic mode
   # This patch is specific to zeromq4
-  if version.to_f >= 4
+  if Chef::Sugar::Constraints.version(version).satisfies?('>= 4')
     patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch" if el?
   end
 

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require 'chef/sugar/constraints'
+
 name "openresty"
 default_version "1.9.3.1"
 
@@ -66,9 +68,9 @@ build do
   # OpenResty 1.7 + RHEL5 Fixes:
   # According to https://github.com/openresty/ngx_openresty/issues/85, OpenResty
   # fails to compile on RHEL5 without the "--with-luajit-xcflags='-std=gnu99'" flags
-  if (version.to_f >= 1.7) &&                          # '1.7.7.2'.to_f evaluates to 1.7
-     (ohai['platform_family'] == 'rhel') &&
-     (ohai['platform_version'].to_f < 6.0)
+  if rhel? &&
+     Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('< 6.0') &&
+     Chef::Sugar::Constraints.version(version).satisfies?('>= 1.7')
     configure << "--with-luajit-xcflags='-std=gnu99'"
   end
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -36,8 +36,7 @@ relative_path "openssl-#{version}"
 
 build do
 
-  env = case ohai["platform"]
-        when "freebsd"
+  env = if freebsd?
           freebsd_flags = {
             "CFLAGS" => "-I#{install_dir}/embedded/include",
             "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
@@ -50,13 +49,13 @@ build do
             )
           end
           freebsd_flags
-        when "mac_os_x"
+        elsif mac_os_x?
           {
             "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
             "LDFLAGS" => "-arch x86_64 -R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
           }
-        when "aix"
-        {
+        elsif aix?
+          {
             "CC" => "xlc -q64",
             "CXX" => "xlC -q64",
             "LD" => "ld -b64",
@@ -67,8 +66,8 @@ build do
             "AR" => "/usr/bin/ar",
             "ARFLAGS" => "-X64 cru",
             "M4" => "/opt/freeware/bin/m4",
-        }
-        when "solaris2"
+          }
+        elsif solaris2?
           {
             "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
             "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
@@ -100,20 +99,19 @@ build do
     ].join(" ")
   end
 
-  configure_command = case ohai["platform"]
-                      when "aix"
+  configure_command = if aix?
                         ["perl", "./Configure",
                          "aix64-cc",
                          common_args,
                         "-L#{install_dir}/embedded/lib",
                         "-I#{install_dir}/embedded/include",
                         "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib"].join(" ")
-                      when "mac_os_x"
+                      elsif mac_os_x?
                         ["./Configure",
                          "darwin64-x86_64-cc",
                          common_args,
                         ].join(" ")
-                      when "smartos"
+                      elsif smartos?
                         ["/bin/bash ./Configure",
                          "solaris64-x86_64-gcc",
                          common_args,
@@ -121,8 +119,8 @@ build do
                          "-I#{install_dir}/embedded/include",
                          "-R#{install_dir}/embedded/lib",
                         "-static-libgcc"].join(" ")
-                      when "solaris2"
-                        if ohai["kernel"]["machine"] =~ /sun/
+                      elsif solaris2?
+                        if sparc?
                           ["/bin/sh ./Configure",
                            "solaris-sparcv9-gcc",
                            common_args,
@@ -142,9 +140,9 @@ build do
                           "-static-libgcc"].join(" ")
                         end
                       else
-                        config = if ohai["os"] == "linux" && ohai["kernel"]["machine"] == "ppc64"
+                        config = if linux? && ppc64?
                                    "./Configure linux-ppc64"
-                                 elsif ohai["os"] == "linux" && ohai["kernel"]["machine"] == "s390x"
+                                 elsif linux? && ohai["kernel"]["machine"] == "s390x"
                                    "./Configure linux64-s390x"
                                  else
                                    "./config"

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -50,7 +50,7 @@ build do
   end
 
   # On Cisco IOS-XR, we don't want libssp as a dependency
-  if ohai['platform'] == 'ios_xr'
+  if ios_xr?
     configure_command << "-Accflags=-fno-stack-protector"
   end
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require 'chef/sugar/constraints'
+
 name "ruby"
 default_version "1.9.3-p550"
 
@@ -54,8 +56,7 @@ relative_path "ruby-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)
 
-case ohai['platform']
-when "mac_os_x"
+if mac_os_x?
   # -Qunused-arguments suppresses "argument unused during compilation"
   # warnings. These can be produced if you compile a program that doesn't
   # link to anything in a path given with -Lextra-libs. Normally these
@@ -64,7 +65,7 @@ when "mac_os_x"
   # of the actual exit code from the compiler).
   env['CFLAGS'] << " -I#{install_dir}/embedded/include/ncurses -arch x86_64 -m64 -O3 -g -pipe -Qunused-arguments"
   env['LDFLAGS'] << " -arch x86_64"
-when "freebsd"
+elsif freebsd?
   # Stops "libtinfo.so.5.9: could not read symbols: Bad value" error when
   # compiling ext/readline. See the following for more info:
   #
@@ -72,7 +73,7 @@ when "freebsd"
   #   http://mailing.freebsd.ports-bugs.narkive.com/kCgK8sNQ/ports-183106-patch-sysutils-libcdio-does-not-build-on-10-0-and-head
   #
   env['LDFLAGS'] << " -ltinfow"
-when "aix"
+elsif aix?
   # this magic per IBM
   env['LDSHARED'] = "xlc -G"
   env['CFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
@@ -83,8 +84,8 @@ when "aix"
   env['SOLIBS'] = "-lm -lc"
   # need to use GNU m4, default m4 doesn't work
   env['M4'] = "/opt/freeware/bin/m4"
-when "solaris2"
-  if ohai['kernel']['machine'].include?('sun4')
+elsif solaris2?
+  if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
     env['CFLAGS'] << " -std=c99 -O0 -g -pipe -mcpu=v9"
     env['LDFLAGS'] << " -mcpu=v9"
@@ -96,9 +97,9 @@ else  # including linux
 end
 
 build do
-  if solaris2? && version.to_f >= 2.1
+  if solaris2? && Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
     patch source: "ruby-no-stack-protector.patch", plevel: 1
-    if ohai['platform_version'].to_f >= 5.11
+    if Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('>= 5.11')
       patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
     end
   elsif solaris2? && version =~ /^1.9/
@@ -108,10 +109,7 @@ build do
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.
-  #
-  # This will be changed to use a chef-sugar helper method once
-  # sethvargo/chef-sugar#116 is available in a release.
-  if ohai['platform'] == 'ios_xr' && version.to_f >= 2.1
+  if ios_xr? && Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
     patch source: "ruby-no-stack-protector.patch", plevel: 1
   end
 
@@ -126,7 +124,7 @@ build do
   # other platforms.  generally you need to have a condition where the
   # embedded and non-embedded libs get into a fight (libiconv, openssl, etc)
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
-  if version.to_f >= 2.1
+  if Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
     patch source: "ruby-2_1_3-no-mkmf.patch", plevel: 1, env: patch_env
     # should intentionally break and fail to apply on 2.2, patch will need to
     # be fixed.
@@ -136,8 +134,8 @@ build do
   # Currently only affects 2.1.7 and 2.2.3. This patch taken from the fix
   # in Ruby trunk and expected to be included in future point releases.
   # https://redmine.ruby-lang.org/issues/11602
-  if ohai['platform_family'] == 'rhel'  &&
-     ohai['platform_version'].to_f < 6  &&
+  if rhel? &&
+     Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('< 6') &&
      (version == '2.1.7' || version == '2.2.3')
 
      patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env
@@ -156,8 +154,7 @@ build do
 
   configure_command << "--with-bundled-md5" if fips_enabled
 
-  case ohai['platform']
-  when "aix"
+  if aix?
     # need to patch ruby's configure file so it knows how to find shared libraries
     patch source: "ruby-aix-configure.patch", plevel: 1, env: patch_env
     # have ruby use zlib on AIX correctly
@@ -171,12 +168,12 @@ build do
     # per IBM, just help ruby along on what it's running on
     configure_command << "--host=powerpc-ibm-aix6.1.0.0 --target=powerpc-ibm-aix6.1.0.0 --build=powerpc-ibm-aix6.1.0.0 --enable-pthread"
 
-  when "freebsd"
+  elsif freebsd?
     # Disable optional support C level backtrace support. This requires the
     # optional devel/libexecinfo port to be installed.
     configure_command << "ac_cv_header_execinfo_h=no"
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
-  when "smartos"
+  elsif smartos?
     # Opscode patch - someara@opscode.com
     # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
     patch source: "ruby-openssl-1.0.1c.patch", plevel: 1


### PR DESCRIPTION
When the IOS-XR changes were initially submitted, chef-sugar's
then-current release did not contain the `ios_xr?` helper method.
It now does, so I'm cleaning up my prior mess.

/cc @chef/engineering-services -- this is not an urgent PR :smile: 