### PR TITLE
AIX version of patch doesn't like these patches due to the formatting…

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -37,11 +37,14 @@ build do
     "--prefix=#{install_dir}/embedded",
   ]
 
-  # Patch to disable multi-os-directory via configure flag (don't use /lib64)
-  # Works on all platforms, and is compatible on 32bit platforms as well
-  if version == "3.2.1"
-    patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1
-    configure_command << "--disable-multi-os-directory"
+  # AIX's old version of patch doesn't like the patch here
+  unless aix?
+    # Patch to disable multi-os-directory via configure flag (don't use /lib64)
+    # Works on all platforms, and is compatible on 32bit platforms as well
+    if version == "3.2.1"
+      patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1
+      configure_command << "--disable-multi-os-directory"
+    end
   end
 
   command configure_command.join(" "), env: env

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -44,9 +44,12 @@ build do
     patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1
   end
 
-  # Update config.guess to support newer platforms (like aarch64)
-  if version == "1.14"
-    patch source: "config.guess_2015-09-14.patch", plevel: 0
+  # AIX's old version of patch doesn't like the config.guess patch here
+  unless aix?
+    # Update config.guess to support newer platforms (like aarch64)
+    if version == "1.14"
+      patch source: "config.guess_2015-09-14.patch", plevel: 0
+    end
   end
 
   command configure_command, env: env

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -29,9 +29,12 @@ relative_path "libtool-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # Update config.guess to support newer platforms (like aarch64)
-  if version == "2.4"
-    patch source: "config.guess_2015-09-14.patch", plevel: 0
+  # AIX's old version of patch doesn't like the config.guess patch here
+  unless aix?
+    # Update config.guess to support newer platforms (like aarch64)
+    if version == "2.4"
+      patch source: "config.guess_2015-09-14.patch", plevel: 0
+    end
   end
 
   command "./configure" \

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -64,12 +64,15 @@ build do
     patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0
   end
 
-  if version == "5.9"
-    # Update config.guess to support platforms made after 2010 (like aarch64)
-    patch source: "config_guess_2015-09-24.patch", plevel: 0
+  # AIX's old version of patch doesn't like the patches here
+  unless aix?
+    if version == "5.9"
+      # Update config.guess to support platforms made after 2010 (like aarch64)
+      patch source: "config_guess_2015-09-24.patch", plevel: 0
 
-    # Patch to add support for GCC 5, doesn't break previous versions
-    patch source: "ncurses-5.9-gcc-5.patch", plevel: 1
+      # Patch to add support for GCC 5, doesn't break previous versions
+      patch source: "ncurses-5.9-gcc-5.patch", plevel: 1
+    end
   end
 
   if mac_os_x? ||


### PR DESCRIPTION
…. Since they are additive and not required for AIX, we have explicitly excluded AIX from the clauses. We should go find out what the issue with these patch files is to prevent this in the future

@btm @jaym @chefsalim @ksubrama @edolnx 
@chef/engineering-services 