### PR TITLE
Use HTTPS sources where trivially available

### DIFF
--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -19,7 +19,7 @@ default_version "2.68"
 
 dependency "m4"
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
        md5: "c3b5247592ce694f7097873aa07d66fe"
 
 relative_path "autoconf-#{version}"

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -19,7 +19,7 @@ default_version "1.11.2"
 
 dependency "autoconf"
 
-source url: "http://ftp.gnu.org/gnu/automake/automake-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/gnu/automake/automake-#{version}.tar.gz",
        md5: "79ad64a9f6e83ea98d6964cef8d8a0bc"
 
 relative_path "automake-#{version}"

--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -22,7 +22,7 @@ dependency "ncurses"
 
 version("4.3.30") { source md5: "a27b3ee9be83bd3ba448c0ff52b28447" }
 
-source url: "http://ftp.gnu.org/gnu/bash/bash-#{version}.tar.gz"
+source url: "https://ftp.gnu.org/gnu/bash/bash-#{version}.tar.gz"
 
 relative_path "bash-#{version}"
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -20,7 +20,7 @@ default_version "7.36.0"
 dependency "zlib"
 dependency "openssl"
 
-source url: "http://curl.haxx.se/download/curl-#{version}.tar.gz",
+source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz",
        md5: "643a7030b27449e76413d501d4b8eb57"
 
 relative_path "curl-#{version}"

--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -25,7 +25,7 @@ dependency "libiconv"
 version("4.9.2")      { source md5: "76f464e0511c26c93425a9dcdc9134cf" }
 version("5.3.0")      { source md5: "39b5b6a0e769716a8e0a339adc79d8ad" }
 
-source url: "http://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
+source url: "https://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
 
 relative_path "gcc-#{version}"
 

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -20,7 +20,7 @@ default_version "1.8.3"
 # Version 1.9 and above are GPLv3, do NOT add later versions in
 version("1.8.3") { source md5: "1d1b1d5c0245b1c00aff92da751e9aa1" }
 
-source url: "http://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
+source url: "https://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
 
 relative_path "gdbm-#{version}"
 

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -17,7 +17,7 @@
 name "help2man"
 default_version "1.40.5"
 
-source url: "http://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
+source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
        md5: "75a7d2f93765cd367aab98986a75f88c"
 
 relative_path "help2man-1.40.5"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -23,7 +23,7 @@ default_version "1.14"
 dependency "patch" if solaris2?
 dependency "mingw-runtime" if windows?
 
-source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
 
 relative_path "libiconv-#{version}"

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -22,7 +22,7 @@ version "1.6.2" do
 end
 
 # ftp on ftp.ossp.org is unavaiable so we must use another mirror site.
-source url: "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-#{version}.tar.gz"
+source url: "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-#{version}.tar.gz"
 
 relative_path "uuid-#{version}"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -32,7 +32,7 @@ version "1.0.2" do
   source md5: "dc40eb23e293448c6fc908757738003f"
 end
 
-source url: "http://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
 relative_path "libsodium-#{version}"
 

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -22,7 +22,7 @@ version("2.4.2") { source md5: "d2f3b7d4627e69e13514a40e72a24d50" }
 version("2.4.6") { source md5: "addf44b646ddb4e3919805aa88fa7c5e" }
 
 
-source url: "http://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
+source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
 
 relative_path "libtool-#{version}"
 

--- a/config/software/libuuid.rb
+++ b/config/software/libuuid.rb
@@ -18,7 +18,7 @@ name "libuuid"
 default_version "2.21"
 
 # We use the version in util-linux, and only build the libuuid subdirectory
-source url: "ftp://ftp.kernel.org/pub/linux/utils/util-linux/v2.21/util-linux-2.21.tar.gz",
+source url: "https://www.kernel.org/pub/linux/utils/util-linux/v2.21/util-linux-2.21.tar.gz",
        md5: "4222aa8c2a1b78889e959a4722f1881a"
 
 relative_path "util-linux-2.21"

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -28,7 +28,7 @@ default_version "0.1.6"
 
 dependency "ruby-windows"
 
-source url: "http://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
+source url: "https://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
        md5: "8bb5d8e43cf18ec48b4751bdd0111c84"
 
 build do

--- a/config/software/libzmq-windows.rb
+++ b/config/software/libzmq-windows.rb
@@ -19,7 +19,7 @@ default_version "2.2.0"
 
 zmq_installer = "ZeroMQ-#{version}~miru1.0-win32.exe"
 
-source url: "http://miru.hk/archive/#{zmq_installer}",
+source url: "https://miru.hk/archive/#{zmq_installer}",
        md5: "207a322228f90f61bfb67e3f335db06e"
 
 build do

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -17,7 +17,7 @@
 name "m4"
 default_version "1.4.17"
 
-source url: "http://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
        md5: "a5e9954b1dae036762f7b13673a2cf76"
 
 relative_path "m4-#{version}"

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -17,7 +17,7 @@
 name "make"
 default_version "4.1"
 
-source url: "http://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
        md5: "654f9117957e6fa6a1c49a8f08270ec9"
 
 relative_path "make-#{version}"

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -17,7 +17,7 @@
 name "makedepend"
 default_version "1.0.5"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
        md5: "efb2d7c7e22840947863efaedc175747"
 
 relative_path "makedepend-1.0.5"

--- a/config/software/mpc.rb
+++ b/config/software/mpc.rb
@@ -23,7 +23,7 @@ dependency "mpfr"
 version("1.0.2") { source md5: "68fadff3358fb3e7976c7a398a0af4c3" }
 version("1.0.3") { source md5: "d6a1d5f8ddea3abd2cc3e98f58352d26" }
 
-source url: "ftp://ftp.gnu.org/gnu/mpc/mpc-#{version}.tar.gz"
+source url: "https://ftp.gnu.org/gnu/mpc/mpc-#{version}.tar.gz"
 
 relative_path "mpc-#{version}"
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,7 +20,7 @@ default_version "5.9"
 dependency "libtool" if aix?
 dependency "patch" if solaris2?
 
-version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
+version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
 version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
 version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150613.tgz" }
 version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150810.tgz" }

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -26,7 +26,7 @@ version("1.7.10.2") { source md5: "bca1744196acfb9e986f1fdbee92641e" }
 version("1.7.10.1") { source md5: "1093b89459922634a818e05f80c1e18a" }
 version("1.4.3.6") { source md5: "5e5359ae3f1b8db4046b358d84fabbc8" }
 
-source url: "http://openresty.org/download/ngx_openresty-#{version}.tar.gz"
+source url: "https://openresty.org/download/ngx_openresty-#{version}.tar.gz"
 
 relative_path "ngx_openresty-#{version}"
 

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -22,7 +22,7 @@ if windows?
 else
   default_version "2.7"
   version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
-  source url: "http://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
+  source url: "https://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
   relative_path "patch-#{version}"
 end
 

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -23,7 +23,7 @@ version "0.28" do
   source md5: "aa3c86e67551adc3ac865160e34a2a0d"
 end
 
-source url: "http://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
+source url: "https://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
 
 relative_path "pkg-config-#{version}"
 

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -25,7 +25,7 @@ dependency "bzip2"
 version("2.7.5") { source md5: "b4f01a1d0ba0b46b05c73b2ac909b1df" }
 version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }
 
-source url: "http://python.org/ftp/python/#{version}/Python-#{version}.tgz"
+source url: "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
 
 relative_path "Python-#{version}"
 

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -22,7 +22,7 @@ dependency "erlang"
 version("2.7.1") { source md5: "34a5f9fb6f22e6681092443fcc80324f" }
 version("3.3.4") { source md5: "61a3822f3af0aaa30da7230dccb17067" }
 
-source url: "http://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/rabbitmq-server-generic-unix-#{version}.tar.gz"
+source url: "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/rabbitmq-server-generic-unix-#{version}.tar.gz"
 
 relative_path "rabbitmq_server-#{version}"
 

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -19,7 +19,7 @@ default_version "3.1.1"
 
 dependency "popt"
 
-source url: "http://rsync.samba.org/ftp/rsync/src/rsync-#{version}.tar.gz",
+source url: "https://rsync.samba.org/ftp/rsync/src/rsync-#{version}.tar.gz",
        md5: "43bd6676f0b404326eee2d63be3cdcfe"
 
 relative_path "rsync-#{version}"

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -29,7 +29,7 @@ if fips_enabled
   end
 elsif windows_arch_i386?
   relative_path "ruby-#{version}-i386-mingw32"
-  source url: "http://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
+  source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
 
   version("1.9.3-p484") { source md5: "a0665113aaeea83f1c4bea02fcf16694" }
   version("2.0.0-p451") { source md5: "37feadb0230e7f475a8591d1807ecfec" }
@@ -40,7 +40,7 @@ elsif windows_arch_i386?
   version("2.2.1") { source md5: "9f1beca535b2e60098d826eb7cb1b972" }
 else
   relative_path "ruby-#{version}-x64-mingw32"
-  source url: "http://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-x64-mingw32.7z?direct"
+  source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-x64-mingw32.7z?direct"
 
   version("2.0.0-p451") { source md5: "d4f6741138a26a4be12e684a16a19b75" }
   version("2.0.0-p645") { source md5: "d57d539b90f5bbf26550a9d1a3c33c33" }

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -83,7 +83,7 @@ version("2.2.3")      { source md5: "150a5efc5f5d8a8011f30aa2594a7654" }
 version("2.2.4")      { source md5: "9a5e15f9d5255ba37ace18771b0a8dd2" }
 version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 
-source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
+source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
 relative_path "ruby-#{version}"
 

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -17,7 +17,7 @@
 name "util-macros"
 default_version "1.18.0"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz",
        md5: "fd0ba21b3179703c071bbb4c3e5fb0f4"
 
 relative_path "util-macros-#{version}"

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -17,7 +17,7 @@
 name "xproto"
 default_version "7.0.25"
 
-source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz",
        md5: "a47db46cb117805bd6947aa5928a7436"
 
 relative_path "xproto-#{version}"


### PR DESCRIPTION
This change was made mostly programmatically by taking http and ftp
sources and attempting to connect to them via HTTPS and make a HEAD
request for the source.  I then validated it by calling the #fetch method on
every software after the change.