### PR TITLE
Revert "Add NodeJS v5.6.0"

### DIFF
--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -35,6 +35,8 @@ version "4.1.2" do
   source md5: "31a3ee2f51bb2018501048f543ea31c7"
 end
 
+# Warning: NodeJS 5.6.0 requires GCC >= 4.8
+
 source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
 relative_path "node-v#{version}"

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -35,10 +35,6 @@ version "4.1.2" do
   source md5: "31a3ee2f51bb2018501048f543ea31c7"
 end
 
-version "5.6.0" do
-  source md5: "6f7c2cec289a20bcd970240dd63c1395"
-end
-
 source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
 relative_path "node-v#{version}"


### PR DESCRIPTION
5.6.0 requires a specific GCC that needs to be specified. 