### PR TITLE
backoff default to 2.2.4

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -24,7 +24,7 @@ name "ruby"
 if windows?
   default_version "ruby-windows"
 else
-  default_version "2.3.0"
+  default_version "2.2.4"
 end
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false


### PR DESCRIPTION
2.3.0 doesn't compile at all for some reason, i tend to suspect we're
applying a patch that is no longer necessary in 2.3.0 or conflicts
with 2.3.0...