### PR TITLE
use symlinks or copies for git-* binaries

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -48,11 +48,12 @@ source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 build do
 
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    "NEEDS_LIBICONV"     => "1",
-    "NO_GETTEXT"         => "1",
-    "NO_PYTHON"          => "1",
-    "NO_R_TO_GCC_LINKER" => "1",
-    "NO_TCLTK"           => "1",
+    "NEEDS_LIBICONV"       => "1",
+    "NO_GETTEXT"           => "1",
+    "NO_PYTHON"            => "1",
+    "NO_R_TO_GCC_LINKER"   => "1",
+    "NO_TCLTK"             => "1",
+    "NO_INSTALL_HARDLINKS" => "1",
 
     "CURLDIR"    => "#{install_dir}/embedded",
     "EXPATDIR"   => "#{install_dir}/embedded",
@@ -84,13 +85,10 @@ build do
     configure_command << "--with-curl=#{install_dir}/embedded"
     configure_command << "--with-expat=#{install_dir}/embedded"
     configure_command << "--with-perl=#{install_dir}/embedded/bin/perl"
-  elsif aix?
-    # without this, git produces some nroff files with "::" in the filename
-    # causing the install process to fail with "sysck: 3001-019"
-    configure_command << "--docdir='/dev/null'"
   end
 
   command configure_command.join(" "), env: env
+
   make "-j #{workers}", env: env
   make "install", env: env
 end


### PR DESCRIPTION
With `NO_INSTALL_HARDLINKS` set, projects building git on AIX will only have singular stanzas in the inventory list and not the gargantuan one with all the hard links that seemed to be failing upon install. From the Git Makefile:
```
# Define NO_INSTALL_HARDLINKS if you prefer to use either symbolic links or
# copies to install built-in git commands e.g. git-cat-file.
```

Removed the `--docdir` flag for AIX since this is now fixed via the config/rename script generation.

/cc @chef/engineering-services 