### PR TITLE
Allow us to enable native build tools/dev-kit on windows

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -21,14 +21,10 @@ source git: "git://github.com/berkshelf/berkshelf"
 
 relative_path "berkshelf"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-  dependency "rubygems"
-else
-  dependency "libffi"
-  dependency "ruby"
-  dependency "rubygems"
+dependency "ruby"
+dependency "rubygems"
+
+unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
   dependency "libarchive"
 end
 

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/chef-provisioning-aws.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/chef-provisioning-azure.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/chef-provisioning-fog.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"
 dependency "bundler"

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/chef-provisioning-vagrant.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/chef-provisioning.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -21,13 +21,7 @@ source git: "git://github.com/Nordstrom/chef-vault.git"
 
 relative_path "chef-vault"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -86,7 +86,9 @@ build do
   appbundle 'ohai'
 
   # Clean up
-  # Move this to a more appropriate place that's common to all software we ship.
+  # TODO: Move this cleanup to a more appropriate place that's common to all
+  # software we ship. Lot's of other dependencies and libraries we build for
+  # ChefDK create docs and man pages and those may occur after this build step.
   delete "#{install_dir}/embedded/docs"
   delete "#{install_dir}/embedded/share/man"
   delete "#{install_dir}/embedded/share/doc"

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/sethvargo/chefspec"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/customink/fauxhai"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -20,13 +20,7 @@ relative_path "ffi-yajl"
 
 source git: "git://github.com/opscode/ffi-yajl"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "libffi"
-  dependency "ruby"
-end
+dependency "ruby"
 
 dependency "rubygems"
 dependency "libyajl2-gem"

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -19,13 +19,7 @@ default_version "v5.0.0"
 
 source git: "git://github.com/acrmp/foodcritic.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "nokogiri"

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/chef/inspec.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/chef/kitchen-inspec.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "test-kitchen"

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "git://github.com/test-kitchen/kitchen-vagrant.git"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "test-kitchen"

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/jonlives/knife-spork"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/chef/knife-windows"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -56,6 +56,10 @@ build do
     # run old make :(
     make env: env, bin: "/usr/ccs/bin/make"
     make "install", env: env, bin: "/usr/ccs/bin/make"
+  elsif windows?
+    # On windows, msys make 3.81 breaks with parallel builds.
+    make env: env
+    make "install", env: env
   else
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -21,6 +21,7 @@ name "libiconv"
 default_version "1.14"
 
 dependency "patch" if solaris2?
+dependency "mingw-runtime" if windows?
 
 source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
@@ -28,37 +29,40 @@ source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
 relative_path "libiconv-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  # For now, just use the libiconv that comes with TDM gcc on windows.
+  unless windows?
+    env = with_standard_compiler_flags(with_embedded_path)
 
-  # freebsd 10 needs to be build PIC
-  env['CFLAGS'] << " -fPIC" if freebsd?
+    # freebsd 10 needs to be build PIC
+    env['CFLAGS'] << " -fPIC" if freebsd?
 
-  configure_command = "./configure" \
-                      " --prefix=#{install_dir}/embedded"
-  if aix?
-    patch_env = env.dup
-    patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
-    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: patch_env
-  else
-    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: env
-  end
-
-  if version == "1.14" && ppc64le?
-    patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1, env: env
-  end
-
-  # AIX's old version of patch doesn't like the config.guess patch here
-  unless aix?
-    # Update config.guess to support newer platforms (like aarch64)
-    if version == "1.14"
-      patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
+    configure_command = "./configure" \
+                        " --prefix=#{install_dir}/embedded"
+    if aix?
+      patch_env = env.dup
+      patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
+      patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: patch_env
+    else
+      patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: env
     end
+
+    if version == "1.14" && ppc64le?
+      patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1, env: env
+    end
+
+    # AIX's old version of patch doesn't like the config.guess patch here
+    unless aix?
+      # Update config.guess to support newer platforms (like aarch64)
+      if version == "1.14"
+        patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
+      end
+    end
+
+    command configure_command, env: env
+
+    make "-j #{workers}", env: env
+    make "-j #{workers} install-lib" \
+            " libdir=#{install_dir}/embedded/lib" \
+            " includedir=#{install_dir}/embedded/include", env: env
   end
-
-  command configure_command, env: env
-
-  make "-j #{workers}", env: env
-  make "-j #{workers} install-lib" \
-          " libdir=#{install_dir}/embedded/lib" \
-          " includedir=#{install_dir}/embedded/include", env: env
 end

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -17,18 +17,22 @@
 name "liblzma"
 default_version "5.2.2"
 
+dependency "mingw" if windows?
+
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
        md5: "7cf6a8544a7dae8e8106fdf7addfa28c"
 
 relative_path "xz-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-debug" \
-          " --disable-dependency-tracking", env: env
+  config_command = [
+    "--disable-debug",
+    "--disable-dependency-tracking",
+  ]
+
+  configure(*config_command, env: env)
 
   make "install", env: env
 end

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -18,9 +18,10 @@ name "libxslt"
 default_version "1.1.28"
 
 dependency "libxml2"
-dependency "libtool" if solaris2?
 dependency "liblzma"
+dependency "libtool" if solaris2?
 dependency "patch" if solaris2?
+dependency "mingw" if windows?
 
 version "1.1.26" do
   source md5: "e61d0364a30146aaa3001296f853b2b9"
@@ -35,18 +36,24 @@ source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
 relative_path "libxslt-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
   patch source: "libxslt-solaris-configure.patch" if solaris?
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --with-libxml-prefix=#{install_dir}/embedded" \
-          " --with-libxml-include-prefix=#{install_dir}/embedded/include" \
-          " --with-libxml-libs-prefix=#{install_dir}/embedded/lib" \
-          " --without-python" \
-          " --without-crypto", env: env
+  configure_commands = [
+    "--with-libxml-prefix=#{install_dir}/embedded",
+    "--with-libxml-include-prefix=#{install_dir}/embedded/include",
+    "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
+    "--without-python",
+    "--without-crypto",
+  ]
 
-  make "-j #{workers}", env: env
+  configure(*configure_commands, env: env)
+
+  if windows?
+    make env: env
+  else
+    make "-j #{workers}", env: env
+  end
   make "install", env: env
 end

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -20,15 +20,8 @@ relative_path "libyajl2-gem"
 
 source git: "git://github.com/opscode/libyajl2-gem"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "libffi"
-  dependency "ruby"
-  dependency "rubygems"
-end
-
+dependency "ruby"
+dependency "rubygems"
 dependency "bundler"
 
 build do

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -42,6 +42,12 @@ build do
     patch source: "v0.1.6.windows-configure.patch", plevel: 1, env: env
   end
 
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  # On windows, msys make 3.81 breaks with parallel builds.
+  if windows?
+    make env: env
+    make "install", env: env
+  else
+    make "-j #{workers}", env: env
+    make "-j #{workers} install", env: env
+  end
 end

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -16,11 +16,9 @@
 
 name "nokogiri"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
+dependency "ruby"
+
+unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
   dependency "libxml2"
   dependency "libxslt"
   dependency "libiconv"

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -18,7 +18,8 @@ name "nokogiri"
 
 dependency "ruby"
 
-unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+unless using_prebuilt_ruby
   dependency "libxml2"
   dependency "libxslt"
   dependency "libiconv"
@@ -58,7 +59,7 @@ build do
   gem_command << "--version '#{version}'" unless version.nil?
 
   # windows uses the 'fat' precompiled binaries'
-  unless windows?
+  unless using_prebuilt_ruby
     # Tell nokogiri to use the system libraries instead of compiling its own
     env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -22,13 +22,7 @@ source git: "git://github.com/opscode/ohai"
 
 relative_path "ohai"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -22,12 +22,7 @@ name "openssl-customization"
 
 source path: "#{project.files_path}/#{name}"
 
-if windows?
-  dependency "ruby-windows"
-else
-  dependency "ruby"
-  dependency "rubygems"
-end
+dependency "ruby"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -68,6 +68,7 @@ build do
 
   command configure_command.join(" "), env: env, in_msys_bash: true
 
+  # Cannot use -j with openssl :(.
   make env: env
   make "install", env: env
 end

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -25,6 +25,7 @@ end
 
 version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
 version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
+version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
 
 # HAHAHA According to the FIPS manual, you need to "securely" fetch the source
 # such as asking some humans to mail you a CD-ROM or something.

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/bbatsov/rubocop"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -50,6 +50,22 @@ build do
   command "echo - #{install_dir}/embedded > config.yml", cwd: embedded_dir
   ruby "dk.rb install", env: env, cwd: embedded_dir
 
-  # many gems that ship with native extensions assume tar will be available in the PATH
-  copy "#{install_dir}/embedded/mingw/bin/bsdtar.exe", "#{install_dir}/embedded/mingw/bin/tar.exe"
+  # Normally we would symlink the required unix tools.
+  # However with the introduction of git-cache to speed up omnibus builds,
+  # we can't do that anymore since git on windows doesn't support symlinks.
+  # https://groups.google.com/forum/#!topic/msysgit/arTTH5GmHRk
+  # Therefore we copy the tools to the necessary places.
+  # We need tar for 'knife cookbook site install' to function correctly and
+  # many gems that ship with native extensions assume tar will be available
+  # in the PATH.
+  {
+    'tar.exe'          => 'bsdtar.exe',
+    'libarchive-2.dll' => 'libarchive-2.dll',
+    'libexpat-1.dll'   => 'libexpat-1.dll',
+    'liblzma-1.dll'    => 'liblzma-1.dll',
+    'libbz2-2.dll'     => 'libbz2-2.dll',
+    'libz-1.dll'       => 'libz-1.dll',
+  }.each do |target, to|
+    copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
+  end
 end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -46,17 +46,17 @@ else
   dependency "patch" if solaris2?
   dependency "ncurses"
   dependency "libedit"
-  # Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
-  # they expect to see our libiconv instead of a system version.
-  # Ignore on windows - TDM GCC comes with libiconv in the runtime
-  # and that's the only one we will ever use.
-  dependency "libiconv"
 end
 
 dependency "zlib"
 dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
+# Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
+# they expect to see our libiconv instead of a system version.
+# Ignore on windows - TDM GCC comes with libiconv in the runtime
+# and that's the only one we will ever use.
+dependency "libiconv"
 
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -40,7 +40,7 @@ if windows? && version == "ruby-windows"
 else
 
 if windows?
-  dependency "mingw" if windows?
+  dependency "mingw"
   dependency "patch"
 else
   dependency "patch" if solaris2?

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -15,23 +15,49 @@
 #
 
 name "ruby"
-default_version "1.9.3-p550"
 
-dependency "zlib"
-dependency "ncurses" unless windows?
-dependency "libedit" unless windows?
-dependency "openssl"
-dependency "libyaml"
-# Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
-# they expect to see our libiconv instead of a system version.
-# Ignore on windows - TDM GCC comes with libiconv in the runtime
-# and that's the only one we will ever use.
-dependency "libiconv" unless windows?
-dependency "libffi"
-dependency "patch" if solaris2? || windows?
-dependency "mingw" if windows?
+# This is now the main software project for anything ruby related.
+# Even if you want a pre-built version of ruby from ruby-installer, include
+# this project as a dependency. If the version is set to ruby-windows,
+# it redirects to depend on the ruby-windows project.
+
+if windows?
+  default_version "ruby-windows"
+else
+  default_version "1.9.3-p550"
+end
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
+
+if windows? && version == "ruby-windows"
+    dependency "ruby-windows"
+    dependency "ruby-windows-devkit"
+    dependency "ruby-windows-devkit-bash"
+    # The custom yakyakyak ruby build comes with openssl and the FIPS module.
+    # Don't clobber it.
+    dependency "openssl-windows" unless fips_enabled
+    dependency "cacerts"
+else
+
+if windows?
+  dependency "mingw" if windows?
+  dependency "patch"
+else
+  dependency "patch" if solaris2?
+  dependency "ncurses"
+  dependency "libedit"
+  # Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
+  # they expect to see our libiconv instead of a system version.
+  # Ignore on windows - TDM GCC comes with libiconv in the runtime
+  # and that's the only one we will ever use.
+  dependency "libiconv"
+end
+
+dependency "zlib"
+dependency "openssl"
+dependency "libffi"
+dependency "libyaml"
+
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
 version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
@@ -211,3 +237,5 @@ build do
   make "-j #{workers} install", env: env
 
 end
+
+end # if windows? && version == 'ruby-windows'

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -233,8 +233,14 @@ build do
   env.merge!("PKG_CONFIG" => "/bin/true") if aix?
 
   configure(*configure_command, env: env)
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  if windows?
+    # On windows, msys make 3.81 breaks with parallel builds.
+    make env: env
+    make "install", env: env
+  else
+    make "-j #{workers}", env: env
+    make "-j #{workers} install", env: env
+  end
 
 end
 

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -17,12 +17,7 @@
 name "rubygems"
 default_version "1.8.24"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
+dependency "ruby"
 
 source git: 'https://github.com/rubygems/rubygems.git'
 

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -103,10 +103,18 @@ build do
 
   ruby "setup.rb --no-ri --no-rdoc", env: env
 
+  # TODO: Add a custom overrides flag here on whether we wish to register
+  # devkit/other system tools or not.
   if windows?
-    # After installing ruby, we need to rerun the command that patches devkit
-    # functionality into rubygems.
-    embedded_dir = "#{install_dir}/embedded"
-    ruby "dk.rb install", env: env, cwd: embedded_dir
+    if project.overrides[:ruby] && project.overrides[:ruby][:version] != "ruby-windows"
+      # Render our registration script and run it in the context of the embedded ruby.
+      erb source: 'register_devtools.rb.erb', dest: "#{project_dir}/register_devtools.rb",
+          vars: { paths: [ "#{install_dir}/embedded/bin", "#{install_dir}/embedded/msys/1.0/bin" ] }
+      ruby "register_devtools.rb", env: env
+    else
+      # After installing ruby, we need to rerun the command that patches devkit
+      # functionality into rubygems.
+      ruby "dk.rb install", env: env, cwd: "#{install_dir}/embedded"
+    end
   end
 end

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -20,13 +20,7 @@ relative_path "test-kitchen"
 
 source git: "git://github.com/test-kitchen/test-kitchen"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"
 

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -19,13 +19,7 @@ default_version "master"
 
 source git: "https://github.com/test-kitchen/winrm-transport"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -45,12 +45,13 @@ build do
     make_args = [
       "-fwin32/Makefile.gcc",
       "SHARED_MODE=1",
-      "ARFLAGS='rcs #{env['ARFLAGS']}'",
-      "RCFLAGS='--define GCC_WINDRES #{env['RCFLAGS']}'",
+      "ARFLAGS=\"rcs #{env['ARFLAGS']}\"",
+      "RCFLAGS=\"--define GCC_WINDRES #{env['RCFLAGS']}\"",
     ]
     arch = windows_arch_i386? ? "-m32" : "-m64"
     make_args << "LOC=\"#{arch}\""
 
+    # On windows, msys make 3.81 doesn't support -j.
     make(*make_args, env: env)
     make("install", *make_args, env: env)
   else

--- a/config/templates/rubygems/register_devtools.rb.erb
+++ b/config/templates/rubygems/register_devtools.rb.erb
@@ -1,0 +1,33 @@
+require 'fileutils'
+require 'pathname'
+
+os_file_path = 'rubygems/defaults/operating_system.rb'
+
+def registration_snippet(file_path)
+	relative_paths = <%= paths %>.map do |p|
+		Pathname.new(p).relative_path_from(Pathname.new(file_path)).to_s
+	end
+
+<<EOF
+Gem.pre_install do |gem_installer|
+	unless gem_installer.spec.extensions.empty?
+		tool_paths = #{relative_paths}.map do |p|
+			File.expand_path(p, __FILE__).gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+		end
+		tool_path = tool_paths.join(File::PATH_SEPARATOR)
+		unless ENV['PATH'].include?(tool_path)
+			Gem.ui.say("Adding native build tools to path: " + tool_path) if Gem.configuration.verbose
+			ENV['PATH'] = [tool_path, ENV['PATH']].join(File::PATH_SEPARATOR)
+		end
+  end
+end
+EOF
+end
+
+['rubylibdir', 'sitelibdir'].each do |rubygems_path|
+	file_path = File.join(RbConfig::CONFIG[rubygems_path], os_file_path)
+	FileUtils.mkdir_p(File.dirname(file_path))
+	File.open(file_path, 'w') do |file|
+		file.write(registration_snippet(file_path))
+	end
+end


### PR DESCRIPTION
This changes the "rubygems" software definition to patch itself to allow native tools to be used when compiling native gems.  It is only enabled when ruby is compiled on windows.