### PR TITLE
pull latest appbundler by default

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -15,7 +15,6 @@
 #
 
 name "appbundler"
-default_version "0.6.0"
 
 dependency "rubygems"
 dependency "bundler"
@@ -23,7 +22,12 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install appbundler" \
-      " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+  gem_command = [
+    "install appbundler",
+    " --no-ri --no-rdoc",
+  ]
+
+  gem_command << " --version '#{version}'" unless version.nil?
+
+  gem gem_command, env: env
 end

--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -15,6 +15,9 @@
 #
 
 name "appbundler"
+default_version "master"
+
+source git: "https://github.com/chef/appbundler.git"
 
 dependency "rubygems"
 dependency "bundler"
@@ -22,12 +25,9 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem_command = [
-    "install appbundler",
-    " --no-ri --no-rdoc",
-  ]
+  bundle "install --without development", env: env
 
-  gem_command << " --version '#{version}'" unless version.nil?
-
-  gem gem_command, env: env
+  gem "build appbundler.gemspec", env: env
+  gem "install appbundler-*.gem" \
+      " --no-ri --no-rdoc", env: env
 end


### PR DESCRIPTION
nobody bumped the equality pin for 12.7.2 so we shipped old
appbundler 0.6.0 long after the 0.7.0 gem was released.