### PR TITLE
fix solaris and freebsd nokogiri builds

### DIFF
--- a/config/patches/libxslt/libxslt-solaris-configure.patch
+++ b/config/patches/libxslt/libxslt-solaris-configure.patch
@@ -1,0 +1,19 @@
+--- libxslt-1.1.28/configure.in	2016-01-19 13:45:52.000000000 -0800
++++ libxslt-1.1.28/configure	2016-01-19 13:46:11.000000000 -0800
+@@ -12849,11 +12849,11 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking how to pass version script to the linker ($LD)" >&5
+ $as_echo_n "checking how to pass version script to the linker ($LD)... " >&6; }
+ VERSION_SCRIPT_FLAGS=none
+-if $LD --help 2>&1 | grep "version-script" >/dev/null 2>/dev/null; then
+-    VERSION_SCRIPT_FLAGS=-Wl,--version-script=
+-elif $LD --help 2>&1 | grep "M mapfile" >/dev/null 2>/dev/null; then
+-    VERSION_SCRIPT_FLAGS="-Wl,-M -Wl,"
+-fi
++#if $LD --help 2>&1 | grep "version-script" >/dev/null 2>/dev/null; then
++#    VERSION_SCRIPT_FLAGS=-Wl,--version-script=
++#elif $LD --help 2>&1 | grep "M mapfile" >/dev/null 2>/dev/null; then
++#    VERSION_SCRIPT_FLAGS="-Wl,-M -Wl,"
++#fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $VERSION_SCRIPT_FLAGS" >&5
+ $as_echo "$VERSION_SCRIPT_FLAGS" >&6; }
+ 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -30,6 +30,9 @@ relative_path "libiconv-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # freebsd 10 needs to be build PIC
+  env['CFLAGS'] << " -fPIC" if freebsd?
+
   configure_command = "./configure" \
                       " --prefix=#{install_dir}/embedded"
   if aix?

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -32,12 +32,19 @@ relative_path "libxml2-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --with-zlib=#{install_dir}/embedded" \
-          " --with-iconv=#{install_dir}/embedded" \
-          " --without-python" \
-          " --without-icu", env: env
+  configure_command = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    "--with-zlib=#{install_dir}/embedded",
+    "--with-iconv=#{install_dir}/embedded",
+    "--without-python",
+    "--without-icu",
+  ]
+
+  # solaris 10 ipv6 support is broken due to no inet_ntop() in -lnsl
+  configure_command << "--enable-ipv6=no" if solaris2?
+
+  command configure_command.join(" "), env: env
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -20,6 +20,7 @@ default_version "1.1.28"
 dependency "libxml2"
 dependency "libtool" if solaris2?
 dependency "liblzma"
+dependency "patch" if solaris2?
 
 version "1.1.26" do
   source md5: "e61d0364a30146aaa3001296f853b2b9"
@@ -35,6 +36,8 @@ relative_path "libxslt-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
+  patch source: "libxslt-solaris-configure.patch" if solaris?
 
   command "./configure" \
           " --prefix=#{install_dir}/embedded" \


### PR DESCRIPTION
* freebsd 10 64-bit needs -fPIC similar to other defns
* solaris 10 ipv6 support in libxml2 needs to be turned off
  (i believe nobody will miss this and ipv6 support seems to be
  crappy in sol10u1 so solaris users just have issues there)
* we also use linker mapfiles to link like we're sol10u1 and
  libxslt gets in a fight with us that we have to apply a
  patch in order to win.