### PR TITLE
Update cacerts version to 2016.01.20.

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,11 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2015.10.28"
+default_version "2016.01.20"
+
+version "2016.01.20" do
+  source md5: "06629db7f712ff3a75630eccaecc1fe4"
+end
 
 version "2015.10.28" do
   source md5: "6f41fb0f0c4b4695c2a6296892278141"


### PR DESCRIPTION
http://curl.haxx.se/ca/cacert.pem was updated on 20.01.2016.