### PR TITLE
Do not specify --with-ext=psych for Ruby >= 2.3

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -182,11 +182,11 @@ build do
 
   configure_command = ["--with-out-ext=dbm",
                        "--enable-shared",
-                       "--with-ext=psych",
                        "--disable-install-doc",
                        "--without-gmp",
                        "--without-gdbm",
                        "--disable-dtrace"]
+  configure_command << "--with-ext=psych" if version.satisfies?('< 2.3')
   configure_command << "--enable-libedit" unless windows?
   configure_command << "--with-bundled-md5" if fips_enabled
 


### PR DESCRIPTION
Attempting to build Ruby 2.3 on OS X with omnibus-software results in a build error:

```
make[2]: `ruby' is up to date.
./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems -r./x86_64-darwin15-fake ./tool/rbinstall.rb --make="/Applications/Xcode.app/Contents/Developer/usr/bin/make" --dest-dir="" --extout=".ext" --mflags="" --make-flags="" --data-mode=0644 --prog-mode=0755 --installed-list .installed.list --mantype="doc"
/Users/alindeman/tmp/omnibus-foo/local/src/ruby/ruby-2.3.0/lib/rubygems/specification.rb:17:in `require': cannot load such file -- stringio (LoadError)
        from /Users/alindeman/tmp/omnibus-foo/local/src/ruby/ruby-2.3.0/lib/rubygems/specification.rb:17:in `<top (required)>'
        from /Users/alindeman/tmp/omnibus-foo/local/src/ruby/ruby-2.3.0/lib/rubygems.rb:1229:in `require'
        from /Users/alindeman/tmp/omnibus-foo/local/src/ruby/ruby-2.3.0/lib/rubygems.rb:1229:in `<module:Gem>'
        from /Users/alindeman/tmp/omnibus-foo/local/src/ruby/ruby-2.3.0/lib/rubygems.rb:116:in `<top (required)>'
        from ./tool/rbinstall.rb:21:in `require'
        from ./tool/rbinstall.rb:21:in `<main>'
make: *** [do-install-nodoc] Error 1
```

As far as I can tell, it's because [changes in Ruby 2.3](https://github.com/ruby/ruby/commit/65ab26604bab94a49546512785aae788ddb76141) result in only extensions in the intersection of with and without being installed. So core extensions like `pathname` and `stringio` are skipped because we specify both `with` and `without` options. Literally the _only_ extension installed is `psych`. Weird, right?

I've compiled Ruby 2.3 without the `--with-ext=psych` option via omnibus-software, and psych is compiled anyway, along with all the other core extensions we actually need. So as far as I can tell, the explicit option is not needed, and because of the change above, it's actually detrimental to the build.