### PR TITLE
Updating to new version methods which support version constraint checks

### DIFF
--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/sugar/constraints'
-
 # We use the version in util-linux, and only build the libuuid subdirectory
 name "libzmq"
 default_version "2.1.11"
@@ -47,7 +45,7 @@ build do
   # centos 5 has an old version of gcc (4.2.1) that has trouble with
   # long long and c++ in pedantic mode
   # This patch is specific to zeromq4
-  if Chef::Sugar::Constraints.version(version).satisfies?('>= 4')
+  if version.satisfies?('>= 4')
     patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch" if el?
   end
 

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/sugar/constraints'
-
 name "openresty"
 default_version "1.9.3.1"
 
@@ -69,8 +67,8 @@ build do
   # According to https://github.com/openresty/ngx_openresty/issues/85, OpenResty
   # fails to compile on RHEL5 without the "--with-luajit-xcflags='-std=gnu99'" flags
   if rhel? &&
-     Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('< 6.0') &&
-     Chef::Sugar::Constraints.version(version).satisfies?('>= 1.7')
+     platform_version.satisfies?('< 6.0') &&
+     version.satisfies?('>= 1.7')
     configure << "--with-luajit-xcflags='-std=gnu99'"
   end
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/sugar/constraints'
-
 name "ruby"
 default_version "1.9.3-p550"
 
@@ -97,9 +95,9 @@ else  # including linux
 end
 
 build do
-  if solaris2? && Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
+  if solaris2? && version.satisfies?('>= 2.1')
     patch source: "ruby-no-stack-protector.patch", plevel: 1
-    if Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('>= 5.11')
+    if platform_version.satisfies?('>= 5.11')
       patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
     end
   elsif solaris2? && version =~ /^1.9/
@@ -109,7 +107,7 @@ build do
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.
-  if ios_xr? && Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
+  if ios_xr? && version.satisfies?('>= 2.1')
     patch source: "ruby-no-stack-protector.patch", plevel: 1
   end
 
@@ -124,7 +122,7 @@ build do
   # other platforms.  generally you need to have a condition where the
   # embedded and non-embedded libs get into a fight (libiconv, openssl, etc)
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
-  if Chef::Sugar::Constraints.version(version).satisfies?('>= 2.1')
+  if version.satisfies?('>= 2.1')
     patch source: "ruby-2_1_3-no-mkmf.patch", plevel: 1, env: patch_env
     # should intentionally break and fail to apply on 2.2, patch will need to
     # be fixed.
@@ -135,7 +133,7 @@ build do
   # in Ruby trunk and expected to be included in future point releases.
   # https://redmine.ruby-lang.org/issues/11602
   if rhel? &&
-     Chef::Sugar::Constraints.version(ohai['platform_version']).satisfies?('< 6') &&
+     platform_version.satisfies?('< 6') &&
      (version == '2.1.7' || version == '2.2.3')
 
      patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env


### PR DESCRIPTION
**NOTE: DO NOT MERGE** until the following omnibus PR is merged: chef/omnibus#601

Updates to software definitions to use the new `platform_version` helper method in chef-sugar 3.3.0 as well as the newly-extended `version` method in omnibus. Users can now perform gemspec-like version constraint checks vs. using `#to_f` and `#to_i` or calling `Chef::Sugar::Constraints` directly.

/cc @chef/omnibus-maintainers 
