### PR TITLE
fix ca-cert md5 and location

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,46 +16,17 @@
 
 name "cacerts"
 
-# Date of the file is in a comment at the start, or in the changelog
-default_version "2015.10.28"
+default_version "2016.01.20"
+
+version "2016.01.20" do
+  source md5: "06629db7f712ff3a75630eccaecc1fe4"
+  FIXME: this is not yet released on github, see https://github.com/bagder/ca-bundle/issues/5
+end
 
 version "2015.10.28" do
   source md5: "6f41fb0f0c4b4695c2a6296892278141"
+  source url: "https://raw.githubusercontent.com/bagder/ca-bundle/86347ecbdc2277f365d02f0d208b822a214e012d/ca-bundle.crt"
 end
-
-version "2015.09.02" do
-  source md5: "3e0e6f302bd4f5b94040b8bcee0ffe15"
-end
-
-version "2015.04.22" do
-  source md5: "380df856e8f789c1af97d0da9a243769"
-end
-
-version "2015.02.25" do
-  source md5: "19e7f27540ee694308729fd677163649"
-end
-
-version "2014.09.03" do
-  source md5: "d7f7dd7e3ede3e323fc0e09381f16caf"
-end
-
-version "2014.08.20" do
-  source md5: "c9f4f7f4d6a5ef6633e893577a09865e"
-end
-
-version "2014.07.15" do
-  source md5: "fd48275847fa10a8007008379ee902f1"
-end
-
-version "2014.04.22" do
-  source md5: "9f92a0d9f605e227ae068e605f4c86fa"
-end
-
-version "2014.01.28" do
-  source md5: "5d108f8ab86afacc6663aafca8604dd3"
-end
-
-source url: "http://curl.haxx.se/ca/cacert.pem"
 
 relative_path "cacerts-#{version}"
 
@@ -64,12 +35,12 @@ build do
 
   # Append the 1024bit Verisign certs so that S3 continues to work
   block do
-    unless File.foreach("#{project_dir}/cacert.pem").grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
-      File.open("#{project_dir}/cacert.pem", "a") { |fd| fd.write(VERISIGN_CERTS) }
+    unless File.foreach("#{project_dir}/ca-bundle.crt").grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
+      File.open("#{project_dir}/ca-bundle.crt", "a") { |fd| fd.write(VERISIGN_CERTS) }
     end
   end
 
-  copy "#{project_dir}/cacert.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
+  copy "#{project_dir}/ca-bundle.crt", "#{install_dir}/embedded/ssl/certs/cacert.pem"
 
   # Windows does not support symlinks
   unless windows?

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -19,12 +19,12 @@ name "cacerts"
 default_version "2016.01.20"
 
 version "2016.01.20" do
-  source md5: "06629db7f712ff3a75630eccaecc1fe4"
-  FIXME: this is not yet released on github, see https://github.com/bagder/ca-bundle/issues/5
+  source md5: "36eee0e80373937dd90a9a334ae42817"
+  source url: "https://raw.githubusercontent.com/bagder/ca-bundle/dfcc02c918b7bf40ed3a7f27a634c74ef4e80829/ca-bundle.crt"
 end
 
 version "2015.10.28" do
-  source md5: "6f41fb0f0c4b4695c2a6296892278141"
+  source md5: "3c58c3f2435598a942dc37cdb02a3ec3"
   source url: "https://raw.githubusercontent.com/bagder/ca-bundle/86347ecbdc2277f365d02f0d208b822a214e012d/ca-bundle.crt"
 end
 


### PR DESCRIPTION
replaces #369 and #549 among others

does not pull out the manual adding of the verisign cert yet (not
validated that its gone)

i would have pulled @wolf31o2's PR into this one, but rebasing on
master created bizzare conflicts.  credit to him though.