### PR TITLE
Vj/include erlang 18.2

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -68,6 +68,11 @@ version '18.1' do
   relative_path 'otp_src_18.1'
 end
 
+version '18.2' do
+  source md5: 'b336d2a8ccfbe60266f71d102e99f7ed'
+  relative_path 'otp_src_18.2'
+end
+
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
     # WARNING!


### PR DESCRIPTION
Include erlang 18.2. Built omnibus package and confirmed this is working locally.