### PR TITLE
Update ruby-windows so DL only updated when it exists

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -64,7 +64,7 @@ build do
     ABI_ver = version[/(^\d+\.\d+)/] + '.0'
     dl_path = File.join(install_dir, "embedded/lib/ruby", ABI_ver, "dl.rb")
 
-    if digest(dl_path) == "78c185a3fcc7b5e2c3db697c85110d8f"
+    if File.exist?(dl_path) && digest(dl_path) == "78c185a3fcc7b5e2c3db697c85110d8f"
       File.open(dl_path, "w") do |f|
         f.print <<-E
   require 'dl.so'


### PR DESCRIPTION
dl.rb no longer exists in Ruby 2.2, so using this causes the ruby-windows software to fail