### PR TITLE
Moving bundler-audit to its own gem group in chef/chef and excluding it from omnibus

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -82,7 +82,7 @@ build do
     end
   end
 
-  excluded_groups = %w{server docgen}
+  excluded_groups = %w{server docgen travis}
   excluded_groups << 'ruby_prof' if aix?
 
   # install the whole bundle first


### PR DESCRIPTION
Bundler-audit depends on Thor which is killing our Solaris builds.

\cc @scotthain @jaym 