### PR TITLE
Clean up large object files

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -43,4 +43,18 @@ build do
 
   gem "install pkg/berkshelf-*.gem" \
       " --no-ri --no-rdoc", env: env
+
+  if windows?
+    block "Clean up large object files" do
+      # find the embedded rubygems dir and clean it up for globbing
+      gem_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".gsub(/\\/, '/')
+
+      # find all the static *.a files in the dep-selector-libgecode gem(s)
+      # we don't use and delete them
+      Dir.glob("#{gem_dir}/dep-selector-libgecode*/**/*.a").each do |f|
+        puts "Deleting #{f}"
+        File.delete(f)
+      end
+    end
+  end
 end

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -37,4 +37,18 @@ build do
   gem "install dep-selector-libgecode" \
       " --version '#{version}'" \
       " --no-ri --no-rdoc", env: env
+
+  if windows?
+    block "Clean up large object files" do
+      # find the embedded rubygems dir and clean it up for globbing
+      gem_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".gsub(/\\/, '/')
+
+      # find all the static *.a files in the dep-selector-libgecode gem(s)
+      # we don't use and delete them
+      Dir.glob("#{gem_dir}/dep-selector-libgecode*/**/*.a").each do |f|
+        puts "Deleting #{f}"
+        File.delete(f)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds some cleanup code to remove un-needed large object files from dep-selector-libgecode gem.  We need to add cleanup code in a couple of places as different versions of the gem get installed.  This saves about 30M from the compressed chefdk package size.

@chef/omnibus-maintainers @adamedx 