### PR TITLE
Add list, fetch, and fetch_all rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 group :development, :test do
   gem 'omnibus', github: 'opscode/omnibus'
+  gem 'highline'
   gem 'rubocop', '= 0.26.1'
   gem 'rake'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,34 @@
 require 'bundler/gem_tasks'
 require 'rubocop/rake_task'
+require 'omnibus-software'
 
 RuboCop::RakeTask.new
 
 task :test do
   OmnibusSoftware.verify!
+end
+
+task :fetch do
+  rake_fakeout
+  software_name = ARGV[1]
+  path = ARGV[2] || "."
+  puts "Downloading #{software_name} to #{path}"
+  OmnibusSoftware.fetch(software_name, path)
+end
+
+task :fetch_all do
+  rake_fakeout
+  path = ARGV[1] || "."
+  puts "Downloading all software to #{path}"
+  OmnibusSoftware.fetch_all(path)
+end
+
+def rake_fakeout
+  ARGV.each { |a| task a.to_sym {} }
+end
+
+task :list do
+  OmnibusSoftware.list
 end
 
 namespace :travis do

--- a/lib/omnibus-software/version.rb
+++ b/lib/omnibus-software/version.rb
@@ -1,0 +1,3 @@
+module OmnibusSoftware
+  VERSION = '4.0.0'
+end

--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-require 'omnibus-software'
+require 'omnibus-software/version'
 
 Gem::Specification.new do |s|
   s.name        = "omnibus-software"


### PR DESCRIPTION
I've used these rake tasks to help investigate out of date software
definitions. For instance, the `fetch` and `fetch_all` commands were
useful when doing the HTTP->HTTPS transition. The `list` command makes
it a bit easier to build quick reports about the software in
omnibus-software.

The `fetch` command could probably be an omnibus feature at some point.