### PR TITLE
Make libzmq not assume omnibus cache directory structure

### DIFF
--- a/config/software/libzmq-windows.rb
+++ b/config/software/libzmq-windows.rb
@@ -25,16 +25,15 @@ source url: "https://miru.hk/archive/#{zmq_installer}",
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "libzmq-cache")
 
-  command "#{zmq_installer} /S /D=#{windows_safe_path(tmpdir)}", env: env
+  command "#{zmq_installer} /S /D=#{windows_safe_path(project_dir)}", env: env
 
-  copy "#{tmpdir}/bin/*", "#{install_dir}/embedded/bin"
-  copy "#{tmpdir}/include/*", "#{install_dir}/embedded/include"
-  copy "#{tmpdir}/lib/*", "#{install_dir}/embedded/lib"
+  copy "bin/*", "#{install_dir}/embedded/bin"
+  copy "include/*", "#{install_dir}/embedded/include"
+  copy "lib/*", "#{install_dir}/embedded/lib"
 
   # Ensure the main DLL is available under a well known name.
-  copy "#{tmpdir}/bin/libzmq-v100-mt.dll", "#{install_dir}/embedded/bin/libzmq.dll"
+  copy "bin/libzmq-v100-mt.dll", "#{install_dir}/embedded/bin/libzmq.dll"
 
-  command "uninstall /S", cwd: tmpdir, env: env
+  command "uninstall /S", env: env
 end

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -25,13 +25,13 @@ version("1.0.21") do
          md5: "f75bb49580c7563f890d1fcfdd415553"
 end
 
-build do
-  tmpdir = File.join(Omnibus::Config.source_dir, "libzmq4x-windows")
+relative_path "libzmq4x-windows"
 
-  copy "#{tmpdir}/bin/*", "#{install_dir}/embedded/bin"
-  copy "#{tmpdir}/include/*", "#{install_dir}/embedded/include"
-  copy "#{tmpdir}/lib/*", "#{install_dir}/embedded/lib"
+build do
+  copy "bin/*", "#{install_dir}/embedded/bin"
+  copy "include/*", "#{install_dir}/embedded/include"
+  copy "lib/*", "#{install_dir}/embedded/lib"
 
   # Ensure the main DLL is available under a well known name.
-  copy "#{tmpdir}/bin/libzmq-mt-4_0_6.dll", "#{install_dir}/embedded/bin/libzmq.dll"
+  copy "bin/libzmq-mt-4_0_6.dll", "#{install_dir}/embedded/bin/libzmq.dll"
 end


### PR DESCRIPTION
The libzmq software definitions assumes that the omnibus source/cache
directory structure (like the fact that it used to unzip things
directly into the cache dir).  Recently, the layout changed to introduce
per-package directories into which things were unzipped.  The correct
way to write the definition is to use relative_path to define the
directory you want to work under and simply assume that all the DSL
methods get run in that directory.