### PR TITLE
update default_version with current status

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -24,7 +24,10 @@ name "ruby"
 if windows?
   default_version "ruby-windows"
 else
-  default_version "2.2.4"
+  # - chef-client cannot use 2.2.x yet due to a bug in IRB that affects chef-shell on linux:
+  #   https://bugs.ruby-lang.org/issues/11869
+  # - the current status of 2.3.x is that it downloads but fails to compile.
+  default_version "2.1.6"
 end
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false


### PR DESCRIPTION
- back the default version down to 2.1.6
- document how 2.2.x and 2.3.x fail