### PR TITLE
Berkshelf2 refactor, 'version' standardization, add validation project def and Quotepocalypse 2016

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,5 @@ UnneededPercentQ:
   Enabled: false
 WordArray:
   Enabled: false
+UnneededInterpolation:
+  Enabled: false

--- a/config/projects/validate.rb
+++ b/config/projects/validate.rb
@@ -11,7 +11,6 @@ Dir.glob('config/software/**').each do |filepath|
   dep_name = ''
   File.readlines(filepath).each do |line|
     if line =~ /name [\"\'](?<name>.*?)[\"\']/
-      # require 'pry'; binding.pry
       dep_name = $~[:name]
       next
     end

--- a/config/projects/validate.rb
+++ b/config/projects/validate.rb
@@ -1,0 +1,20 @@
+name "validate"
+
+package_name    "validate"
+install_dir     "/opt/validate"
+build_version   "0.0.1dev"
+build_iteration 1
+
+dependency 'preparation'
+
+Dir.glob('config/software/**').each do |filepath|
+  dep_name = ''
+  File.readlines(filepath).each do |line|
+    if line =~ /name [\"\'](?<name>.*?)[\"\']/
+      # require 'pry'; binding.pry
+      dep_name = $~[:name]
+      next
+    end
+  end
+  dependency "#{dep_name}"
+end

--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -14,20 +14,20 @@
 # limitations under the License.
 #
 
-name "appbundler"
-default_version "master"
+name 'appbundler'
+default_version 'master'
 
-source git: "https://github.com/chef/appbundler.git"
+source git: 'https://github.com/chef/appbundler.git'
 
-dependency "rubygems"
-dependency "bundler"
+dependency 'rubygems'
+dependency 'bundler'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build appbundler.gemspec", env: env
-  gem "install appbundler-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build appbundler.gemspec', env: env
+  gem 'install appbundler-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "autoconf"
-default_version "2.68"
+name 'autoconf'
+default_version '2.68'
 
 dependency 'm4'
 
@@ -33,9 +33,9 @@ build do
     env['M4'] = "#{install_dir}/embedded/bin/m4"
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -17,16 +17,12 @@
 name "autoconf"
 default_version "2.68"
 
-dependency "m4"
-
-version "2.69" do
-  source md5: "82d05e03b93e45f5a39b828dc9c6c29b"
-end
-version "2.68" do
-  source md5: "c3b5247592ce694f7097873aa07d66fe"
-end
+dependency 'm4'
 
 source url: "https://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz"
+
+version('2.69') { source md5: '82d05e03b93e45f5a39b828dc9c6c29b' }
+version('2.68') { source md5: 'c3b5247592ce694f7097873aa07d66fe' }
 
 relative_path "autoconf-#{version}"
 

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "automake"
-default_version "1.11.2"
+name 'automake'
+default_version '1.11.2'
 
 dependency 'autoconf'
 
@@ -29,14 +29,14 @@ relative_path "automake-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if version.satisfies?(">= 1.15")
-    command "./bootstrap.sh", env: env
+  if version.satisfies?('>= 1.15')
+    command './bootstrap.sh', env: env
   else
-    command "./bootstrap", env: env
+    command './bootstrap', env: env
   end
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -17,17 +17,12 @@
 name "automake"
 default_version "1.11.2"
 
-dependency "autoconf"
-
-version "1.15" do
-  source md5: "716946a105ca228ab545fc37a70df3a3"
-end
-
-version "1.11.2" do
-  source md5: "79ad64a9f6e83ea98d6964cef8d8a0bc"
-end
+dependency 'autoconf'
 
 source url: "https://ftp.gnu.org/gnu/automake/automake-#{version}.tar.gz"
+
+version('1.15')   { source md5: '716946a105ca228ab545fc37a70df3a3' }
+version('1.11.2') { source md5: '79ad64a9f6e83ea98d6964cef8d8a0bc' }
 
 relative_path "automake-#{version}"
 

--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -17,12 +17,12 @@
 name "bash"
 default_version "4.3.30"
 
-dependency "libiconv"
-dependency "ncurses"
-
-version("4.3.30") { source md5: "a27b3ee9be83bd3ba448c0ff52b28447" }
+dependency 'libiconv'
+dependency 'ncurses'
 
 source url: "https://ftp.gnu.org/gnu/bash/bash-#{version}.tar.gz"
+
+version('4.3.30') { source md5: 'a27b3ee9be83bd3ba448c0ff52b28447' }
 
 relative_path "bash-#{version}"
 

--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "bash"
-default_version "4.3.30"
+name 'bash'
+default_version '4.3.30'
 
 dependency 'libiconv'
 dependency 'ncurses'
@@ -29,16 +29,16 @@ relative_path "bash-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                        "--prefix=#{install_dir}/embedded"]
 
   # On freebsd, you have to force static linking, otherwise the executable
   # will link against the system ncurses instead of ours.
   if freebsd?
-    configure_command << "--enable-static-link"
+    configure_command << '--enable-static-link'
   end
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 end

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -14,33 +14,33 @@
 # limitations under the License.
 #
 
-name "berkshelf"
-default_version "master"
+name 'berkshelf'
+default_version 'master'
 
-source git: "https://github.com/berkshelf/berkshelf.git"
+source git: 'https://github.com/berkshelf/berkshelf.git'
 
-relative_path "berkshelf"
+relative_path 'berkshelf'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
-unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
-  dependency "libarchive"
+unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == 'ruby-windows')
+  dependency 'libarchive'
 end
 
-dependency "nokogiri"
-dependency "bundler"
-dependency "dep-selector-libgecode"
+dependency 'nokogiri'
+dependency 'bundler'
+dependency 'dep-selector-libgecode'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install" \
+  bundle 'install' \
          " --jobs #{workers}" \
-         " --without guard", env: env
+         ' --without guard', env: env
 
-  bundle "exec thor gem:build", env: env
+  bundle 'exec thor gem:build', env: env
 
-  gem "install pkg/berkshelf-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'install pkg/berkshelf-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -18,13 +18,13 @@ Omnibus.logger.deprecated('berkshelf2') do
   'Please upgrade to Berkshelf 3. Continued use of Berkshelf 2 will not be supported in the future.'
 end
 
-name "berkshelf2"
-default_version "2.0.18"
+name 'berkshelf2'
+default_version '2.0.18'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "nokogiri"
-dependency "libffi"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'nokogiri'
+dependency 'libffi'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -29,27 +29,18 @@ dependency "libffi"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install celluloid" \
-      " --version '~> 0.16.0'" \
-      " --no-ri --no-rdoc", env: env
+  gems = {
+    'celluloid'    => '0.16.0',
+    'celluloid-io' => '0.16.1',
+    'hashie'       => '2.0.0',
+    'varia_model'  => '0.3.2',
+    'i18n'         => '0.6.11',
+    'berkshelf'    => "#{version}"
+  }
 
-  gem "install celluloid-io" \
-      " --version '~> 0.16.1'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install hashie" \
-      " --version '~> 2.0.0'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install varia_model" \
-      " --version '0.3.2'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install i18n" \
-      " --version '0.6.11'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install berkshelf" \
-      " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+  gems.map do |name, version|
+    gem "install #{name}" \
+        " --version #{version}" \
+        ' --no-ri --no-rdoc', env: env
+  end
 end

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -35,7 +35,7 @@ build do
     'hashie'       => '2.0.0',
     'varia_model'  => '0.3.2',
     'i18n'         => '0.6.11',
-    'berkshelf'    => "#{version}"
+    'berkshelf'    => "#{version}",
   }
 
   gems.map do |name, version|

--- a/config/software/binutils.rb
+++ b/config/software/binutils.rb
@@ -14,14 +14,15 @@
 # limitations under the License.
 #
 
-name "binutils"
-default_version "2.25-tdm64-1"
+name 'binutils'
+default_version '2.25-tdm64-1'
 
-dependency "msys-base"
+dependency 'msys-base'
 
 source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-#{version}.tar.lzma"
-version("2.25-tdm64-1") { source sha256: "4722bb7b4d46cef714234109e25e5d1cfd29f4e53365b6d615c8a00735f60e40" }
+
+version('2.25-tdm64-1') { source sha256: '4722bb7b4d46cef714234109e25e5d1cfd29f4e53365b6d615c8a00735f60e40' }
 
 build do
-  copy "*", "#{install_dir}/embedded"
+  copy '*', "#{install_dir}/embedded"
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "bundler"
+name 'bundler'
 
-dependency "rubygems"
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   v_opts = "--version '#{version}'" unless version.nil?
   gem [
-    "install bundler",
+    'install bundler',
     v_opts,
-    "--no-ri --no-rdoc",
-  ].compact.join(" "), env: env
+    '--no-ri --no-rdoc'
+  ].compact.join(' '), env: env
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -25,6 +25,6 @@ build do
   gem [
     'install bundler',
     v_opts,
-    '--no-ri --no-rdoc'
+    '--no-ri --no-rdoc',
   ].compact.join(' '), env: env
 end

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -17,11 +17,11 @@
 # This library object is required for building Python with the bz2 module,
 # and should be picked up automatically when building Python.
 
-name "bzip2"
-default_version "1.0.6"
+name 'bzip2'
+default_version '1.0.6'
 
-dependency "zlib"
-dependency "openssl"
+dependency 'zlib'
+dependency 'openssl'
 
 source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz"
 
@@ -33,7 +33,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   # Avoid warning where .rodata cannot be used when making a shared object
-  env["CFLAGS"] << " -fPIC"
+  env['CFLAGS'] << ' -fPIC'
 
   # The list of arguments to pass to make
   args = "PREFIX='#{install_dir}/embedded' VERSION='#{version}'"

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -23,10 +23,9 @@ default_version "1.0.6"
 dependency "zlib"
 dependency "openssl"
 
-version "1.0.6" do
-  source md5: "00b516f4704d4a7cb50a1d97e6e8e15b"
-end
 source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz"
+
+version('1.0.6') { source md5: '00b516f4704d4a7cb50a1d97e6e8e15b' }
 
 relative_path "#{name}-#{version}"
 

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -14,18 +14,17 @@
 # limitations under the License.
 #
 
-name "cacerts"
+name 'cacerts'
 
-default_version "2016.01.20"
+default_version '2016.01.20'
 
-version "2016.01.20" do
-  source md5: "36eee0e80373937dd90a9a334ae42817"
-  source url: "https://raw.githubusercontent.com/bagder/ca-bundle/dfcc02c918b7bf40ed3a7f27a634c74ef4e80829/ca-bundle.crt"
+version '2016.01.20' do
+  source md5: '36eee0e80373937dd90a9a334ae42817',
+         url: 'https://raw.githubusercontent.com/bagder/ca-bundle/dfcc02c918b7bf40ed3a7f27a634c74ef4e80829/ca-bundle.crt'
 end
-
-version "2015.10.28" do
-  source md5: "3c58c3f2435598a942dc37cdb02a3ec3"
-  source url: "https://raw.githubusercontent.com/bagder/ca-bundle/86347ecbdc2277f365d02f0d208b822a214e012d/ca-bundle.crt"
+version '2015.10.28' do
+  source md5: '3c58c3f2435598a942dc37cdb02a3ec3',
+         url: 'https://raw.githubusercontent.com/bagder/ca-bundle/86347ecbdc2277f365d02f0d208b822a214e012d/ca-bundle.crt'
 end
 
 relative_path "cacerts-#{version}"
@@ -36,7 +35,7 @@ build do
   # Append the 1024bit Verisign certs so that S3 continues to work
   block do
     unless File.foreach("#{project_dir}/ca-bundle.crt").grep(/^Verisign Class 3 Public Primary Certification Authority$/).any?
-      File.open("#{project_dir}/ca-bundle.crt", "a") { |fd| fd.write(VERISIGN_CERTS) }
+      File.open("#{project_dir}/ca-bundle.crt', 'a") { |fd| fd.write(VERISIGN_CERTS) }
     end
   end
 

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -14,18 +14,18 @@
 # limitations under the License.
 #
 
-name "chef-gem"
-default_version "11.12.2"
+name 'chef-gem'
+default_version '11.12.2'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "libffi"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'libffi'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install chef" \
+  gem 'install chef' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-aws"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-aws.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+source git: 'https://github.com/chef/chef-provisioning-aws.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -14,22 +14,22 @@
 # limitations under the License.
 #
 
-name "chef-provisioning-aws"
-default_version "master"
+name 'chef-provisioning-aws'
+default_version 'master'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
 source git: 'https://github.com/chef/chef-provisioning-aws.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-provisioning-aws.gemspec", env: env
-  gem "install chef-provisioning-aws-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-provisioning-aws.gemspec', env: env
+  gem 'install chef-provisioning-aws-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "chef-provisioning-azure"
-default_version "master"
+name 'chef-provisioning-azure'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -27,9 +27,9 @@ source git: 'https://github.com/chef/chef-provisioning-azure.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-provisioning-azure.gemspec", env: env
-  gem "install chef-provisioning-azure-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-provisioning-azure.gemspec', env: env
+  gem 'install chef-provisioning-azure-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-azure"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-azure.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
+source git: 'https://github.com/chef/chef-provisioning-azure.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -17,7 +17,6 @@
 name "chef-provisioning-fog"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-fog.git"
 
 dependency "ruby"
 dependency "rubygems"
@@ -25,6 +24,7 @@ dependency "nokogiri"
 dependency "bundler"
 dependency "chef"
 
+source git: 'https://github.com/chef/chef-provisioning-fog.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -14,24 +14,23 @@
 # limitations under the License.
 #
 
-name "chef-provisioning-fog"
-default_version "master"
+name 'chef-provisioning-fog'
+default_version 'master'
 
-
-dependency "ruby"
-dependency "rubygems"
-dependency "nokogiri"
-dependency "bundler"
-dependency "chef"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'nokogiri'
+dependency 'bundler'
+dependency 'chef'
 
 source git: 'https://github.com/chef/chef-provisioning-fog.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-provisioning-fog.gemspec", env: env
-  gem "install chef-provisioning-fog-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-provisioning-fog.gemspec', env: env
+  gem 'install chef-provisioning-fog-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -14,22 +14,22 @@
 # limitations under the License.
 #
 
-name "chef-provisioning-vagrant"
-default_version "master"
+name 'chef-provisioning-vagrant'
+default_version 'master'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
 source git: 'https://github.com/chef/chef-provisioning-vagrant.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-provisioning-vagrant.gemspec", env: env
-  gem "install chef-provisioning-vagrant-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-provisioning-vagrant.gemspec', env: env
+  gem 'install chef-provisioning-vagrant-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-vagrant"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-vagrant.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+source git: 'https://github.com/chef/chef-provisioning-vagrant.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
+source git: 'https://github.com/chef/chef-provisioning.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "chef-provisioning"
-default_version "master"
+name 'chef-provisioning'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -27,9 +27,9 @@ source git: 'https://github.com/chef/chef-provisioning.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-provisioning.gemspec", env: env
-  gem "install chef-provisioning-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-provisioning.gemspec', env: env
+  gem 'install chef-provisioning-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -29,9 +29,9 @@ relative_path 'chef-vault'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chef-vault.gemspec", env: env
-  gem "install chef-vault-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chef-vault.gemspec', env: env
+  gem 'install chef-vault-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "chef-vault"
-default_version "master"
+name 'chef-vault'
+default_version 'master'
 
-source git: "https://github.com/chef/chef-vault.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-relative_path "chef-vault"
+source git: 'https://github.com/chef/chef-vault.git'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
+relative_path 'chef-vault'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-name "chef"
-default_version "master"
+name 'chef'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -57,7 +57,7 @@ build do
 
   # Install components that live inside Chef's git repo. For now this is just
   # 'chef-config'
-  bundle "exec rake install_components", env: env
+  bundle 'exec rake install_components', env: env
 
   gemspec_name = windows? ? 'chef-windows.gemspec' : 'chef.gemspec'
 
@@ -66,12 +66,12 @@ build do
   gem "build #{gemspec_name}", env: env
 
   # Don't use -n #{install_dir}/bin. Appbundler will take care of them later
-  gem "install chef*.gem --no-ri --no-rdoc --verbose", env: env
+  gem 'install chef*.gem --no-ri --no-rdoc --verbose', env: env
 
   # Always deploy the powershell modules in the correct place.
   if windows?
     mkdir "#{install_dir}/modules/chef"
-    copy "distro/powershell/chef/*", "#{install_dir}/modules/chef"
+    copy 'distro/powershell/chef/*', "#{install_dir}/modules/chef"
   end
 
   auxiliary_gems = {}

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -16,10 +16,16 @@
 name "chef"
 default_version "master"
 
-# For the specific super-special version "local_source", build the source from
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'ohai'
+dependency 'appbundler'
+
+# For the specific super-special version 'local_source', build the source from
 # the local git checkout. This is what you'd want to occur by default if you
 # just ran omnibus build locally.
-version("local_source") do
+version('local_source') do
   source path: "#{project.files_path}/../..",
          # Since we are using the local repo, we try to not copy any files
          # that are generated in the process of bundle installing omnibus.
@@ -28,23 +34,17 @@ version("local_source") do
          # omnibus cache source directory, but we do this regardless
          # to maintain consistency between what a local build sees and
          # what a github based build will see.
-         options: { exclude: [ "omnibus/vendor" ] }
+         options: { exclude: [ 'omnibus/vendor' ] }
 end
 
-# For any version other than "local_source", fetch from github.
+# For any version other than 'local_source', fetch from github.
 # This is the behavior the transitive omnibus software deps such as chef-dk
 # expect.
-if version != "local_source"
-  source git: "https://github.com/chef/chef.git"
+if version != 'local_source'
+  source git: 'https://github.com/chef/chef.git'
 end
 
-relative_path "chef"
-
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "ohai"
-dependency "appbundler"
+relative_path 'chef'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -28,9 +28,9 @@ source git: 'https://github.com/sethvargo/chefspec.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build chefspec.gemspec", env: env
-  gem "install chefspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build chefspec.gemspec', env: env
+  gem 'install chefspec-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
-name "chefspec"
-default_version "master"
+name 'chefspec'
+default_version 'master'
 
-source git: "https://github.com/sethvargo/chefspec.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
+dependency 'fauxhai'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
-dependency "fauxhai"
+source git: 'https://github.com/sethvargo/chefspec.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/clean-static-libs.rb
+++ b/config/software/clean-static-libs.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "clean-static-libs"
-description "cleanup un-needed static libraries from the build"
+name 'clean-static-libs'
+description 'cleanup un-needed static libraries from the build'
 default_version '1.0.0'
 
 build do
   # Remove static object files for all platforms
   # except AIX which uses them at runtime.
   unless aix?
-    block "Remove static libraries" do
+    block 'Remove static libraries' do
       # find the embedded ruby gems dir and clean it up for globbing
-      target_dir = "#{install_dir}/embedded/lib/ruby/gems".gsub(/\\/, '/')
+      target_dir = "#{install_dir}/embedded/lib/ruby/gems".tr('\\', '/')
 
       # find all the static *.a files and delete them
       Dir.glob("#{target_dir}/**/*.a").each do |f|

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "cpanminus"
-default_version "1.7004"
+name 'cpanminus'
+default_version '1.7004'
 
 dependency 'perl'
 
@@ -29,5 +29,5 @@ relative_path "cpanminus-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "cat cpanm | perl - App::cpanminus", env: env
+  command 'cat cpanm | perl - App::cpanminus', env: env
 end

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -17,17 +17,12 @@
 name "cpanminus"
 default_version "1.7004"
 
-dependency "perl"
-
-version "1.7040" do
-  source md5: "4fabebffe22eaaf584b345b082a8a9c1"
-end
-
-version "1.7004" do
-  source md5: "02fe90392f33a12979e188ea110dae67"
-end
+dependency 'perl'
 
 source url: "https://github.com/miyagawa/cpanminus/archive/#{version}.tar.gz"
+
+version('1.7040') { source md5: '4fabebffe22eaaf584b345b082a8a9c1' }
+version('1.7004') { source md5: '02fe90392f33a12979e188ea110dae67' }
 
 relative_path "cpanminus-#{version}"
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "curl"
-default_version "7.47.1"
+name 'curl'
+default_version '7.47.1'
 
 dependency 'zlib'
 dependency 'openssl'
@@ -32,38 +32,38 @@ build do
 
   if freebsd?
     # from freebsd ports - IPv6 Hostcheck patch
-    patch source: "curl-freebsd-hostcheck.patch", plevel: 1, env: env
+    patch source: 'curl-freebsd-hostcheck.patch', plevel: 1, env: env
   end
 
   delete "#{project_dir}/src/tool_hugehelp.c"
 
   if aix?
     # otherwise gawk will die during ./configure with variations on the theme of:
-    # "/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded"
-    env["LIBPATH"] = "/usr/lib:/lib"
+    # '/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded'
+    env['LIBPATH'] = '/usr/lib:/lib'
   end
 
   configure_command = [
-    "./configure",
+    './configure',
     "--prefix=#{install_dir}/embedded",
-    "--disable-manual",
-    "--disable-debug",
-    "--enable-optimize",
-    "--disable-ldap",
-    "--disable-ldaps",
-    "--disable-rtsp",
-    "--enable-proxy",
-    "--disable-dependency-tracking",
-    "--enable-ipv6",
-    "--without-libidn",
-    "--without-gnutls",
-    "--without-librtmp",
+    '--disable-manual',
+    '--disable-debug',
+    '--enable-optimize',
+    '--disable-ldap',
+    '--disable-ldaps',
+    '--disable-rtsp',
+    '--enable-proxy',
+    '--disable-dependency-tracking',
+    '--enable-ipv6',
+    '--without-libidn',
+    '--without-gnutls',
+    '--without-librtmp',
     "--with-ssl=#{install_dir}/embedded",
-    "--with-zlib=#{install_dir}/embedded",
+    "--with-zlib=#{install_dir}/embedded"
   ]
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -17,18 +17,13 @@
 name "curl"
 default_version "7.47.1"
 
-dependency "zlib"
-dependency "openssl"
-
-version "7.47.1" do
-  source md5: "3f9d1be7bf33ca4b8c8602820525302b"
-end
-
-version "7.36.0" do
-  source md5: "643a7030b27449e76413d501d4b8eb57"
-end
+dependency 'zlib'
+dependency 'openssl'
 
 source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz"
+
+version('7.47.1') { source md5: '3f9d1be7bf33ca4b8c8602820525302b' }
+version('7.36.0') { source md5: '643a7030b27449e76413d501d4b8eb57' }
 
 relative_path "curl-#{version}"
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -59,7 +59,7 @@ build do
     '--without-gnutls',
     '--without-librtmp',
     "--with-ssl=#{install_dir}/embedded",
-    "--with-zlib=#{install_dir}/embedded"
+    "--with-zlib=#{install_dir}/embedded",
   ]
 
   command configure_command.join(' '), env: env

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "dep-selector-libgecode"
-default_version "1.0.2"
+name 'dep-selector-libgecode'
+default_version '1.0.2'
 
-dependency "rubygems"
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -26,15 +26,15 @@ build do
   # need to use 4.4, which is provided by the gcc44 and gcc44-c++ packages.
   # These do not use the gcc binaries so we set the flags to point to the
   # correct version here.
-  if File.exist?("/usr/bin/gcc44")
-    env["CC"]  = "gcc44"
-    env["CXX"] = "g++44"
+  if File.exist?('/usr/bin/gcc44')
+    env['CC']  = 'gcc44'
+    env['CXX'] = 'g++44'
   end
 
   # Ruby DevKit ships with BSD Tar
-  env["PROG_TAR"] = "bsdtar" if windows?
+  env['PROG_TAR'] = 'bsdtar' if windows?
 
-  gem "install dep-selector-libgecode" \
+  gem 'install dep-selector-libgecode' \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name "erlang"
-default_version "R15B03-1"
+name 'erlang'
+default_version 'R15B03-1'
 
-dependency "zlib"
-dependency "openssl"
-dependency "ncurses"
+dependency 'zlib'
+dependency 'openssl'
+dependency 'ncurses'
 
 source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 
@@ -40,8 +40,8 @@ relative_path "otp_src_#{version.split('-')[0]}"
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
     # WARNING!
-    "CFLAGS"  => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
-    "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
+    'CFLAGS'  => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
+    'LDFLAGS' => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include"
   )
   env.delete('CPPFLAGS')
 
@@ -58,18 +58,18 @@ build do
     link "#{install_dir}/embedded/include/#{name}", "#{install_dir}/embedded/erlang/include/#{name}"
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --enable-threads" \
-          " --enable-smp-support" \
-          " --enable-kernel-poll" \
-          " --enable-dynamic-ssl-lib" \
-          " --enable-shared-zlib" \
-          " --enable-hipe" \
-          " --without-javac" \
+          ' --enable-threads' \
+          ' --enable-smp-support' \
+          ' --enable-kernel-poll' \
+          ' --enable-dynamic-ssl-lib' \
+          ' --enable-shared-zlib' \
+          ' --enable-hipe' \
+          ' --without-javac' \
           " --with-ssl=#{install_dir}/embedded" \
-          " --disable-debug", env: env
+          ' --disable-debug', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -41,7 +41,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
     # WARNING!
     'CFLAGS'  => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
-    'LDFLAGS' => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include"
+    'LDFLAGS' => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
   )
   env.delete('CPPFLAGS')
 

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -23,55 +23,19 @@ dependency "ncurses"
 
 source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 
-version "R15B03-1" do
-  source md5:   "eccd1e6dda6132993555e088005019f2"
-  relative_path "otp_src_R15B03"
-end
+version('R15B03-1') { source md5: 'eccd1e6dda6132993555e088005019f2' }
+version('R16B03-1') { source md5: 'e5ece977375197338c1b93b3d88514f8' }
+version('R15B02')   { source md5: 'ccbe5e032a2afe2390de8913bfe737a1' }
+version('17.0')     { source md5: 'a5f78c1cf0eb7724de3a59babc1a28e5' }
+version('17.1')     { source md5: '9c90706ce70e01651adde34a2b79bf4c' }
+version('17.3')     { source md5: '1d0bb2d54dfe1bb6844756b99902ba20' }
+version('17.4')     { source md5: '3d33c4c6bd7950240dcd7479edd9c7d8' }
+version('17.5')     { source md5: '346dd0136bf1cc28cebc140e505206bb' }
+version('18.1')     { source md5: 'fa64015fdd133e155b5b19bf90ac8678' }
+version('18.2')     { source md5: 'b336d2a8ccfbe60266f71d102e99f7ed' }
 
-version "R16B03-1" do
-  source md5:   "e5ece977375197338c1b93b3d88514f8"
-  relative_path "otp_src_#{version}"
-end
-
-version "R15B02" do
-  source md5:   "ccbe5e032a2afe2390de8913bfe737a1"
-  relative_path "otp_src_#{version}"
-end
-
-version '17.0' do
-  source md5: 'a5f78c1cf0eb7724de3a59babc1a28e5'
-  relative_path 'otp_src_17.0'
-end
-
-version '17.1' do
-  source md5: '9c90706ce70e01651adde34a2b79bf4c'
-  relative_path 'otp_src_17.1'
-end
-
-version '17.3' do
-  source md5: '1d0bb2d54dfe1bb6844756b99902ba20'
-  relative_path 'otp_src_17.3'
-end
-
-version '17.4' do
-  source md5: '3d33c4c6bd7950240dcd7479edd9c7d8'
-  relative_path 'otp_src_17.4'
-end
-
-version '17.5' do
-  source md5: '346dd0136bf1cc28cebc140e505206bb'
-  relative_path 'otp_src_17.5'
-end
-
-version '18.1' do
-  source md5: 'fa64015fdd133e155b5b19bf90ac8678'
-  relative_path 'otp_src_18.1'
-end
-
-version '18.2' do
-  source md5: 'b336d2a8ccfbe60266f71d102e99f7ed'
-  relative_path 'otp_src_18.2'
-end
+# below produces 'otp_src_R15B03' given version = 'R15B03-1'
+relative_path "otp_src_#{version.split('-')[0]}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -17,10 +17,11 @@
 name "expat"
 default_version "2.1.0"
 
-relative_path "expat-#{version}"
+source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+version('2.1.0') { source md5: 'dd7dab7a5fea97d2a6a43f511449b7cd' }
+
+relative_path "expat-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "expat"
-default_version "2.1.0"
+name 'expat'
+default_version '2.1.0'
 
 source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz"
 
@@ -26,9 +26,9 @@ relative_path "expat-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -14,22 +14,22 @@
 # limitations under the License.
 #
 
-name "fauxhai"
-default_version "master"
+name 'fauxhai'
+default_version 'master'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
 source git: 'https://github.com/customink/fauxhai.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build fauxhai.gemspec", env: env
-  gem "install fauxhai-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build fauxhai.gemspec', env: env
+  gem 'install fauxhai-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -17,12 +17,12 @@
 name "fauxhai"
 default_version "master"
 
-source git: "https://github.com/customink/fauxhai.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+source git: 'https://github.com/customink/fauxhai.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -18,13 +18,13 @@ name "ffi-yajl"
 default_version "master"
 relative_path "ffi-yajl"
 
-source git: "https://github.com/opscode/ffi-yajl.git"
 
 dependency "ruby"
 
 dependency "rubygems"
 dependency "libyajl2-gem"
 dependency "bundler"
+source git: 'https://github.com/opscode/ffi-yajl.git'
 
 build do
   env = with_embedded_path()

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -14,26 +14,25 @@
 # limitations under the License.
 #
 
-name "ffi-yajl"
-default_version "master"
-relative_path "ffi-yajl"
+name 'ffi-yajl'
+default_version 'master'
+relative_path 'ffi-yajl'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'libyajl2-gem'
+dependency 'bundler'
 
-dependency "ruby"
-
-dependency "rubygems"
-dependency "libyajl2-gem"
-dependency "bundler"
 source git: 'https://github.com/opscode/ffi-yajl.git'
 
 build do
   env = with_embedded_path()
 
-  bundle "install --without development_extras", env: env
-  bundle "exec rake gem", env: env
+  bundle 'install --without development_extras', env: env
+  bundle 'exec rake gem', env: env
 
-  delete "pkg/*java*"
+  delete 'pkg/*java*'
 
-  gem "install pkg/ffi-yajl-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'install pkg/ffi-yajl-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/figlet-fonts.rb
+++ b/config/software/figlet-fonts.rb
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name "figlet-fonts"
-default_version "master"
+name 'figlet-fonts'
+default_version 'master'
 
-dependency "figlet"
+dependency 'figlet'
 
-source git: "https://github.com/cmatsuoka/figlet-fonts.git"
+source git: 'https://github.com/cmatsuoka/figlet-fonts.git'
 
 relative_path "figlet-fonts-#{version}"
 

--- a/config/software/figlet.rb
+++ b/config/software/figlet.rb
@@ -33,7 +33,7 @@ build do
     env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
     env['CC'] = 'cc_r -q64'
     env['LD'] = 'cc_r -q64'
-    patch source: "aix-figlet-cdefs.patch", plevel: 0, env: env
+    patch source: 'aix-figlet-cdefs.patch', plevel: 0, env: env
   end
 
   mkdir "#{install_dir}/share/figlet/fonts"

--- a/config/software/figlet.rb
+++ b/config/software/figlet.rb
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name "figlet"
-default_version "2.2.5"
-
-version("2.2.5") { source md5: "eaaeb356007755c9770a842aefd8ed5f" }
+name 'figlet'
+default_version '2.2.5'
 
 source url: "https://github.com/cmatsuoka/figlet/archive/#{version}.tar.gz"
+
+version('2.2.5') { source md5: 'eaaeb356007755c9770a842aefd8ed5f' }
 
 relative_path "figlet-#{version}"
 

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -17,13 +17,13 @@
 name "foodcritic"
 default_version "v6.0.0"
 
-source git: "https://github.com/acrmp/foodcritic.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "nokogiri"
 dependency "chef"
+source git: 'https://github.com/acrmp/foodcritic.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -14,23 +14,23 @@
 # limitations under the License.
 #
 
-name "foodcritic"
-default_version "v6.0.0"
+name 'foodcritic'
+default_version 'v6.0.0'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'nokogiri'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "nokogiri"
-dependency "chef"
 source git: 'https://github.com/acrmp/foodcritic.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build foodcritic.gemspec", env: env
-  gem "install foodcritic-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build foodcritic.gemspec', env: env
+  gem 'install foodcritic-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "gcc"
-default_version "4.9.2"
+name 'gcc'
+default_version '4.9.2'
 
 dependency 'gmp'
 dependency 'mpfr'
@@ -33,15 +33,15 @@ relative_path "gcc-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                      "--prefix=#{install_dir}/embedded",
-                     "--disable-nls",
-                     "--enable-languages=c,c++",
-                     "--with-as=/usr/ccs/bin/as",
-                     "--with-ld=/usr/ccs/bin/ld"]
+                     '--disable-nls',
+                     '--enable-languages=c,c++',
+                     '--with-as=/usr/ccs/bin/as',
+                     '--with-ld=/usr/ccs/bin/ld']
 
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
   # gcc takes quite a long time to build (over 2 hours) so we're setting the mixlib shellout
   # timeout to 4 hours. It's not great but it's required (on solaris at least, need to verify
   # on any other platforms we may use this with)

--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -17,17 +17,16 @@
 name "gcc"
 default_version "4.9.2"
 
-dependency "gmp"
-dependency "mpfr"
-dependency "mpc"
-dependency "libiconv"
-
-version("4.9.3")      { source md5: "648bfba342bb41a4b5350fb685f85bc5" }
-version("4.9.2")      { source md5: "76f464e0511c26c93425a9dcdc9134cf" }
-
-version("5.3.0")      { source md5: "39b5b6a0e769716a8e0a339adc79d8ad" }
+dependency 'gmp'
+dependency 'mpfr'
+dependency 'mpc'
+dependency 'libiconv'
 
 source url: "https://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
+
+version('4.9.3') { source md5: '648bfba342bb41a4b5350fb685f85bc5' }
+version('4.9.2') { source md5: '76f464e0511c26c93425a9dcdc9134cf' }
+version('5.3.0') { source md5: '39b5b6a0e769716a8e0a339adc79d8ad' }
 
 relative_path "gcc-#{version}"
 

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -17,10 +17,13 @@
 name "gdbm"
 default_version "1.8.3"
 
-# Version 1.9 and above are GPLv3, do NOT add later versions in
-version("1.8.3") { source md5: "1d1b1d5c0245b1c00aff92da751e9aa1" }
+name 'gdbm'
+default_version '1.8.3'
 
 source url: "https://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
+
+# Version 1.9 and above are GPLv3, do NOT add later versions in
+version('1.8.3') { source md5: '1d1b1d5c0245b1c00aff92da751e9aa1' }
 
 relative_path "gdbm-#{version}"
 

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-name "gdbm"
-default_version "1.8.3"
-
 name 'gdbm'
 default_version '1.8.3'
 
@@ -30,26 +27,26 @@ relative_path "gdbm-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if version == "1.8.3"
-    patch source: "v1.8.3-Makefile.in.patch", plevel: 0, env: env
+  if version == '1.8.3'
+    patch source: 'v1.8.3-Makefile.in.patch', plevel: 0, env: env
   end
 
   # Update config.guess to support newer platforms (like aarch64)
-  if version == "1.8.3"
-    patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
+  if version == '1.8.3'
+    patch source: 'config.guess_2015-09-14.patch', plevel: 0, env: env
   end
 
   if freebsd?
-    command "./configure" \
-            " --enable-libgdbm-compat" \
-            " --with-pic" \
+    command './configure' \
+            ' --enable-libgdbm-compat' \
+            ' --with-pic' \
             " --prefix=#{install_dir}/embedded", env: env
   else
-    command "./configure" \
-            " --enable-libgdbm-compat" \
+    command './configure' \
+            ' --enable-libgdbm-compat' \
             " --prefix=#{install_dir}/embedded", env: env
   end
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/gecode.rb
+++ b/config/software/gecode.rb
@@ -17,20 +17,13 @@
 name "gecode"
 default_version "3.7.3"
 
-version "3.7.3" do
-  source md5: "7a5cb9945e0bb48f222992f2106130ac"
-end
+source url: "http://www.gecode.org/download/gecode-#{version}.tar.gz"
 
-version "3.7.1" do
-  source md5: "b4191d8cfafa18bd9b78594544be2a04"
-end
+version('3.7.3') { source md5: '7a5cb9945e0bb48f222992f2106130ac' }
+version('3.7.1') { source md5: 'b4191d8cfafa18bd9b78594544be2a04' }
 
 # Major version, have not tried yet
-version "4.4.0" do
-  source md5: "a892852927b12ed291b435c72c085834"
-end
-
-source url: "http://www.gecode.org/download/gecode-#{version}.tar.gz"
+version('4.4.0') { source md5: 'a892852927b12ed291b435c72c085834' }
 
 relative_path "gecode-#{version}"
 

--- a/config/software/gecode.rb
+++ b/config/software/gecode.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "gecode"
-default_version "3.7.3"
+name 'gecode'
+default_version '3.7.3'
 
 source url: "http://www.gecode.org/download/gecode-#{version}.tar.gz"
 
@@ -34,21 +34,21 @@ build do
   # need to use 4.4, which is provided by the gcc44 and gcc44-c++ packages.
   # These do not use the gcc binaries so we set the flags to point to the
   # correct version here.
-  if File.exist?("/usr/bin/gcc44")
-    env["CC"]  = "gcc44"
-    env["CXX"] = "g++44"
+  if File.exist?('/usr/bin/gcc44')
+    env['CC']  = 'gcc44'
+    env['CXX'] = 'g++44'
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-doc-dot" \
-          " --disable-doc-search" \
-          " --disable-doc-tagfile" \
-          " --disable-doc-chm" \
-          " --disable-doc-docset" \
-          " --disable-qt" \
-          " --disable-examples", env: env
+          ' --disable-doc-dot' \
+          ' --disable-doc-search' \
+          ' --disable-doc-tagfile' \
+          ' --disable-doc-chm' \
+          ' --disable-doc-docset' \
+          ' --disable-qt' \
+          ' --disable-examples', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -24,29 +24,15 @@ dependency "pcre"
 dependency "libiconv"
 dependency "expat"
 
+source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
+
 relative_path "git-#{version}"
 
-version "2.7.1" do
-  source md5: "846ac45a1638e9a6ff3a9b790f6c8d99"
-end
-
-version "2.6.2" do
-  source md5: "da293290da69f45a86a311ad3cd43dc8"
-end
-
-version "2.2.1" do
-  source md5: "ff41fdb094eed1ec430aed8ee9b9849c"
-end
-
-version "1.9.5" do
-  source md5: "e9c82e71bec550e856cccd9548902885"
-end
-
-version "1.9.0" do
-  source md5: "0e00839539fc43cd2c350589744f254a"
-end
-
-source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
+version('2.7.1') { source md5: '846ac45a1638e9a6ff3a9b790f6c8d99' }
+version('2.6.2') { source md5: 'da293290da69f45a86a311ad3cd43dc8' }
+version('2.2.1') { source md5: 'ff41fdb094eed1ec430aed8ee9b9849c' }
+version('1.9.5') { source md5: 'e9c82e71bec550e856cccd9548902885' }
+version('1.9.0') { source md5: '0e00839539fc43cd2c350589744f254a' }
 
 build do
 

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -53,7 +53,7 @@ build do
     'ICONVDIR'   => "#{install_dir}/embedded",
     'LIBPCREDIR' => "#{install_dir}/embedded",
     'OPENSSLDIR' => "#{install_dir}/embedded",
-    'ZLIB_PATH'  => "#{install_dir}/embedded"
+    'ZLIB_PATH'  => "#{install_dir}/embedded",
   )
 
   # AIX needs /opt/freeware/bin only for patch

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "git"
-default_version "1.9.5"
+name 'git'
+default_version '1.9.5'
 
-dependency "curl"
-dependency "zlib"
-dependency "openssl"
-dependency "pcre"
-dependency "libiconv"
-dependency "expat"
+dependency 'curl'
+dependency 'zlib'
+dependency 'openssl'
+dependency 'pcre'
+dependency 'libiconv'
+dependency 'expat'
 
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
@@ -35,26 +35,25 @@ version('1.9.5') { source md5: 'e9c82e71bec550e856cccd9548902885' }
 version('1.9.0') { source md5: '0e00839539fc43cd2c350589744f254a' }
 
 build do
-
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    "NEEDS_LIBICONV"       => "1",
-    "NO_GETTEXT"           => "1",
-    "NO_PYTHON"            => "1",
+    'NEEDS_LIBICONV'       => '1',
+    'NO_GETTEXT'           => '1',
+    'NO_PYTHON'            => '1',
     # Disabling perl - we don't currently need any of the provided
     # functionality: https://github.com/git/git/blob/563e38491eaee6e02643a22c9503d4f774d6c5be/INSTALL#L102-L109
     # Perl on certain platforms (like OSX) brings along libgcc as a dependency,
     # which we'd like to avoid.
-    "NO_PERL"              => "1",
-    "NO_R_TO_GCC_LINKER"   => "1",
-    "NO_TCLTK"             => "1",
-    "NO_INSTALL_HARDLINKS" => "1",
+    'NO_PERL'              => '1',
+    'NO_R_TO_GCC_LINKER'   => '1',
+    'NO_TCLTK'             => '1',
+    'NO_INSTALL_HARDLINKS' => '1',
 
-    "CURLDIR"    => "#{install_dir}/embedded",
-    "EXPATDIR"   => "#{install_dir}/embedded",
-    "ICONVDIR"   => "#{install_dir}/embedded",
-    "LIBPCREDIR" => "#{install_dir}/embedded",
-    "OPENSSLDIR" => "#{install_dir}/embedded",
-    "ZLIB_PATH"  => "#{install_dir}/embedded",
+    'CURLDIR'    => "#{install_dir}/embedded",
+    'EXPATDIR'   => "#{install_dir}/embedded",
+    'ICONVDIR'   => "#{install_dir}/embedded",
+    'LIBPCREDIR' => "#{install_dir}/embedded",
+    'OPENSSLDIR' => "#{install_dir}/embedded",
+    'ZLIB_PATH'  => "#{install_dir}/embedded"
   )
 
   # AIX needs /opt/freeware/bin only for patch
@@ -64,28 +63,28 @@ build do
 
     # But only needs the below for 1.9.5
     if version == '1.9.5'
-      patch source: "aix-strcmp-in-dirc.patch", plevel: 1, env: patch_env
+      patch source: 'aix-strcmp-in-dirc.patch', plevel: 1, env: patch_env
     end
 
     # this may be needed for 2.6.2 as well, but 2.6.2 won't compile
     # on AIX for other reasons.
     if version <= '2.2.1'
-      patch source: "aix-use-freeware-install.patch", plevel: 1, env: patch_env
+      patch source: 'aix-use-freeware-install.patch', plevel: 1, env: patch_env
     end
   end
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                        "--prefix=#{install_dir}/embedded"]
 
   if freebsd?
-    configure_command << "--enable-pthreads=-pthread"
-    configure_command << "ac_cv_header_libcharset_h=no"
+    configure_command << '--enable-pthreads=-pthread'
+    configure_command << 'ac_cv_header_libcharset_h=no'
     configure_command << "--with-curl=#{install_dir}/embedded"
     configure_command << "--with-expat=#{install_dir}/embedded"
   end
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/gmp.rb
+++ b/config/software/gmp.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "gmp"
-default_version "6.0.0a"
-
-version("6.1.0")  { source md5: "86ee6e54ebfc4a90b643a65e402c4048" }
-version("6.0.0a") { source md5: "b7ff2d88cae7f8085bd5006096eed470" }
+name 'gmp'
+default_version '6.0.0a'
 
 source url: "https://ftp.gnu.org/gnu/gmp/gmp-#{version}.tar.bz2"
 
-if version == "6.0.0a"
+version('6.1.0')  { source md5: '86ee6e54ebfc4a90b643a65e402c4048' }
+version('6.0.0a') { source md5: 'b7ff2d88cae7f8085bd5006096eed470' }
+
+if version == '6.0.0a'
   # version 6.0.0a expands to 6.0.0
   relative_path "gmp-6.0.0"
 else

--- a/config/software/gmp.rb
+++ b/config/software/gmp.rb
@@ -24,7 +24,7 @@ version('6.0.0a') { source md5: 'b7ff2d88cae7f8085bd5006096eed470' }
 
 if version == '6.0.0a'
   # version 6.0.0a expands to 6.0.0
-  relative_path "gmp-6.0.0"
+  relative_path 'gmp-6.0.0'
 else
   relative_path "gmp-#{version}"
 end
@@ -33,13 +33,13 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if solaris2?
-    env['ABI'] = "32"
+    env['ABI'] = '32'
   end
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                        "--prefix=#{install_dir}/embedded"]
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 end

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "help2man"
-default_version "1.40.5"
+name 'help2man'
+default_version '1.40.5'
 
 source url: "https://ftp.gnu.org/gnu/help2man/help2man-#{version}.tar.gz"
 
 version('1.47.3') { source md5: 'd1d44a7a7b2bd61755a2045d96ecaea0' }
 version('1.40.5') { source md5: '75a7d2f93765cd367aab98986a75f88c' }
 
-relative_path "help2man-1.40.5"
+relative_path 'help2man-1.40.5'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -30,5 +30,5 @@ build do
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -17,15 +17,10 @@
 name "help2man"
 default_version "1.40.5"
 
-version "1.47.3" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.47.3.tar.xz",
-         md5: "d1d44a7a7b2bd61755a2045d96ecaea0"
-end
+source url: "https://ftp.gnu.org/gnu/help2man/help2man-#{version}.tar.gz"
 
-version "1.40.5" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
-         md5: "75a7d2f93765cd367aab98986a75f88c"
-end
+version('1.47.3') { source md5: 'd1d44a7a7b2bd61755a2045d96ecaea0' }
+version('1.40.5') { source md5: '75a7d2f93765cd367aab98986a75f88c' }
 
 relative_path "help2man-1.40.5"
 

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "highline-gem"
-default_version "1.6.21"
+name 'highline-gem'
+default_version '1.6.21'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install highline" \
+  gem 'install highline' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -17,11 +17,11 @@
 name "inspec"
 default_version "master"
 
-source git: "https://github.com/chef/inspec.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+source git: 'https://github.com/chef/inspec.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -14,21 +14,21 @@
 # limitations under the License.
 #
 
-name "inspec"
-default_version "master"
+name 'inspec'
+default_version 'master'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 source git: 'https://github.com/chef/inspec.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --with test integration --without tools maintenance", env: env
+  bundle 'install --with test integration --without tools maintenance', env: env
 
-  gem "build inspec.gemspec", env: env
-  gem "install inspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build inspec.gemspec', env: env
+  gem 'install inspec-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-name "keepalived"
-default_version "1.2.9"
+name 'keepalived'
+default_version '1.2.9'
 
-dependency "popt"
-dependency "openssl"
+dependency 'popt'
+dependency 'openssl'
 
 source url: "http://www.keepalived.org/software/keepalived-#{version}.tar.gz"
 
@@ -34,14 +34,14 @@ build do
   # This is cherry-picked from change
   # d384ce8b3492b9d76af23e621a20bed8da9c6016 of keepalived, (master
   # branch), and should be no longer necessary after 1.2.9.
-  if version == "1.2.9"
-    patch source: "keepalived-1.2.9_opscode_centos_5.patch", env: env
+  if version == '1.2.9'
+    patch source: 'keepalived-1.2.9_opscode_centos_5.patch', env: env
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-iconv", env: env
+          ' --disable-iconv', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -22,17 +22,9 @@ dependency "openssl"
 
 source url: "http://www.keepalived.org/software/keepalived-#{version}.tar.gz"
 
-version "1.2.19" do
-  source md5: "5c98b06639dd50a6bff76901b53febb6"
-end
-
-version "1.2.9" do
-  source md5: "adfad98a2cc34230867d794ebc633492"
-end
-
-version "1.1.20" do
-  source md5: "6c3065c94bb9e2187c4b5a80f6d8be31"
-end
+version('1.2.19') { source md5: '5c98b06639dd50a6bff76901b53febb6' }
+version('1.2.9')  { source md5: 'adfad98a2cc34230867d794ebc633492' }
+version('1.1.20') { source md5: '6c3065c94bb9e2187c4b5a80f6d8be31' }
 
 relative_path "keepalived-#{version}"
 

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -17,13 +17,13 @@
 name "kitchen-inspec"
 default_version "master"
 
-source git: "https://github.com/chef/kitchen-inspec.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "test-kitchen"
 dependency "inspec"
+source git: 'https://github.com/chef/kitchen-inspec.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -14,23 +14,23 @@
 # limitations under the License.
 #
 
-name "kitchen-inspec"
-default_version "master"
+name 'kitchen-inspec'
+default_version 'master'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'test-kitchen'
+dependency 'inspec'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "test-kitchen"
-dependency "inspec"
 source git: 'https://github.com/chef/kitchen-inspec.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development guard test", env: env
+  bundle 'install --without development guard test', env: env
 
-  gem "build kitchen-inspec.gemspec", env: env
-  gem "install kitchen-inspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build kitchen-inspec.gemspec', env: env
+  gem 'install kitchen-inspec-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "kitchen-vagrant"
-default_version "master"
+name 'kitchen-vagrant'
+default_version 'master'
 
-source git: "https://github.com/test-kitchen/kitchen-vagrant.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'test-kitchen'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "test-kitchen"
+source git: 'https://github.com/test-kitchen/kitchen-vagrant.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -27,9 +27,9 @@ source git: 'https://github.com/test-kitchen/kitchen-vagrant.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development guard test", env: env
+  bundle 'install --without development guard test', env: env
 
-  gem "build kitchen-vagrant.gemspec", env: env
-  gem "install kitchen-vagrant-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build kitchen-vagrant.gemspec', env: env
+  gem 'install kitchen-vagrant-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -17,12 +17,12 @@
 name "knife-spork"
 default_version "master"
 
-source git: "https://github.com/jonlives/knife-spork.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
+source git: 'https://github.com/jonlives/knife-spork.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "knife-spork"
-default_version "master"
+name 'knife-spork'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -27,9 +27,9 @@ source git: 'https://github.com/jonlives/knife-spork.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build knife-spork.gemspec", env: env
-  gem "install knife-spork-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build knife-spork.gemspec', env: env
+  gem 'install knife-spork-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -27,9 +27,9 @@ source git: 'https://github.com/chef/knife-windows.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without test development", env: env
+  bundle 'install --without test development', env: env
 
-  gem "build knife-windows.gemspec", env: env
-  gem "install knife-windows-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build knife-windows.gemspec', env: env
+  gem 'install knife-windows-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "knife-windows"
-default_version "master"
+name 'knife-windows'
+default_version 'master'
 
-source git: "https://github.com/chef/knife-windows.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'chef'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
-dependency "chef"
+source git: 'https://github.com/chef/knife-windows.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -17,8 +17,8 @@
 # A requirement for api.berkshelf.com that is used in berkshelf specs
 # https://github.com/berkshelf/api.berkshelf.com
 
-name "libarchive"
-default_version "3.1.2"
+name 'libarchive'
+default_version '3.1.2'
 
 source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
 
@@ -30,19 +30,19 @@ build do
   env = with_standard_compiler_flags(with_embedded_path, bfd_flags: true)
 
   configure("--prefix=#{install_dir}/embedded",
-            "--without-lzma",
-            "--without-lzo2",
-            "--without-nettle",
-            "--without-xml2",
-            "--without-expat",
-            "--without-bz2lib",
-            "--without-iconv",
-            "--without-zlib",
-            "--disable-bsdtar",
-            "--disable-bsdcpio",
-            "--without-lzmadec",
-            "--without-openssl", env: env)
+            '--without-lzma',
+            '--without-lzo2',
+            '--without-nettle',
+            '--without-xml2',
+            '--without-expat',
+            '--without-bz2lib',
+            '--without-iconv',
+            '--without-zlib',
+            '--disable-bsdtar',
+            '--disable-bsdcpio',
+            '--without-lzmadec',
+            '--without-openssl', env: env)
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -20,8 +20,9 @@
 name "libarchive"
 default_version "3.1.2"
 
-source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
-       md5: 'efad5a503f66329bb9d2f4308b5de98a'
+source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
+
+version('3.1.2') { source md5: 'efad5a503f66329bb9d2f4308b5de98a' }
 
 relative_path "libarchive-#{version}"
 

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -39,18 +39,18 @@ build do
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
   if version.to_i < 20150325 && (freebsd? || openbsd?)
-    patch source: "freebsd-vi-fix.patch", env: env
+    patch source: 'freebsd-vi-fix.patch', env: env
   end
 
   if openbsd?
-    patch source: "openbsd-weak-alias-fix.patch", plevel: 1, env: env
+    patch source: 'openbsd-weak-alias-fix.patch', plevel: 1, env: env
   end
 
-  if version == "20120601-3.0" && ppc64le?
-    patch source: "v20120601-3.0.ppc64le-configure.patch", env: env
+  if version == '20120601-3.0' && ppc64le?
+    patch source: 'v20120601-3.0.ppc64le-configure.patch', env: env
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -14,21 +14,21 @@
 # limitations under the License.
 #
 
-name "libedit"
-default_version "20120601-3.0"
+name 'libedit'
+default_version '20120601-3.0'
 
-dependency "ncurses"
-
-version("20150325-3.1") { source md5: "43cdb5df3061d78b5e9d59109871b4f6" }
-version("20141030-3.1") { source md5: "5f18e63346d31b877cdf36b5c59b810b" }
-version("20130712-3.1") { source md5: "0891336c697362727a1fa7e60c5cb96c" }
-version("20120601-3.0") { source md5: "e50f6a7afb4de00c81650f7b1a0f5aea" }
+dependency 'ncurses'
 
 source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
 
-if version == "20141030-3.1"
+version('20150325-3.1') { source md5: '43cdb5df3061d78b5e9d59109871b4f6' }
+version('20141030-3.1') { source md5: '5f18e63346d31b877cdf36b5c59b810b' }
+version('20130712-3.1') { source md5: '0891336c697362727a1fa7e60c5cb96c' }
+version('20120601-3.0') { source md5: 'e50f6a7afb4de00c81650f7b1a0f5aea' }
+
+if version == '20141030-3.1'
   # released tar file has name discrepency in folder name for this version
-  relative_path "libedit-20141029-3.1"
+  relative_path 'libedit-20141029-3.1'
 else
   relative_path "libedit-#{version}"
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-name "libffi"
+name 'libffi'
 
-default_version "3.2.1"
+default_version '3.2.1'
 
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency 'libtool' unless windows?
@@ -31,7 +31,7 @@ relative_path "libffi-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
-  env['INSTALL'] = "/opt/freeware/bin/install" if aix?
+  env['INSTALL'] = '/opt/freeware/bin/install' if aix?
 
   configure_command = []
 
@@ -39,9 +39,9 @@ build do
   unless aix?
     # Patch to disable multi-os-directory via configure flag (don't use /lib64)
     # Works on all platforms, and is compatible on 32bit platforms as well
-    if version == "3.2.1"
-      patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1, env: env
-      configure_command << "--disable-multi-os-directory"
+    if version == '3.2.1'
+      patch source: 'libffi-3.2.1-disable-multi-os-directory.patch', plevel: 1, env: env
+      configure_command << '--disable-multi-os-directory'
     end
   end
 
@@ -49,12 +49,12 @@ build do
 
   if solaris2?
     # run old make :(
-    make env: env, bin: "/usr/ccs/bin/make"
-    make "install", env: env, bin: "/usr/ccs/bin/make"
+    make env: env, bin: '/usr/ccs/bin/make'
+    make 'install', env: env, bin: '/usr/ccs/bin/make'
   elsif windows?
     # On windows, msys make 3.81 breaks with parallel builds.
     make env: env
-    make "install", env: env
+    make 'install', env: env
   else
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env
@@ -62,5 +62,4 @@ build do
 
   # libffi's default install location of header files is awful...
   copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
-
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -19,12 +19,12 @@ name "libffi"
 default_version "3.2.1"
 
 # Is libtool actually necessary? Doesn't configure generate one?
-dependency "libtool" unless windows?
-
-version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
-version("3.2.1")  { source md5: "83b89587607e3eb65c70d361f13bab43" }
+dependency 'libtool' unless windows?
 
 source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
+
+version('3.0.13') { source md5: '45f3b6dbc9ee7c7dfbbbc5feba571529' }
+version('3.2.1')  { source md5: '83b89587607e3eb65c70d361f13bab43' }
 
 relative_path "libffi-#{version}"
 

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -16,7 +16,7 @@
 
 #
 # NOTE: Instead of depending on this software definition, there is no
-#       reason not to include "-static-libgcc" in your LDFLAGS instead.
+#       reason not to include '-static-libgcc' in your LDFLAGS instead.
 #       That will probably be the best solution going forwards rather than
 #       fuss around with the dynamic linking business here.
 #
@@ -24,28 +24,27 @@
 # # Uncomment the following code to throw a warning when someone depends on this
 # # software definition.
 # Omnibus.logger.deprecated('libgcc') do
-#   "Please do not use the libgcc dependency, it will be removed in the " \
-#   "future. Compile with `--static-libgcc' instead!"
+#   'Please do not use the libgcc dependency, it will be removed in the ' \
+#   'future. Compile with `--static-libgcc' instead!'
 # end
 
-name "libgcc"
-description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
-default_version "0.0.1"
+name 'libgcc'
+description 'On UNIX systems where we bootstrap a compiler, copy the libgcc'
+
+default_version '0.0.1'
 
 build do
   libgcc_file = if solaris2?
-                  "/opt/csw/lib/libgcc_s.so.1"
+                  '/opt/csw/lib/libgcc_s.so.1'
                 elsif freebsd?
-                  "/lib/libgcc_s.so.1"
-                else
-                  nil
+                  '/lib/libgcc_s.so.1'
                 end
 
   if libgcc_file
     if File.exist?(libgcc_file)
       copy libgcc_file, "#{install_dir}/embedded/lib/"
     else
-      raise "Cannot find libgcc -- where is your gcc compiler?"
+      raise 'Cannot find libgcc -- where is your gcc compiler?'
     end
   end
 end

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -17,10 +17,10 @@
 # CAUTION - although its not used, external libraries such as nokogiri may pick up an optional dep on
 # libiconv such that removal of libiconv will break those libraries on upgrade.  With an better story around
 # external gem handling when chef-client is upgraded libconv could be dropped.
-name "libiconv"
-default_version "1.14"
+name 'libiconv'
+default_version '1.14'
 
-dependency "patch" if solaris2?
+dependency 'patch' if solaris2?
 
 source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz"
 
@@ -32,7 +32,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path, bfd_flags: true)
 
   # freebsd 10 needs to be build PIC
-  env['CFLAGS'] << " -fPIC" if freebsd?
+  env['CFLAGS'] << ' -fPIC' if freebsd?
 
   if aix?
     patch_env = env.dup
@@ -42,21 +42,21 @@ build do
     patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: env
   end
 
-  if version == "1.14" && ppc64le?
-    patch source: "v1.14.ppc64le-ldemulation.patch", plevel: 1, env: env
+  if version == '1.14' && ppc64le?
+    patch source: 'v1.14.ppc64le-ldemulation.patch', plevel: 1, env: env
   end
 
   # AIX's old version of patch doesn't like the config.guess patch here
   unless aix?
     # Update config.guess to support newer platforms (like aarch64)
-    if version == "1.14"
-      patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
+    if version == '1.14'
+      patch source: 'config.guess_2015-09-14.patch', plevel: 0, env: env
     end
   end
 
   # Make windres use the correct cross compilation architecture flags
   if windows?
-    patch source: "libiconv-1.14-take-windres-rcflags.patch", env: env
+    patch source: 'libiconv-1.14-take-windres-rcflags.patch', env: env
   end
 
   configure(env: env)
@@ -64,6 +64,6 @@ build do
   pmake = "-j #{workers}" unless windows?
   make "#{pmake}", env: env
   make "#{pmake} install-lib" \
-          " libdir=#{install_dir}/embedded/lib" \
-          " includedir=#{install_dir}/embedded/include", env: env
+       " libdir=#{install_dir}/embedded/lib" \
+       " includedir=#{install_dir}/embedded/include", env: env
 end

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -22,8 +22,9 @@ default_version "1.14"
 
 dependency "patch" if solaris2?
 
-source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
-       md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
+source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz"
+
+version('1.14') { source md5: 'e34509b1623cec449dfeb73d7ce9c6c6' }
 
 relative_path "libiconv-#{version}"
 

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -17,8 +17,9 @@
 name "liblzma"
 default_version "5.2.2"
 
-source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
-       md5: "7cf6a8544a7dae8e8106fdf7addfa28c"
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz"
+
+version('5.2.2') { source md5: '7cf6a8544a7dae8e8106fdf7addfa28c' }
 
 relative_path "xz-#{version}"
 

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "liblzma"
-default_version "5.2.2"
+name 'liblzma'
+default_version '5.2.2'
 
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz"
 
@@ -31,14 +31,14 @@ build do
   env['CPPFLAGS'] = "-I#{install_dir}/embedded/include" if windows?
 
   config_command = [
-    "--disable-debug",
-    "--disable-dependency-tracking",
-    "--disable-doc",
-    "--disable-scripts",
+    '--disable-debug',
+    '--disable-dependency-tracking',
+    '--disable-doc',
+    '--disable-scripts'
   ]
-  config_command << "--disable-nls" if windows?
+  config_command << '--disable-nls' if windows?
 
   configure(*config_command, env: env)
 
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -34,7 +34,7 @@ build do
     '--disable-debug',
     '--disable-dependency-tracking',
     '--disable-doc',
-    '--disable-scripts'
+    '--disable-scripts',
   ]
   config_command << '--disable-nls' if windows?
 

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -14,15 +14,13 @@
 # limitations under the License.
 #
 
-name "libossp-uuid"
-default_version "1.6.2"
-
-version "1.6.2" do
-  source md5: "5db0d43a9022a6ebbbc25337ae28942f"
-end
+name 'libossp-uuid'
+default_version '1.6.2'
 
 # ftp on ftp.ossp.org is unavaiable so we must use another mirror site.
 source url: "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-#{version}.tar.gz"
+
+version('1.6.2') { source md5: '5db0d43a9022a6ebbbc25337ae28942f' }
 
 relative_path "uuid-#{version}"
 

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -27,9 +27,9 @@ relative_path "uuid-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -23,19 +23,12 @@ dependency "autoconf"
 dependency "automake"
 dependency "libtool"
 
+source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
 # perhaps use git https://github.com/jedisct1/libsodium/
-version "1.0.8" do
-  source md5: "0a66b86fd3aab3fe4c858edcd2772760"
-end
-version "1.0.2" do
-  source md5: "dc40eb23e293448c6fc908757738003f"
-end
-version "0.7.1" do
-  source md5: "c224fe3923d1dcfe418c65c8a7246316"
-end
-
-source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+version('1.0.8') { source md5: '0a66b86fd3aab3fe4c858edcd2772760' }
+version('1.0.2') { source md5: 'dc40eb23e293448c6fc908757738003f' }
+version('0.7.1') { source md5: 'c224fe3923d1dcfe418c65c8a7246316' }
 
 relative_path "libsodium-#{version}"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -16,12 +16,12 @@
 #
 
 # We use the version in util-linux, and only build the libuuid subdirectory
-name "libsodium"
-default_version "1.0.2"
+name 'libsodium'
+default_version '1.0.2'
 
-dependency "autoconf"
-dependency "automake"
-dependency "libtool"
+dependency 'autoconf'
+dependency 'automake'
+dependency 'libtool'
 
 source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
@@ -34,8 +34,8 @@ relative_path "libsodium-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "libtool"
-default_version "2.4"
-
-# NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet
-version("2.4.6") { source md5: "addf44b646ddb4e3919805aa88fa7c5e" }
-version("2.4.2") { source md5: "d2f3b7d4627e69e13514a40e72a24d50" }
-version("2.4")   { source md5: "b32b04148ecdd7344abc6fe8bd1bb021" }
+name 'libtool'
+default_version '2.4'
 
 source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
+
+# NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet
+version('2.4.6') { source md5: 'addf44b646ddb4e3919805aa88fa7c5e' }
+version('2.4.2') { source md5: 'd2f3b7d4627e69e13514a40e72a24d50' }
+version('2.4')   { source md5: 'b32b04148ecdd7344abc6fe8bd1bb021' }
 
 relative_path "libtool-#{version}"
 

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -32,18 +32,18 @@ build do
   # AIX's old version of patch doesn't like the config.guess patch here
   unless aix?
     # Update config.guess to support newer platforms (like aarch64)
-    if version == "2.4"
-      patch source: "config.guess_2015-09-14.patch", plevel: 0, env: env
+    if version == '2.4'
+      patch source: 'config.guess_2015-09-14.patch', plevel: 0, env: env
     end
   end
 
   if aix?
-    env["M4"] = "/opt/freeware/bin/m4"
+    env['M4'] = '/opt/freeware/bin/m4'
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libuuid.rb
+++ b/config/software/libuuid.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "libuuid"
-default_version "2.21"
+name 'libuuid'
+default_version '2.21'
 
 source url: "https://www.kernel.org/pub/linux/utils/util-linux/v#{version}/util-linux-#{version}.tar.gz"
 
@@ -35,6 +35,6 @@ build do
 
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
-  make "-j #{workers}", env: env, cwd: "#{project_dir}/libuuid"
-  make "-j #{workers} install", env: env, cwd: "#{project_dir}/libuuid"
+  make "-j #{workers}', env: env, cwd: '#{project_dir}/libuuid"
+  make "-j #{workers} install', env: env, cwd: '#{project_dir}/libuuid"
 end

--- a/config/software/libuuid.rb
+++ b/config/software/libuuid.rb
@@ -20,14 +20,13 @@ default_version "2.21"
 source url: "https://www.kernel.org/pub/linux/utils/util-linux/v#{version}/util-linux-#{version}.tar.gz"
 
 # We use the version in util-linux, and only build the libuuid subdirectory
-version "2.27.1" do
-  source md5: "e9c73747eadf5201b2a198530add4f87",
-         url: "https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.gz"
-end
-version "2.21" do
-  source md5: "4222aa8c2a1b78889e959a4722f1881a"
+# Note the 'v2.27' and then '..2.27.1.tar..' requiring it's explicit url
+version '2.27.1' do
+  source md5: 'e9c73747eadf5201b2a198530add4f87',
+         url: 'https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.gz'
 end
 
+version('2.21') { source md5: '4222aa8c2a1b78889e959a4722f1881a' }
 
 relative_path "util-linux-#{version}"
 

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -17,15 +17,13 @@
 name "libxml2"
 default_version "2.9.3"
 
-dependency "zlib"
-dependency "libiconv"
-dependency "liblzma"
-
-version "2.9.3" do
-  source md5: "daece17e045f1c107610e137ab50c179"
-end
+dependency 'zlib'
+dependency 'libiconv'
+dependency 'liblzma'
 
 source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
+
+version('2.9.3') { source md5: 'daece17e045f1c107610e137ab50c179' }
 
 relative_path "libxml2-#{version}"
 

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "libxml2"
-default_version "2.9.3"
+name 'libxml2'
+default_version '2.9.3'
 
 dependency 'zlib'
 dependency 'libiconv'
@@ -33,12 +33,12 @@ build do
   configure_command = [
     "--with-zlib=#{install_dir}/embedded",
     "--with-iconv=#{install_dir}/embedded",
-    "--without-python",
-    "--without-icu",
+    '--without-python',
+    '--without-icu'
   ]
 
   # solaris 10 ipv6 support is broken due to no inet_ntop() in -lnsl
-  configure_command << "--enable-ipv6=no" if solaris2?
+  configure_command << '--enable-ipv6=no' if solaris2?
 
   configure(*configure_command, env: env)
 
@@ -47,5 +47,5 @@ build do
   else
     make "-j #{workers}", env: env
   end
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -34,7 +34,7 @@ build do
     "--with-zlib=#{install_dir}/embedded",
     "--with-iconv=#{install_dir}/embedded",
     '--without-python',
-    '--without-icu'
+    '--without-icu',
   ]
 
   # solaris 10 ipv6 support is broken due to no inet_ntop() in -lnsl

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -22,15 +22,11 @@ dependency "liblzma"
 dependency "libtool" if solaris2?
 dependency "patch" if solaris2?
 
-version "1.1.28" do
-  source md5: "9667bf6f9310b957254fdcf6596600b7"
-end
-
-version "1.1.26" do
-  source md5: "e61d0364a30146aaa3001296f853b2b9"
-end
 
 source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+
+version('1.1.28') { source md5: '9667bf6f9310b957254fdcf6596600b7' }
+version('1.1.26') { source md5: 'e61d0364a30146aaa3001296f853b2b9' }
 
 relative_path "libxslt-#{version}"
 

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
-name "libxslt"
-default_version "1.1.28"
+name 'libxslt'
+default_version '1.1.28'
 
-dependency "libxml2"
-dependency "liblzma"
-dependency "libtool" if solaris2?
-dependency "patch" if solaris2?
-
+dependency 'libxml2'
+dependency 'liblzma'
+dependency 'libtool' if solaris2?
+dependency 'patch' if solaris2?
 
 source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
 
@@ -33,26 +32,26 @@ relative_path "libxslt-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
 
-  patch source: "libxslt-cve-2015-7995.patch", env: env
-  patch source: "libxslt-solaris-configure.patch", env: env if solaris?
-  patch source: "libxslt-mingw32.patch", env: env if windows?
+  patch source: 'libxslt-cve-2015-7995.patch', env: env
+  patch source: 'libxslt-solaris-configure.patch', env: env if solaris?
+  patch source: 'libxslt-mingw32.patch', env: env if windows?
 
   configure_commands = [
     "--with-libxml-prefix=#{install_dir}/embedded",
     "--with-libxml-include-prefix=#{install_dir}/embedded/include",
     "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
-    "--without-python",
-    "--without-crypto",
+    '--without-python',
+    '--without-crypto'
   ]
 
   configure(*configure_commands, env: env)
 
   if windows?
     # Apply a post configure patch to prevent dll base address clash
-    patch source: "libxslt-windows-relocate.patch", env: env if windows?
+    patch source: 'libxslt-windows-relocate.patch', env: env if windows?
     make env: env
   else
     make "-j #{workers}", env: env
   end
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -41,7 +41,7 @@ build do
     "--with-libxml-include-prefix=#{install_dir}/embedded/include",
     "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
     '--without-python',
-    '--without-crypto'
+    '--without-crypto',
   ]
 
   configure(*configure_commands, env: env)

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -14,9 +14,8 @@
 # limitations under the License.
 #
 
-name "libyajl2-gem"
-default_version "master"
-relative_path "libyajl2-gem"
+name 'libyajl2-gem'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -29,15 +28,15 @@ relative_path 'libyajl2-gem'
 build do
   env = with_embedded_path()
 
-  command "git submodule init", env: env
-  command "git submodule update", env: env
+  command 'git submodule init', env: env
+  command 'git submodule update', env: env
 
-  bundle "install --without development_extras", env: env
-  bundle "exec rake prep", env: env
-  bundle "exec rake gem", env: env
+  bundle 'install --without development_extras', env: env
+  bundle 'exec rake prep', env: env
+  bundle 'exec rake gem', env: env
 
-  delete "pkg/*java*"
+  delete 'pkg/*java*'
 
-  gem "install pkg/libyajl2-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'install pkg/libyajl2-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -18,11 +18,13 @@ name "libyajl2-gem"
 default_version "master"
 relative_path "libyajl2-gem"
 
-source git: "https://github.com/opscode/libyajl2-gem.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
+source git: 'https://github.com/opscode/libyajl2-gem.git'
+
+relative_path 'libyajl2-gem'
 
 build do
   env = with_embedded_path()

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -23,10 +23,10 @@
 # This component should be removed when libyaml 0.1.5 ships with ruby builds
 # of rubyinstaller.org
 #
-name "libyaml-windows"
-default_version "0.1.6"
+name 'libyaml-windows'
+default_version '0.1.6'
 
-dependency "ruby-windows"
+dependency 'ruby-windows'
 
 source url: "https://packages.openknapsack.org/libyaml/libyaml-#{version}-x86-windows.tar.lzma"
 
@@ -35,7 +35,7 @@ version('0.1.6') { source md5: '8bb5d8e43cf18ec48b4751bdd0111c84' }
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  tmpdir = File.join(Omnibus::Config.cache_dir, "libyaml-cache")
+  tmpdir = File.join(Omnibus::Config.cache_dir, 'libyaml-cache')
 
   # Ensure the directory exists
   mkdir tmpdir
@@ -44,7 +44,7 @@ build do
   command "7z.exe x #{project_file} -o#{tmpdir} -r -y", env: env
 
   # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(tmpdir, "libyaml-0.1.6-x86-windows.tar")} -o#{tmpdir} -r -y", env: env
+  command "7z.exe x #{File.join(tmpdir, 'libyaml-0.1.6-x86-windows.tar')} -o#{tmpdir} -r -y", env: env
 
   # Now copy over libyaml-0-2.dll to the build dir
   copy "#{tmpdir}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll"

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -28,8 +28,9 @@ default_version "0.1.6"
 
 dependency "ruby-windows"
 
-source url: "https://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
-       md5: "8bb5d8e43cf18ec48b4751bdd0111c84"
+source url: "https://packages.openknapsack.org/libyaml/libyaml-#{version}-x86-windows.tar.lzma"
+
+version('0.1.6') { source md5: '8bb5d8e43cf18ec48b4751bdd0111c84' }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -17,8 +17,9 @@
 name "libyaml"
 default_version '0.1.6'
 
-source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
-       md5: '5fe00cda18ca5daeb43762b80c38e06e'
+source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz"
+
+version('0.1.6') { source md5: '5fe00cda18ca5daeb43762b80c38e06e' }
 
 relative_path "yaml-#{version}"
 

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-name "libyaml"
+name 'libyaml'
 default_version '0.1.6'
 
 source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz"
@@ -26,22 +26,22 @@ relative_path "yaml-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true))
 
-  if version == "0.1.6" && ppc64le?
-    patch source: "v0.1.6.ppc64le-configure.patch", plevel: 1, env: env
+  if version == '0.1.6' && ppc64le?
+    patch source: 'v0.1.6.ppc64le-configure.patch', plevel: 1, env: env
   end
 
-  configure "--enable-shared", env: env
+  configure '--enable-shared', env: env
 
   # Windows had worse automake/libtool version issues.
   # Just patch the output instead.
-  if version == "0.1.6" && windows?
-    patch source: "v0.1.6.windows-configure.patch", plevel: 1, env: env
+  if version == '0.1.6' && windows?
+    patch source: 'v0.1.6.windows-configure.patch', plevel: 1, env: env
   end
 
   # On windows, msys make 3.81 breaks with parallel builds.
   if windows?
     make env: env
-    make "install", env: env
+    make 'install', env: env
   else
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env

--- a/config/software/libzmq-windows.rb
+++ b/config/software/libzmq-windows.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "libzmq-windows"
-default_version "2.2.0"
+name 'libzmq-windows'
+default_version '2.2.0'
 
 zmq_installer = "ZeroMQ-#{version}~miru1.0-win32.exe"
 
@@ -29,12 +29,12 @@ build do
 
   command "#{zmq_installer} /S /D=#{windows_safe_path(project_dir)}", env: env
 
-  copy "bin/*", "#{install_dir}/embedded/bin"
-  copy "include/*", "#{install_dir}/embedded/include"
-  copy "lib/*", "#{install_dir}/embedded/lib"
+  copy 'bin/*', "#{install_dir}/embedded/bin"
+  copy 'include/*', "#{install_dir}/embedded/include"
+  copy 'lib/*', "#{install_dir}/embedded/lib"
 
   # Ensure the main DLL is available under a well known name.
-  copy "bin/libzmq-v100-mt.dll", "#{install_dir}/embedded/bin/libzmq.dll"
+  copy 'bin/libzmq-v100-mt.dll', "#{install_dir}/embedded/bin/libzmq.dll"
 
-  command "uninstall /S", env: env
+  command 'uninstall /S', env: env
 end

--- a/config/software/libzmq-windows.rb
+++ b/config/software/libzmq-windows.rb
@@ -19,8 +19,9 @@ default_version "2.2.0"
 
 zmq_installer = "ZeroMQ-#{version}~miru1.0-win32.exe"
 
-source url: "https://miru.hk/archive/#{zmq_installer}",
-       md5: "207a322228f90f61bfb67e3f335db06e"
+source url: "https://miru.hk/archive/#{zmq_installer}"
+
+version('2.2.0') { source md5: '207a322228f90f61bfb67e3f335db06e' }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -22,26 +22,18 @@ dependency "autoconf"
 dependency "automake"
 dependency "libtool"
 
-version "2.2.0" do
-  source md5: "1b11aae09b19d18276d0717b2ea288f6"
-  dependency "libuuid"
-end
-version "2.1.11" do
-  source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
-  dependency "libuuid"
-end
+source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
-version "4.1.4" do
-  source md5: "a611ecc93fffeb6d058c0e6edf4ad4fb"
-  dependency "libsodium"
-end
-version "4.0.5" do
-  source md5: "73c39f5eb01b9d7eaf74a5d899f1d03d"
-  dependency "libsodium"
-end
-version "4.0.4" do
-  source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"
-  dependency "libsodium"
+version('2.2.0')  { source md5: '1b11aae09b19d18276d0717b2ea288f6' }
+version('2.1.11') { source md5: 'f0f9fd62acb1f0869d7aa80379b1f6b7' }
+version('4.1.4')  { source md5: 'a611ecc93fffeb6d058c0e6edf4ad4fb' }
+version('4.0.5')  { source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d' }
+version('4.0.4')  { source md5: 'f3c3defbb5ef6cc000ca65e529fdab3b' }
+
+if version <= '2.2.0'
+  dependency 'libuuid'
+elsif version >= '4.0.4'
+  dependency 'libsodium'
 end
 
 relative_path "zeromq-#{version}"

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -15,12 +15,12 @@
 #
 
 # We use the version in util-linux, and only build the libuuid subdirectory
-name "libzmq"
-default_version "2.1.11"
+name 'libzmq'
+default_version '2.1.11'
 
-dependency "autoconf"
-dependency "automake"
-dependency "libtool"
+dependency 'autoconf'
+dependency 'automake'
+dependency 'libtool'
 
 source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
@@ -37,7 +37,6 @@ elsif version >= '4.0.4'
 end
 
 relative_path "zeromq-#{version}"
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -47,10 +46,10 @@ build do
   # long long and c++ in pedantic mode
   # This patch is specific to zeromq4
   if version.satisfies?('>= 4')
-    patch source: "zeromq-4.0.5_configure-pedantic_centos_5.patch", env: env if el?
+    patch source: 'zeromq-4.0.5_configure-pedantic_centos_5.patch', env: env if el?
   end
 
-  command "./autogen.sh", env: env
+  command './autogen.sh', env: env
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -23,13 +23,13 @@ source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{vers
 # https://github.com/jdmundrawala/zeromq4-x/releases/download/libzmq4x-1.0.21/libzmq4x-windows.zip
 version('1.0.21') { source md5: 'f75bb49580c7563f890d1fcfdd415553' }
 
-relative_path "libzmq4x-windows"
+relative_path 'libzmq4x-windows'
 
 build do
-  copy "bin/*", "#{install_dir}/embedded/bin"
-  copy "include/*", "#{install_dir}/embedded/include"
-  copy "lib/*", "#{install_dir}/embedded/lib"
+  copy 'bin/*', "#{install_dir}/embedded/bin"
+  copy 'include/*', "#{install_dir}/embedded/include"
+  copy 'lib/*', "#{install_dir}/embedded/lib"
 
   # Ensure the main DLL is available under a well known name.
-  copy "bin/libzmq-mt-4_0_6.dll", "#{install_dir}/embedded/bin/libzmq.dll"
+  copy 'bin/libzmq-mt-4_0_6.dll', "#{install_dir}/embedded/bin/libzmq.dll"
 end

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -14,16 +14,14 @@
 # limitations under the License.
 #
 
-name "libzmq4x-windows"
-default_version "1.0.21"
+name 'libzmq4x-windows'
+default_version '1.0.21'
+
+source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip"
 
 # Longer term we need to move this to a chef internal build pipeline
 # https://github.com/jdmundrawala/zeromq4-x/releases/download/libzmq4x-1.0.21/libzmq4x-windows.zip
-#
-version("1.0.21") do
-  source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip",
-         md5: "f75bb49580c7563f890d1fcfdd415553"
-end
+version('1.0.21') { source md5: 'f75bb49580c7563f890d1fcfdd415553' }
 
 relative_path "libzmq4x-windows"
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -21,11 +21,10 @@ dependency "popt"
 
 source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
-version "3.9.2" do
-  source md5: "584bca013dcceeb23b06b27d6d0342fb"
-end
-version "3.8.5" do
-  source md5: "d3c13e2a963a55c584cfaa83e96b173d",
+version('3.9.2') { source md5: '584bca013dcceeb23b06b27d6d0342fb' }
+
+version '3.8.5' do
+  source md5: 'd3c13e2a963a55c584cfaa83e96b173d',
          url: "https://fedorahosted.org/releases/l/o/logrotate/logrotate-#{version}.tar.gz"
 end
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "logrotate"
-default_version "3.8.5"
+name 'logrotate'
+default_version '3.8.5'
 
-dependency "popt"
+dependency 'popt'
 
 source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
@@ -33,20 +33,20 @@ relative_path "logrotate-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
     # Patch allows this to be set manually
-    "BASEDIR" => "#{install_dir}/embedded",
+    'BASEDIR' => "#{install_dir}/embedded"
   )
 
   # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS
   # and CFLAGS
-  env["EXTRA_LDFLAGS"] = env["LDFLAGS"]
-  env["EXTRA_CFLAGS"]  = env["CFLAGS"]
+  env['EXTRA_LDFLAGS'] = env['LDFLAGS']
+  env['EXTRA_CFLAGS']  = env['CFLAGS']
 
-  patch source: "logrotate_basedir_override.patch", plevel: 0, env: env
+  patch source: 'logrotate_basedir_override.patch', plevel: 0, env: env
 
   make "-j #{workers}", env: env
 
   # Yes, this is horrible. Due to how the makefile is structured, we need to
   # specify PREFIX, *but not BASEDIR* in order to get this installed into
   # +"#{install_dir}/embedded/sbin"+
-  make "install", env: { "PREFIX" => "#{install_dir}/embedded" }
+  make 'install', env: { 'PREFIX' => "#{install_dir}/embedded" }
 end

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -33,7 +33,7 @@ relative_path "logrotate-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
     # Patch allows this to be set manually
-    'BASEDIR' => "#{install_dir}/embedded"
+    'BASEDIR' => "#{install_dir}/embedded",
   )
 
   # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -17,8 +17,9 @@
 name "m4"
 default_version "1.4.17"
 
-source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
-       md5: "a5e9954b1dae036762f7b13673a2cf76"
+source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz"
+
+version('1.4.17') { source md5: 'a5e9954b1dae036762f7b13673a2cf76' }
 
 relative_path "m4-#{version}"
 

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "m4"
-default_version "1.4.17"
+name 'm4'
+default_version '1.4.17'
 
 source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz"
 

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "make"
-default_version "4.1"
+name 'make'
+default_version '4.1'
 
 source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz"
 
@@ -26,11 +26,11 @@ relative_path "make-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 
   # We are very prescriptive. We made make, we will make all the things use it!
   link "#{install_dir}/embedded/bin/make", "#{install_dir}/embedded/bin/gmake"

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -17,8 +17,9 @@
 name "make"
 default_version "4.1"
 
-source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
-       md5: "654f9117957e6fa6a1c49a8f08270ec9"
+source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz"
+
+version('4.1') { source md5: '654f9117957e6fa6a1c49a8f08270ec9' }
 
 relative_path "make-#{version}"
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "makedepend"
-default_version "1.0.5"
+name 'makedepend'
+default_version '1.0.5'
 
 dependency 'xproto'
 dependency 'util-macros'

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -17,14 +17,15 @@
 name "makedepend"
 default_version "1.0.5"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
-       md5: "efb2d7c7e22840947863efaedc175747"
+dependency 'xproto'
+dependency 'util-macros'
+dependency 'pkg-config-lite'
 
-relative_path "makedepend-1.0.5"
+source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-#{version}.tar.gz"
 
-dependency "xproto"
-dependency "util-macros"
-dependency "pkg-config-lite"
+version('1.0.5') { source md5: 'efb2d7c7e22840947863efaedc175747' }
+
+relative_path 'makedepend-1.0.5'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/mingw-get.rb
+++ b/config/software/mingw-get.rb
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 
-name "mingw-get"
-default_version "0.6.2-beta-20131004-1"
+name 'mingw-get'
+default_version '0.6.2-beta-20131004-1'
 
-version("0.6.2-beta-20131004-1") do
-  source url: "http://iweb.dl.sourceforge.net/project/mingw/Installer/mingw-get/mingw-get-0.6.2-beta-20131004-1/mingw-get-0.6.2-mingw32-beta-20131004-1-bin.zip",
-         sha256: "2e0e9688d42adc68c5611759947e064156e169ff871816cae52d33ee0655826d"
+version '0.6.2-beta-20131004-1' do
+  source url: 'http://iweb.dl.sourceforge.net/project/mingw/Installer/mingw-get/mingw-get-0.6.2-beta-20131004-1/mingw-get-0.6.2-mingw32-beta-20131004-1-bin.zip',
+         sha256: '2e0e9688d42adc68c5611759947e064156e169ff871816cae52d33ee0655826d'
 end
 
 build do
-  copy "*", "#{install_dir}/embedded"
+  copy '*', "#{install_dir}/embedded"
 end

--- a/config/software/mingw-runtime.rb
+++ b/config/software/mingw-runtime.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "mingw-runtime"
-default_version "v4-git20150618-gcc5-tdm64-1"
+name 'mingw-runtime'
+default_version 'v4-git20150618-gcc5-tdm64-1'
 
-dependency "msys-base"
+dependency 'msys-base'
 
 source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-#{version}.tar.lzma"
 
-version("v4-git20150618-gcc5-tdm64-1") { source sha256: "29186e0bb36824b10026d78bdcf238d631d8fc1d90718d2ebbd9ec239b6f94dd" }
+version('v4-git20150618-gcc5-tdm64-1') { source sha256: '29186e0bb36824b10026d78bdcf238d631d8fc1d90718d2ebbd9ec239b6f94dd' }
 
 build do
-  copy "*", "#{install_dir}/embedded"
+  copy '*', "#{install_dir}/embedded"
 end

--- a/config/software/mingw.rb
+++ b/config/software/mingw.rb
@@ -14,18 +14,18 @@
 # limitations under the License.
 #
 
-name "mingw"
-default_version "5.1.0-tdm64-1"
+name 'mingw'
+default_version '5.1.0-tdm64-1'
 
-dependency "msys-base"
-dependency "msys-coreutils-ext"
-dependency "binutils"
-dependency "mingw-runtime"
+dependency 'msys-base'
+dependency 'msys-coreutils-ext'
+dependency 'binutils'
+dependency 'mingw-runtime'
 
 source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/#{version}/gcc-#{version}-core.tar.lzma"
 
-version("5.1.0-tdm64-1") { source sha256: "29393aac890847089ad1e93f81a28f6744b1609c00b25afca818f3903e42e4bd" }
+version('5.1.0-tdm64-1') { source sha256: '29393aac890847089ad1e93f81a28f6744b1609c00b25afca818f3903e42e4bd' }
 
 build do
-  copy "*", "#{install_dir}/embedded"
+  copy '*', "#{install_dir}/embedded"
 end

--- a/config/software/mpc.rb
+++ b/config/software/mpc.rb
@@ -17,13 +17,13 @@
 name "mpc"
 default_version "1.0.2"
 
-dependency "gmp"
-dependency "mpfr"
-
-version("1.0.2") { source md5: "68fadff3358fb3e7976c7a398a0af4c3" }
-version("1.0.3") { source md5: "d6a1d5f8ddea3abd2cc3e98f58352d26" }
+dependency 'gmp'
+dependency 'mpfr'
 
 source url: "https://ftp.gnu.org/gnu/mpc/mpc-#{version}.tar.gz"
+
+version('1.0.2') { source md5: '68fadff3358fb3e7976c7a398a0af4c3' }
+version('1.0.3') { source md5: 'd6a1d5f8ddea3abd2cc3e98f58352d26' }
 
 relative_path "mpc-#{version}"
 

--- a/config/software/mpc.rb
+++ b/config/software/mpc.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "mpc"
-default_version "1.0.2"
+name 'mpc'
+default_version '1.0.2'
 
 dependency 'gmp'
 dependency 'mpfr'
@@ -30,10 +30,10 @@ relative_path "mpc-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                        "--prefix=#{install_dir}/embedded"]
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 end

--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "mpfr"
-default_version "3.1.2"
+name 'mpfr'
+default_version '3.1.2'
 
 dependency 'gmp'
 
@@ -29,10 +29,10 @@ relative_path "mpfr-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = ["./configure",
+  configure_command = ['./configure',
                        "--prefix=#{install_dir}/embedded"]
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 end

--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -17,12 +17,12 @@
 name "mpfr"
 default_version "3.1.2"
 
-dependency "gmp"
-
-version("3.1.2") { source md5: "181aa7bb0e452c409f2788a4a7f38476" }
-version("3.1.3") { source md5: "7b650781f0a7c4a62e9bc8bdaaa0018b" }
+dependency 'gmp'
 
 source url: "http://www.mpfr.org/mpfr-#{version}/mpfr-#{version}.tar.gz"
+
+version('3.1.2') { source md5: '181aa7bb0e452c409f2788a4a7f38476' }
+version('3.1.3') { source md5: '7b650781f0a7c4a62e9bc8bdaaa0018b' }
 
 relative_path "mpfr-#{version}"
 

--- a/config/software/msys-base.rb
+++ b/config/software/msys-base.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "msys-base"
-default_version "2013072300"
+name 'msys-base'
+default_version '2013072300'
 
-dependency "mingw-get"
+dependency 'mingw-get'
 
 env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/msys-coreutils-ext.rb
+++ b/config/software/msys-coreutils-ext.rb
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-name "msys-coreutils-ext"
-default_version "5.97-3"
+name 'msys-coreutils-ext'
+default_version '5.97-3'
 
-dependency "mingw-get"
-dependency "msys-base"
+dependency 'mingw-get'
+dependency 'msys-base'
 
 # This package brings in occasionally used utilities such as dd, chown, chgrp,
 # hostname, mkfifo, stat etc. Some of these don't make sense on windows but

--- a/config/software/mysql2.rb
+++ b/config/software/mysql2.rb
@@ -25,27 +25,27 @@
 # Then run 'chef-server-ctl reconfigure'
 #
 
-versions_to_install = ["0.3.6", "0.3.7"]
+versions_to_install = ['0.3.6', '0.3.7']
 
-name "mysql2"
-default_version versions_to_install.join("-")
+name 'mysql2'
+default_version versions_to_install.join('-')
 
-dependency "ruby"
-dependency "bundler"
+dependency 'ruby'
+dependency 'bundler'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   cache_path = "#{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
 
-  gem "install rake-compiler" \
-      " --version '0.8.3'" \
-      " --no-ri --no-rdoc", env: env
+  gem 'install rake-compiler' \
+      ' --version "0.8.3"' \
+      ' --no-ri --no-rdoc', env: env
 
   mkdir cache_path
 
   versions_to_install.each do |version|
-    gem "fetch mysql2" \
+    gem 'fetch mysql2' \
         " --version '#{version}'", env: env, cwd: cache_path
   end
 end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-name "ncurses"
-default_version "5.9"
+name 'ncurses'
+default_version '5.9'
 
-dependency "libtool" if aix?
-dependency "patch" if solaris2?
+dependency 'libtool' if aix?
+dependency 'patch' if solaris2?
 
 source url: "ftp://invisible-island.net/ncurses/current/ncurses-#{version}.tgz"
 
@@ -39,7 +39,7 @@ relative_path "ncurses-#{version}"
 # Ruby 1.9 optimistically builds against libncursesw for UTF-8
 # support. In order to prevent Ruby from linking against a
 # package-installed version of ncursesw, we build wide-character
-# support into ncurses with the "--enable-widec" configure parameter.
+# support into ncurses with the '--enable-widec' configure parameter.
 # To support other applications and libraries that still try to link
 # against libncurses, we also have to create non-wide libraries.
 #
@@ -57,27 +57,27 @@ build do
     # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0
     # compatibility:
     # http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/devel/ncurses/patches/
-    patch source: "patch-aa", plevel: 0, env: env
-    patch source: "patch-ab", plevel: 0, env: env
-    patch source: "patch-ac", plevel: 0, env: env
-    patch source: "patch-ad", plevel: 0, env: env
-    patch source: "patch-cxx_cursesf.h", plevel: 0, env: env
-    patch source: "patch-cxx_cursesm.h", plevel: 0, env: env
+    patch source: 'patch-aa', plevel: 0, env: env
+    patch source: 'patch-ab', plevel: 0, env: env
+    patch source: 'patch-ac', plevel: 0, env: env
+    patch source: 'patch-ad', plevel: 0, env: env
+    patch source: 'patch-cxx_cursesf.h', plevel: 0, env: env
+    patch source: 'patch-cxx_cursesm.h', plevel: 0, env: env
 
     # Opscode patches - <someara@opscode.com>
     # The configure script from the pristine tarball detects xopen_source_extended incorrectly.
     # Manually working around a false positive.
-    patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0, env: env
+    patch source: 'ncurses-5.9-solaris-xopen_source_extended-detection.patch', plevel: 0, env: env
   end
 
   # AIX's old version of patch doesn't like the patches here
   unless aix?
-    if version == "5.9"
+    if version == '5.9'
       # Update config.guess to support platforms made after 2010 (like aarch64)
-      patch source: "config_guess_2015-09-24.patch", plevel: 0, env: env
+      patch source: 'config_guess_2015-09-24.patch', plevel: 0, env: env
 
       # Patch to add support for GCC 5, doesn't break previous versions
-      patch source: "ncurses-5.9-gcc-5.patch", plevel: 1, env: env
+      patch source: 'ncurses-5.9-gcc-5.patch', plevel: 1, env: env
     end
   end
 
@@ -91,23 +91,23 @@ build do
     # Patches ncurses for clang compiler. Changes have been accepted into
     # upstream, but occurred shortly after the 5.9 release. We should be able
     # to remove this after upgrading to any release created after June 2012
-    patch source: "ncurses-clang.patch", env: env
+    patch source: 'ncurses-clang.patch', env: env
   end
 
   if openbsd?
-    patch source: "patch-ncurses_tinfo_lib__baudrate.c", plevel: 0, env: env
+    patch source: 'patch-ncurses_tinfo_lib__baudrate.c', plevel: 0, env: env
   end
 
   configure_command = [
-    "./configure",
+    './configure',
     "--prefix=#{install_dir}/embedded",
-    "--enable-overwrite",
-    "--with-shared",
-    "--with-termlib",
-    "--without-ada",
-    "--without-cxx-binding",
-    "--without-debug",
-    "--without-manpages",
+    '--enable-overwrite',
+    '--with-shared',
+    '--with-termlib',
+    '--without-ada',
+    '--without-cxx-binding',
+    '--without-debug',
+    '--without-manpages'
   ]
 
   if aix?
@@ -116,39 +116,39 @@ build do
     # see http://invisible-island.net/ncurses/NEWS.html#t20140621
 
     # let libtool deal with library silliness
-    configure_command << "--with-libtool=\"#{install_dir}/embedded/bin/libtool\""
+    configure_command << "--with-libtool='#{install_dir}/embedded/bin/libtool'"
 
     # stick with just the shared libs on AIX
-    configure_command << "--without-normal"
+    configure_command << '--without-normal'
 
     # ncurses's ./configure incorrectly
-    # "figures out" ARFLAGS if you try
+    # 'figures out' ARFLAGS if you try
     # to set them yourself
     env.delete('ARFLAGS')
 
     # use gnu install from the coreutils IBM rpm package
-    env['INSTALL'] = "/opt/freeware/bin/install"
+    env['INSTALL'] = '/opt/freeware/bin/install'
   end
 
   # only Solaris 10 sh has a problem with
   # parens enclosed case statement conditions the configure script
-  configure_command.unshift "bash" if solaris2?
+  configure_command.unshift 'bash' if solaris2?
 
-  command configure_command.join(" "), env: env
+  command configure_command.join(' '), env: env
 
   # unfortunately, libtool may try to link to libtinfo
   # before it has been assembled; so we have to build in serial
-  make "libs", env: env if aix?
+  make 'libs', env: env if aix?
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 
   # Build non-wide-character libraries
-  make "distclean", env: env
-  configure_command << "--enable-widec"
+  make 'distclean', env: env
+  configure_command << '--enable-widec'
 
-  command configure_command.join(" "), env: env
-  make "libs", env: env if aix?
+  command configure_command.join(' '), env: env
+  make 'libs', env: env if aix?
   make "-j #{workers}", env: env
 
   # Installing the non-wide libraries will also install the non-wide

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,10 +20,16 @@ default_version "5.9"
 dependency "libtool" if aix?
 dependency "patch" if solaris2?
 
-version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
-version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
-version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150613.tgz" }
-version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150810.tgz" }
+source url: "ftp://invisible-island.net/ncurses/current/ncurses-#{version}.tgz"
+
+version '5.9' do
+  source md5: '8cb9c412e5f2d96bc6f459aa8c6282a1',
+         url: 'https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz'
+end
+
+version('5.9-20150530') { source md5: 'bb2cbe1d788d3ab0138fc2734e446b43' }
+version('6.0-20150613') { source md5: '0c6a0389d004c78f4a995bc61884a563' }
+version('6.0-20150810') { source md5: '78bfcb4634a87b4cda390956586f8f1f' }
 
 relative_path "ncurses-#{version}"
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -107,7 +107,7 @@ build do
     '--without-ada',
     '--without-cxx-binding',
     '--without-debug',
-    '--without-manpages'
+    '--without-manpages',
   ]
 
   if aix?

--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -14,37 +14,37 @@
 # limitations under the License.
 #
 
-name "nginx"
-default_version "1.8.1"
+name 'nginx'
+default_version '1.8.1'
 
-dependency "pcre"
-dependency "openssl"
+dependency 'pcre'
+dependency 'openssl'
 
 source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
 
-version("1.9.1") { source md5: "fc054d51effa7c80a2e143bc4e2ae6a7" }
-version("1.8.1") { source md5: "2e91695074dbdfbf1bcec0ada9fda462" }
-version("1.8.0") { source md5: "3ca4a37931e9fa301964b8ce889da8cb" }
-version("1.6.3") { source md5: "ea813aee2c344c2f5b66cdb24a472738" }
-version("1.4.7") { source md5: "aee151d298dcbfeb88b3f7dd3e7a4d17" }
-version("1.4.4") { source md5: "5dfaba1cbeae9087f3949860a02caa9f" }
+version('1.9.1') { source md5: 'fc054d51effa7c80a2e143bc4e2ae6a7' }
+version('1.8.1') { source md5: '2e91695074dbdfbf1bcec0ada9fda462' }
+version('1.8.0') { source md5: '3ca4a37931e9fa301964b8ce889da8cb' }
+version('1.6.3') { source md5: 'ea813aee2c344c2f5b66cdb24a472738' }
+version('1.4.7') { source md5: 'aee151d298dcbfeb88b3f7dd3e7a4d17' }
+version('1.4.4') { source md5: '5dfaba1cbeae9087f3949860a02caa9f' }
 
 relative_path "nginx-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --with-http_ssl_module" \
-          " --with-http_stub_status_module" \
-          " --with-ipv6" \
-          " --with-debug" \
-          " --with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"" \
+          ' --with-http_ssl_module' \
+          ' --with-http_stub_status_module' \
+          ' --with-ipv6' \
+          ' --with-debug' \
+          " --with-cc-opt='-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include'" \
           " --with-ld-opt=-L#{install_dir}/embedded/lib", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 
   # Ensure the logs directory is available on rebuild from git cache
   touch "#{install_dir}/embedded/logs/.gitkeep"

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "nodejs"
-default_version "0.10.10"
+name 'nodejs'
+default_version '0.10.10'
 
-dependency "python"
+dependency 'python'
 
 source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
@@ -36,5 +36,5 @@ build do
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -19,25 +19,13 @@ default_version "0.10.10"
 
 dependency "python"
 
-version "0.10.10" do
-  source md5: "a47a9141567dd591eec486db05b09e1c"
-end
-
-version "0.10.26" do
-  source md5: "15e9018dadc63a2046f61eb13dfd7bd6"
-end
-
-version "0.10.35" do
-  source md5: "2c00d8cf243753996eecdc4f6e2a2d11"
-end
-
-version "4.1.2" do
-  source md5: "31a3ee2f51bb2018501048f543ea31c7"
-end
+source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
 # Warning: NodeJS 5.6.0 requires GCC >= 4.8
-
-source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
+version('0.10.10') { source md5: 'a47a9141567dd591eec486db05b09e1c' }
+version('0.10.26') { source md5: '15e9018dadc63a2046f61eb13dfd7bd6' }
+version('0.10.35') { source md5: '2c00d8cf243753996eecdc4f6e2a2d11' }
+version('4.1.2')   { source md5: '31a3ee2f51bb2018501048f543ea31c7' }
 
 relative_path "node-v#{version}"
 

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -14,20 +14,20 @@
 # limitations under the License.
 #
 
-name "nokogiri"
+name 'nokogiri'
 
-dependency "ruby"
+dependency 'ruby'
 
-using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == 'ruby-windows')
 unless using_prebuilt_ruby
-  dependency "libxml2"
-  dependency "libxslt"
-  dependency "libiconv"
-  dependency "liblzma"
-  dependency "zlib"
+  dependency 'libxml2'
+  dependency 'libxslt'
+  dependency 'libiconv'
+  dependency 'liblzma'
+  dependency 'zlib'
 end
 
-dependency "rubygems"
+dependency 'rubygems'
 
 #
 # NOTE: As of nokogiri 1.6.4 it will superficially 'work' to remove most
@@ -55,27 +55,27 @@ dependency "rubygems"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem_command = [ "install nokogiri" ]
+  gem_command = [ 'install nokogiri' ]
   gem_command << "--version '#{version}'" unless version.nil?
 
   # windows uses the 'fat' precompiled binaries'
   unless using_prebuilt_ruby
     # Tell nokogiri to use the system libraries instead of compiling its own
-    env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
+    env['NOKOGIRI_USE_SYSTEM_LIBRARIES'] = 'true'
 
     gem_command += [
-      "--",
-      "--use-system-libraries",
+      '--',
+      '--use-system-libraries',
       "--with-xml2-lib=#{install_dir}/embedded/lib",
       "--with-xml2-include=#{install_dir}/embedded/include/libxml2",
       "--with-xslt-lib=#{install_dir}/embedded/lib",
       "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
       "--with-iconv-dir=#{install_dir}/embedded",
-      "--with-zlib-dir=#{install_dir}/embedded",
+      "--with-zlib-dir=#{install_dir}/embedded"
     ]
   end
 
-  gem gem_command.join(" "), env: env
+  gem gem_command.join(' '), env: env
 
   delete "#{install_dir}/embedded/lib/ruby/gems/2.1.0/gems/mini_portile2-2.0.0/test"
 end

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -71,7 +71,7 @@ build do
       "--with-xslt-lib=#{install_dir}/embedded/lib",
       "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
       "--with-iconv-dir=#{install_dir}/embedded",
-      "--with-zlib-dir=#{install_dir}/embedded"
+      "--with-zlib-dir=#{install_dir}/embedded",
     ]
   end
 

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-name "ohai"
-default_version "master"
+name 'ohai'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -29,9 +29,9 @@ relative_path 'ohai'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle 'install --without development', env: env
 
-  gem "build ohai.gemspec", env: env
-  gem "install ohai*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build ohai.gemspec', env: env
+  gem 'install ohai*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -18,13 +18,13 @@
 name "ohai"
 default_version "master"
 
-source git: "https://github.com/opscode/ohai.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
-relative_path "ohai"
+source git: 'https://github.com/opscode/ohai.git'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
+relative_path 'ohai'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -14,25 +14,25 @@
 # limitations under the License.
 #
 
-name "omnibus-ctl"
-default_version "0.3.6"
+name 'omnibus-ctl'
+default_version '0.3.6'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
-source git: "https://github.com/chef/omnibus-ctl.git"
+source git: 'https://github.com/chef/omnibus-ctl.git'
 
-relative_path "omnibus-ctl"
+relative_path 'omnibus-ctl'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   # Remove existing built gems in case they exist in the current dir
-  delete "omnibus-ctl-*.gem"
+  delete 'omnibus-ctl-*.gem'
 
-  gem "build omnibus-ctl.gemspec", env: env
-  gem "install omnibus-ctl-*.gem --no-rdoc --no-ri", env: env
+  gem 'build omnibus-ctl.gemspec', env: env
+  gem 'install omnibus-ctl-*.gem --no-rdoc --no-ri', env: env
 
   touch "#{install_dir}/embedded/service/omnibus-ctl/.gitkeep"
 end

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name "openresty"
-default_version "1.9.7.2"
+name 'openresty'
+default_version '1.9.7.2'
 
-dependency "pcre"
-dependency "openssl"
-dependency "zlib"
+dependency 'pcre'
+dependency 'openssl'
+dependency 'zlib'
 
 if version < '1.9.7.2'
   source_package_name = 'ngx_openresty'
@@ -43,17 +43,17 @@ build do
   env['PATH'] += "#{env['PATH']}:/usr/sbin:/sbin"
 
   configure = [
-    "./configure",
+    './configure',
     "--prefix=#{install_dir}/embedded",
     "--sbin-path=#{install_dir}/embedded/sbin/nginx",
     "--conf-path=#{install_dir}/embedded/conf/nginx.conf",
-    "--with-http_ssl_module",
-    "--with-debug",
-    "--with-http_stub_status_module",
+    '--with-http_ssl_module',
+    '--with-debug',
+    '--with-http_stub_status_module',
     # Building Nginx with non-system OpenSSL
     # http://www.ruby-forum.com/topic/207287#902308
-    "--with-ld-opt=\"-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz\"",
-    "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"",
+    "--with-ld-opt='-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz'",
+    "--with-cc-opt='-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include'",
     # Options inspired by the OpenResty Cookbook
     '--with-md5-asm',
     '--with-sha1-asm',
@@ -63,7 +63,7 @@ build do
     '--without-mail_smtp_module',
     '--without-mail_imap_module',
     '--without-mail_pop3_module',
-    '--with-ipv6',
+    '--with-ipv6'
     # AIO support define in Openresty cookbook. Requires Kernel >= 2.6.22
     # Ubuntu 10.04 reports: 2.6.32-38-server #83-Ubuntu SMP
     # However, they require libatomic-ops-dev and libaio
@@ -73,17 +73,17 @@ build do
 
   # OpenResty 1.7 + RHEL5 Fixes:
   # According to https://github.com/openresty/ngx_openresty/issues/85, OpenResty
-  # fails to compile on RHEL5 without the "--with-luajit-xcflags='-std=gnu99'" flags
+  # fails to compile on RHEL5 without the '--with-luajit-xcflags="-std=gnu99"' flags
   if rhel? &&
      platform_version.satisfies?('< 6.0') &&
      version.satisfies?('>= 1.7')
-    configure << "--with-luajit-xcflags='-std=gnu99'"
+    configure << '--with-luajit-xcflags="-std=gnu99"'
   end
 
-  command configure.join(" "), env: env
+  command configure.join(' '), env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 
   touch "#{install_dir}/embedded/nginx/logs/.gitkeep"
 end

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -21,32 +21,20 @@ dependency "pcre"
 dependency "openssl"
 dependency "zlib"
 
-source_package_name = "openresty"
-
-version("1.9.7.3") { source md5: "33579b96a8c22bedee97eadfc99d9564" }
-
-version("1.9.7.2") do
-  source md5: "78a263de11ff43c95e847f208cce0899"
-  source_package_name = "ngx_openresty"
-end
-version("1.9.3.1") do
-  source md5: "cde1f7127f6ba413ee257003e49d6d0a"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.2") do
-  source md5: "bca1744196acfb9e986f1fdbee92641e"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.1") do
-  source md5: "1093b89459922634a818e05f80c1e18a"
-  source_package_name = "ngx_openresty"
-end
-version("1.4.3.6") do
-  source md5: "5e5359ae3f1b8db4046b358d84fabbc8"
-  source_package_name = "ngx_openresty"
+if version < '1.9.7.2'
+  source_package_name = 'ngx_openresty'
+else
+  source_package_name = 'openresty'
 end
 
 source url: "https://openresty.org/download/#{source_package_name}-#{version}.tar.gz"
+
+version('1.9.7.3')  { source md5: '33579b96a8c22bedee97eadfc99d9564' }
+version('1.9.7.2')  { source md5: '78a263de11ff43c95e847f208cce0899' }
+version('1.9.3.1')  { source md5: 'cde1f7127f6ba413ee257003e49d6d0a' }
+version('1.7.10.2') { source md5: 'bca1744196acfb9e986f1fdbee92641e' }
+version('1.7.10.1') { source md5: '1093b89459922634a818e05f80c1e18a' }
+version('1.4.3.6')  { source md5: '5e5359ae3f1b8db4046b358d84fabbc8' }
 
 relative_path "#{source_package_name}-#{version}"
 

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -18,14 +18,14 @@
 # This software makes sure that SSL_CERT_FILE environment variable is pointed
 # to the bundled CA certificates that ship with omnibus. With this, Chef
 # tools can be used with https URLs out of the box.
-name "openssl-customization"
+name 'openssl-customization'
 
 source path: "#{project.files_path}/#{name}"
 
-dependency "ruby"
+dependency 'ruby'
 
 build do
-  block "Add OpenSSL customization file" do
+  block 'Add OpenSSL customization file' do
     # gets directories for RbConfig::CONFIG and sanitizes them.
     def get_sanitized_rbconfig(config)
       ruby = windows_safe_path("#{install_dir}/embedded/bin/ruby")
@@ -46,25 +46,25 @@ build do
       embedded_ruby_site_dir = get_sanitized_rbconfig('sitelibdir')
       embedded_ruby_lib_dir  = get_sanitized_rbconfig('rubylibdir')
 
-      source_ssl_env_hack      = File.join(project_dir, "windows", "ssl_env_hack.rb")
-      destination_ssl_env_hack = File.join(embedded_ruby_site_dir, "ssl_env_hack.rb")
+      source_ssl_env_hack      = File.join(project_dir, 'windows', 'ssl_env_hack.rb')
+      destination_ssl_env_hack = File.join(embedded_ruby_site_dir, 'ssl_env_hack.rb')
 
       copy(source_ssl_env_hack, destination_ssl_env_hack)
 
       # Unfortunately there is no patch on windows, but luckily we only need to append a line to the openssl.rb
       # to pick up our script which find the CA bundle in omnibus installations and points SSL_CERT_FILE to it
       # if it's not already set
-      source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
-      File.open(source_openssl_rb, "r+") do |f|
+      source_openssl_rb = File.join(embedded_ruby_lib_dir, 'openssl.rb')
+      File.open(source_openssl_rb, 'r+') do |f|
         unpatched_openssl_rb = f.read
         f.rewind
         f.write("\nrequire 'ssl_env_hack'\n")
         f.write(unpatched_openssl_rb)
       end
     else
-      embedded_ruby_lib_dir  = get_sanitized_rbconfig('rubylibdir')
-      source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
-      File.open(source_openssl_rb, "r+") do |f|
+      embedded_ruby_lib_dir = get_sanitized_rbconfig('rubylibdir')
+      source_openssl_rb = File.join(embedded_ruby_lib_dir, 'openssl.rb')
+      File.open(source_openssl_rb, 'r+') do |f|
         unpatched_openssl_rb = f.read
         f.rewind
         f.write(unpatched_openssl_rb)

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -17,18 +17,17 @@
 name "openssl-fips"
 default_version "2.0.10"
 
-version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
-version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
-version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
-
-# HAHAHA According to the FIPS manual, you need to "securely" fetch the source
+# HAHAHA According to the FIPS manual, you need to 'securely' fetch the source
 # such as asking some humans to mail you a CD-ROM or something.
 # You are then supposed to manually verify the PGP signatures.
 # When making an "official" build - make sure you go do that...
 source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
 
-relative_path "openssl-fips-#{version}"
+version('2.0.11') { source sha256: 'a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac' }
+version('2.0.10') { source sha256: 'a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771' }
+version('2.0.9')  { source md5: 'c8256051d7a76471c6ad4fb771404e60' }
 
+relative_path "openssl-fips-#{version}"
 
 build do
   # According to the FIPS manual, this is the only environment you are allowed

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-name "openssl-fips"
-default_version "2.0.10"
+name 'openssl-fips'
+default_version '2.0.10'
 
 # HAHAHA According to the FIPS manual, you need to 'securely' fetch the source
 # such as asking some humans to mail you a CD-ROM or something.
 # You are then supposed to manually verify the PGP signatures.
-# When making an "official" build - make sure you go do that...
+# When making an 'official' build - make sure you go do that...
 source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
 
 version('2.0.11') { source sha256: 'a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac' }
@@ -45,30 +45,30 @@ build do
 
     if windows_arch_i386?
       # Patch Makefile.shared to let us set the bit-ness of the resource compiler.
-      patch source: "openssl-fips-take-windres-rcflags.patch", env: default_env
+      patch source: 'openssl-fips-take-windres-rcflags.patch', env: default_env
       # Patch Makefile.org to update the compiler flags/options table for mingw.
-      patch source: "openssl-fips-fix-compiler-flags-table-for-msys.patch", env: default_env
+      patch source: 'openssl-fips-fix-compiler-flags-table-for-msys.patch', env: default_env
       # Patch Configure to call ar.exe without anooying it.
-      patch source: "openssl-fips-ar-needs-operation-before-target.patch", env: default_env
+      patch source: 'openssl-fips-ar-needs-operation-before-target.patch', env: default_env
 
-      platform = "mingw"
+      platform = 'mingw'
       # Sparingly bring in the only flags absolutely needed to build this.
       # Do not bring in optimization flags and other library paths.
       env['ARFLAGS'] = default_env['ARFLAGS']
       env['RCFLAGS'] = default_env['RCFLAGS']
     else
-      platform = "mingw64"
+      platform = 'mingw64'
     end
 
     configure_command = ["perl.exe ./Configure #{platform}"]
     configure_command << "--prefix=#{install_dir}/embedded"
   else
-    configure_command = ["./config"]
+    configure_command = ['./config']
   end
 
-  command configure_command.join(" "), env: env, in_msys_bash: true
+  command configure_command.join(' '), env: env, in_msys_bash: true
 
   # Cannot use -j with openssl :(.
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -21,25 +21,18 @@ default_version "1.0.1r"
 
 dependency "ruby-windows"
 
-if windows_arch_i386?
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x86-windows.tar.lzma",
-           md5: "72e2cab647192ddc5314760feca6b424"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x86-windows.tar.lzma",
-           md5: "971abfe54d89d79b34c7444dcab8e17b"
-  end
+if i386?
+  arch = 'x86'
 else
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x64-windows.tar.lzma",
-           md5: "d1aa3c43f21eaf42abf321cbfd9de331"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x64-windows.tar.lzma",
-           md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b"
-  end
+  arch = 'x64'
 end
+
+source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-#{version}/openssl-#{version}-#{arch}-windows.tar.lzma"
+
+version('1.0.1r') { source md5: '72e2cab647192ddc5314760feca6b424' }
+version('1.0.1s') { source md5: '971abfe54d89d79b34c7444dcab8e17b' }
+version('1.0.1r') { source md5: 'd1aa3c43f21eaf42abf321cbfd9de331' }
+version('1.0.1s') { source md5: '0a8d444d22ab43ecf8ae29ec8d31fa1b' }
 
 relative_path 'bin'
 

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name "openssl-windows"
+name 'openssl-windows'
 # 1.0.1s is binary imcompatible with ruby from rubyinstaller due to an API
 # change removing SSLv2 functions.
-default_version "1.0.1r"
+default_version '1.0.1r'
 
-dependency "ruby-windows"
+dependency 'ruby-windows'
 
 if i386?
   arch = 'x86'
@@ -38,6 +38,6 @@ relative_path 'bin'
 
 build do
   # Copy over the required dlls into embedded/bin
-  copy "libeay32.dll", "#{install_dir}/embedded/bin/"
-  copy "ssleay32.dll", "#{install_dir}/embedded/bin/"
+  copy 'libeay32.dll', "#{install_dir}/embedded/bin/"
+  copy 'ssleay32.dll', "#{install_dir}/embedded/bin/"
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -64,7 +64,7 @@ build do
     'no-idea',
     'no-mdc2',
     'no-rc5',
-    'shared'
+    'shared',
   ]
 
   if fips_enabled

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -16,15 +16,15 @@
 
 name "openssl"
 
+default_version '1.0.1s'
+
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
-dependency "zlib"
-dependency "cacerts"
-dependency "makedepend" unless aix? || windows?
-dependency "patch" if solaris2?
-dependency "openssl-fips" if fips_enabled
-
-default_version "1.0.1s"
+dependency 'zlib'
+dependency 'cacerts'
+dependency 'makedepend'   unless aix? || windows?
+dependency 'patch'        if solaris2?
+dependency 'openssl-fips' if fips_enabled
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-name "openssl"
+name 'openssl'
 
 default_version '1.0.1s'
 
@@ -32,17 +32,16 @@ source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract:
 
 # We have not tested version 1.0.2. It's here so we can run experimental builds
 # to verify that it still compiles on all our platforms.
-version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }
-version("1.0.1s") { source md5: "562986f6937aabc7c11a6d376d8a0d26" }
-version("1.0.1r") { source md5: "1abd905e079542ccae948af37e393d28" }
+version('1.0.2g') { source md5: 'f3c710c045cdee5fd114feb69feba7aa' }
+version('1.0.1s') { source md5: '562986f6937aabc7c11a6d376d8a0d26' }
+version('1.0.1r') { source md5: '1abd905e079542ccae948af37e393d28' }
 
 relative_path "openssl-#{version}"
 
 build do
-
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
   if aix?
-    env["M4"] = "/opt/freeware/bin/m4"
+    env['M4'] = '/opt/freeware/bin/m4'
   elsif freebsd?
     # Should this just be in standard_compiler_flags?
     env['LDFLAGS'] += " -Wl,-rpath,#{install_dir}/embedded/lib"
@@ -52,7 +51,7 @@ build do
     # and the 32-bit calling convention involving XMM registers is...  vague.
     # Do not enable SSE2 generally because the hand optimized assembly will
     # overwrite registers that mingw expects to get preserved.
-    arch_flag = windows_arch_i386? ? "-m32" : "-m64"
+    arch_flag = windows_arch_i386? ? '-m32' : '-m64'
     env['CFLAGS'] = "-I#{install_dir}/embedded/include #{arch_flag}"
     env['CPPFLAGS'] = env['CFLAGS']
     env['CXXFLAGS'] = env['CFLAGS']
@@ -62,45 +61,45 @@ build do
     "--prefix=#{install_dir}/embedded",
     "--with-zlib-lib=#{install_dir}/embedded/lib",
     "--with-zlib-include=#{install_dir}/embedded/include",
-    "no-idea",
-    "no-mdc2",
-    "no-rc5",
-    "shared",
+    'no-idea',
+    'no-mdc2',
+    'no-rc5',
+    'shared'
   ]
 
   if fips_enabled
-    configure_args << "--with-fipsdir=#{install_dir}/embedded" << "fips"
+    configure_args << "--with-fipsdir=#{install_dir}/embedded" << 'fips'
   end
 
   if windows?
-    configure_args << "zlib-dynamic"
+    configure_args << 'zlib-dynamic'
   else
-    configure_args << "zlib"
+    configure_args << 'zlib'
   end
 
   configure_cmd =
     if aix?
-      "perl ./Configure aix64-cc"
+      'perl ./Configure aix64-cc'
     elsif mac_os_x?
-      "./Configure darwin64-x86_64-cc"
+      './Configure darwin64-x86_64-cc'
     elsif smartos?
-      "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
+      '/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc'
     elsif solaris2?
       # This should not require a /bin/sh, but without it we get
       # Errno::ENOEXEC: Exec format error
-      platform = sparc? ? "solaris-sparcv9-gcc" : "solaris-x86-gcc"
+      platform = sparc? ? 'solaris-sparcv9-gcc' : 'solaris-x86-gcc'
       "/bin/sh ./Configure #{platform}"
     elsif windows?
-      platform = windows_arch_i386? ? "mingw" : "mingw64"
+      platform = windows_arch_i386? ? 'mingw' : 'mingw64'
       "perl.exe ./Configure #{platform}"
     else
       prefix =
         if linux? && ppc64?
-          "./Configure linux-ppc64"
-        elsif linux? && ohai["kernel"]["machine"] == "s390x"
-          "./Configure linux64-s390x"
+          './Configure linux-ppc64'
+        elsif linux? && ohai['kernel']['machine'] == 's390x'
+          './Configure linux64-s390x'
         else
-          "./config"
+          './config'
         end
       "#{prefix} disable-gost"
     end
@@ -109,32 +108,32 @@ build do
 
     # This enables omnibus to use 'makedepend'
     # from fileset 'X11.adt.imake' (AIX install media)
-    env['PATH'] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+    env['PATH'] = "/usr/lpp/X11/bin:#{ENV['PATH']}"
 
     patch_env = env.dup
     patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
+    patch source: 'openssl-1.0.1f-do-not-build-docs.patch', env: patch_env
   else
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
+    patch source: 'openssl-1.0.1f-do-not-build-docs.patch', env: env
   end
 
   if windows?
     # Patch Makefile.shared to let us set the bit-ness of the resource compiler.
-    patch source: "openssl-1.0.1q-take-windres-rcflags.patch", env: env
+    patch source: 'openssl-1.0.1q-take-windres-rcflags.patch', env: env
     # Patch Makefile.org to update the compiler flags/options table for mingw.
-    patch source: "openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch", env: env
+    patch source: 'openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch', env: env
     # Patch Configure to call ar.exe without anooying it.
-    patch source: "openssl-1.0.1q-ar-needs-operation-before-target.patch", env: env
+    patch source: 'openssl-1.0.1q-ar-needs-operation-before-target.patch', env: env
   end
 
   # Out of abundance of caution, we put the feature flags first and then
   # the crazy platform specific compiler flags at the end.
   configure_args << env['CFLAGS'] << env['LDFLAGS']
 
-  configure_command = configure_args.unshift(configure_cmd).join(" ")
+  configure_command = configure_args.unshift(configure_cmd).join(' ')
 
   command configure_command, env: env, in_msys_bash: true
-  make "depend", env: env
+  make 'depend', env: env
   # make -j N on openssl is not reliable
   make env: env
   if aix?
@@ -145,7 +144,7 @@ build do
     # can't install the library that is already in use. Ideally we would patch openssl
     # to make this not be an issue.
     # Bug Ref: http://rt.openssl.org/Ticket/Display.html?id=2986&user=guest&pass=guest
-    command "sudo /usr/sbin/slibclean", env: env
+    command 'sudo /usr/sbin/slibclean', env: env
   end
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -14,18 +14,20 @@
 # limitations under the License.
 #
 
-name "patch"
+name 'patch'
 
 if windows?
   # TODO more recent version now?
-  default_version "2.6.1"
-  dependency "mingw-get"
+  default_version '2.6.1'
+  dependency 'mingw-get'
 else
-  default_version "2.7"
+  default_version '2.7'
 
-  version("2.7.5") { source md5: "ed4d5674ef4543b4eb463db168886dc7" }
-  version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
   source url: "https://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
+
+  version('2.7.5') { source md5: 'ed4d5674ef4543b4eb463db168886dc7' }
+  version('2.7')   { source md5: '1cbaa223ff4991be9fae8ec1d11fb5ab' }
+
   relative_path "patch-#{version}"
 end
 
@@ -36,7 +38,7 @@ build do
     command "mingw-get.exe -v install msys-patch-bin=#{version}-*",
             env: env, cwd: "#{install_dir}/embedded"
   else
-    configure "--disable-xattr", env: env
+    configure '--disable-xattr', env: env
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env
   end

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -14,21 +14,16 @@
 # limitations under the License.
 #
 
-name "pcre"
-default_version "8.38"
+name 'pcre'
+default_version '8.38'
 
-dependency "libedit"
-dependency "ncurses"
-
-version "8.38" do
-  source md5: "8a353fe1450216b6655dfcf3561716d9"
-end
-
-version "8.31" do
-  source md5: "fab1bb3b91a4c35398263a5c1e0858c1"
-end
+dependency 'libedit'
+dependency 'ncurses'
 
 source url: "http://iweb.dl.sourceforge.net/project/pcre/pcre/#{version}/pcre-#{version}.tar.gz"
+
+version('8.38') { source md5: '8a353fe1450216b6655dfcf3561716d9' }
+version('8.31') { source md5: 'fab1bb3b91a4c35398263a5c1e0858c1' }
 
 relative_path "pcre-#{version}"
 

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -30,12 +30,12 @@ relative_path "pcre-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --enable-utf" \
-          " --enable-unicode-properties" \
-          " --enable-pcretest-libedit", env: env
+          ' --enable-utf' \
+          ' --enable-unicode-properties' \
+          ' --enable-pcretest-libedit', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/perl-extutils-embed.rb
+++ b/config/software/perl-extutils-embed.rb
@@ -27,11 +27,11 @@ relative_path "ExtUtils-Embed-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    "INSTALL_BASE" => "#{install_dir}/embedded",
+    'INSTALL_BASE' => "#{install_dir}/embedded"
   )
 
   command "#{install_dir}/embedded/bin/perl Makefile.PL", env: env
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/perl-extutils-embed.rb
+++ b/config/software/perl-extutils-embed.rb
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 
-name "perl-extutils-embed"
-default_version "1.14"
+name 'perl-extutils-embed'
+default_version '1.14'
 
-dependency "perl"
+dependency 'perl'
 
-source url: "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed-#{version}.tar.gz",
-       md5: "b2a2c26a18bca3ce69f8a0b1b54a0105"
+source url: "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed-#{version}.tar.gz"
+
+version('1.14') { source md5: 'b2a2c26a18bca3ce69f8a0b1b54a0105' }
 
 relative_path "ExtUtils-Embed-#{version}"
 

--- a/config/software/perl-extutils-embed.rb
+++ b/config/software/perl-extutils-embed.rb
@@ -27,7 +27,7 @@ relative_path "ExtUtils-Embed-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    'INSTALL_BASE' => "#{install_dir}/embedded"
+    'INSTALL_BASE' => "#{install_dir}/embedded",
   )
 
   command "#{install_dir}/embedded/bin/perl Makefile.PL", env: env

--- a/config/software/perl-extutils-makemaker.rb
+++ b/config/software/perl-extutils-makemaker.rb
@@ -29,11 +29,11 @@ relative_path "ExtUtils-MakeMaker-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    "INSTALL_BASE" => "#{install_dir}/embedded",
+    'INSTALL_BASE' => "#{install_dir}/embedded"
   )
 
   command "#{install_dir}/embedded/bin/perl Makefile.PL", env: env
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/perl-extutils-makemaker.rb
+++ b/config/software/perl-extutils-makemaker.rb
@@ -14,23 +14,16 @@
 # limitations under the License.
 #
 
-name "perl-extutils-makemaker"
-default_version "6.78"
+name 'perl-extutils-makemaker'
+default_version '6.78'
 
-dependency "perl"
-
-version "6.98" do
-  source md5: "3eb83b59e33159ecc700bf60ac3c357a"
-end
-version "6.78" do
-  source md5: "843886bc1060b5e5c619e34029343eba"
-end
-version "7.10" do
-  source md5: "2639a21adee5e0a903730c12dcba08ec"
-end
+dependency 'perl'
 
 source url: "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-#{version}.tar.gz"
 
+version('6.98') { source md5: '3eb83b59e33159ecc700bf60ac3c357a' }
+version('6.78') { source md5: '843886bc1060b5e5c619e34029343eba' }
+version('7.10') { source md5: '2639a21adee5e0a903730c12dcba08ec' }
 
 relative_path "ExtUtils-MakeMaker-#{version}"
 

--- a/config/software/perl-extutils-makemaker.rb
+++ b/config/software/perl-extutils-makemaker.rb
@@ -29,7 +29,7 @@ relative_path "ExtUtils-MakeMaker-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    'INSTALL_BASE' => "#{install_dir}/embedded"
+    'INSTALL_BASE' => "#{install_dir}/embedded",
   )
 
   command "#{install_dir}/embedded/bin/perl Makefile.PL", env: env

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-name "perl"
+name 'perl'
 
 if windows?
-  default_version "5.8.8"
-  dependency "mingw-get"
+  default_version '5.8.8'
+  dependency 'mingw-get'
 else
-  default_version "5.18.1"
+  default_version '5.18.1'
 
   source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz"
 
@@ -41,35 +41,35 @@ build do
     if solaris2? && File.exist?(solaris_mapfile_path)
       cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}"
     elsif aix?
-      cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"
+      cc_command = '-Dcc="/opt/IBM/xlc/13.1.0/bin/cc_r -q64"'
     elsif freebsd? && ohai['os_version'].to_i >= 1000024
-      cc_command = "-Dcc='clang'"
+      cc_command = '-Dcc="clang"'
     else
-      cc_command = "-Dcc='gcc -static-libgcc'"
+      cc_command = '-Dcc="gcc -static-libgcc"'
     end
 
-    configure_command = ["sh Configure",
-                        " -de",
+    configure_command = ['sh Configure',
+                        ' -de',
                         " -Dprefix=#{install_dir}/embedded",
-                        " -Duseshrplib",
-                        " -Dusethreads",
+                        ' -Duseshrplib',
+                        ' -Dusethreads',
                         " #{cc_command}",
-                        " -Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"]
+                        ' -Dnoextensions="DB_File GDBM_File NDBM_File ODBM_File"']
 
     if aix?
-      configure_command << "-Dmake=gmake"
-      configure_command << "-Duse64bitall"
+      configure_command << '-Dmake=gmake'
+      configure_command << '-Duse64bitall'
     end
 
     # On Cisco IOS-XR, we don't want libssp as a dependency
     if ios_xr?
-      configure_command << "-Accflags=-fno-stack-protector"
+      configure_command << '-Accflags=-fno-stack-protector'
     end
 
-    command configure_command.join(" "), env: env
+    command configure_command.join(' '), env: env
     make "-j #{workers}", env: env
     # using the install.perl target lets
     # us skip install the manpages
-    make "install.perl", env: env
+    make 'install.perl', env: env
   end
 end

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -22,13 +22,11 @@ if windows?
 else
   default_version "5.18.1"
 
-  version "5.22.1" do
-    source md5: "19295bbb775a3c36123161b9bf4892f1"
-  end
-  version "5.18.1" do
-    source md5: "304cb5bd18e48c44edd6053337d3386d"
-  end
   source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz"
+
+  version('5.22.1') { source md5: '19295bbb775a3c36123161b9bf4892f1' }
+  version('5.18.1') { source md5: '304cb5bd18e48c44edd6053337d3386d' }
+
   relative_path "perl-#{version}"
 end
 

--- a/config/software/perl_pg_driver.rb
+++ b/config/software/perl_pg_driver.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "perl_pg_driver"
-default_version "3.3.0"
+name 'perl_pg_driver'
+default_version '3.3.0'
 
 dependency 'perl'
 dependency 'cpanminus'
@@ -31,5 +31,5 @@ relative_path "DBD-Pg-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "cpanm -v --notest .", env: env
+  command 'cpanm -v --notest .', env: env
 end

--- a/config/software/perl_pg_driver.rb
+++ b/config/software/perl_pg_driver.rb
@@ -17,18 +17,14 @@
 name "perl_pg_driver"
 default_version "3.3.0"
 
-dependency "perl"
-dependency "cpanminus"
-dependency "postgresql"
-
-version "3.5.3" do
-  source md5: "21cdf31a8d1f77466920375aa766c164"
-end
-version "3.3.0" do
-  source md5: "547de1382a47d66872912fe64282ff55"
-end
+dependency 'perl'
+dependency 'cpanminus'
+dependency 'postgresql'
 
 source url: "http://search.cpan.org/CPAN/authors/id/T/TU/TURNSTEP/DBD-Pg-#{version}.tar.gz"
+
+version('3.5.3') { source md5: '21cdf31a8d1f77466920375aa766c164' }
+version('3.3.0') { source md5: '547de1382a47d66872912fe64282ff55' }
 
 relative_path "DBD-Pg-#{version}"
 

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "pg-gem"
-default_version "0.17.1"
+name 'pg-gem'
+default_version '0.17.1'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install pg" \
+  gem 'install pg' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -14,9 +14,8 @@
 # limitations under the License.
 #
 
-name "pkg-config-lite"
-default_version "0.28-1"
-
+name 'pkg-config-lite'
+default_version '0.28-1'
 
 source url: "http://downloads.sourceforge.net/project/pkgconfiglite/#{version}/pkg-config-lite-#{version}.tar.gz"
 
@@ -27,13 +26,13 @@ relative_path "pkg-config-lite-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if version == "0.28-1"
-    patch source: "pkg-config-lite-0.28-1.config.guess.patch", plevel: 0
+  if version == '0.28-1'
+    patch source: 'pkg-config-lite-0.28-1.config.guess.patch', plevel: 0
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-host-tool" \
+          ' --disable-host-tool' \
           " --with-pc-path=#{install_dir}/embedded/bin/pkgconfig", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -17,11 +17,10 @@
 name "pkg-config-lite"
 default_version "0.28-1"
 
-version "0.28-1" do
-  source md5: "61f05feb6bab0a6bbfab4b6e3b2f44b6"
-end
 
 source url: "http://downloads.sourceforge.net/project/pkgconfiglite/#{version}/pkg-config-lite-#{version}.tar.gz"
+
+version('0.28-1') { source md5: '61f05feb6bab0a6bbfab4b6e3b2f44b6' }
 
 relative_path "pkg-config-lite-#{version}"
 

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "pkg-config"
-default_version "0.28"
+name 'pkg-config'
+default_version '0.28'
 
 dependency 'libiconv'
 
@@ -29,21 +29,21 @@ relative_path "pkg-config-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if version == "0.28" && ppc64le?
-    patch source: "v0.28.ppc64le-configure.patch", plevel: 1, env: env
+  if version == '0.28' && ppc64le?
+    patch source: 'v0.28.ppc64le-configure.patch', plevel: 1, env: env
   end
 
   # pkg-config (at least up to 0.28) includes an older version of
   # libcharset/lib/config.charset that doesn't know about openbsd
   if openbsd?
-    patch source: "openbsd-charset.patch", plevel: 1, env: env
+    patch source: 'openbsd-charset.patch', plevel: 1, env: env
   end
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-debug" \
-          " --disable-host-tool" \
-          " --with-internal-glib" \
+          ' --disable-debug' \
+          ' --disable-host-tool' \
+          ' --with-internal-glib' \
           " --with-pc-path=#{install_dir}/embedded/bin/pkgconfig", env: env
 
 
@@ -51,9 +51,9 @@ build do
   # Only allows GLIB_CFLAGS and GLIB_LIBS.
   # These do not serve our purpose, so we must explicitly
   # ./configure in the glib dir, with the Omnibus ldflags.
-  command  "./configure" \
+  command  './configure' \
            " --prefix=#{install_dir}/embedded" \
-           " --with-libiconv=gnu", env: env, cwd: "#{project_dir}/glib"
+           ' --with-libiconv=gnu', env: env, cwd: "#{project_dir}/glib"
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -17,17 +17,12 @@
 name "pkg-config"
 default_version "0.28"
 
-dependency "libiconv"
-
-version "0.29" do
-  source md5: "77f27dce7ef88d0634d0d6f90e03a77f"
-end
-
-version "0.28" do
-  source md5: "aa3c86e67551adc3ac865160e34a2a0d"
-end
+dependency 'libiconv'
 
 source url: "https://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
+
+version('0.29') { source md5: '77f27dce7ef88d0634d0d6f90e03a77f' }
+version('0.28') { source md5: 'aa3c86e67551adc3ac865160e34a2a0d' }
 
 relative_path "pkg-config-#{version}"
 

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "popt"
-default_version "1.16"
+name 'popt'
+default_version '1.16'
 
 source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz"
 
@@ -27,10 +27,10 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   # --disable-nls => Disable localization support.
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-nls", env: env
+          ' --disable-nls', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -17,8 +17,9 @@
 name "popt"
 default_version "1.16"
 
-source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz",
-       md5: "3743beefa3dd6247a73f8f7a32c14c33"
+source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz"
+
+version('1.16') { source md5: '3743beefa3dd6247a73f8f7a32c14c33' }
 
 relative_path "popt-#{version}"
 

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -14,15 +14,14 @@
 # limitations under the License.
 #
 
-name "postgresql"
-default_version "9.2.10"
+name 'postgresql'
+default_version '9.2.10'
 
-dependency "zlib"
-dependency "openssl"
-dependency "libedit"
-dependency "ncurses"
-dependency "libossp-uuid"
-
+dependency 'zlib'
+dependency 'openssl'
+dependency 'libedit'
+dependency 'ncurses'
+dependency 'libossp-uuid'
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 
@@ -49,14 +48,14 @@ relative_path "postgresql-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --with-libedit-preferred" \
-          " --with-openssl" \
-          " --with-ossp-uuid" \
+          ' --with-libedit-preferred' \
+          ' --with-openssl' \
+          ' --with-ossp-uuid' \
           " --with-includes=#{install_dir}/embedded/include" \
           " --with-libraries=#{install_dir}/embedded/lib", env: env
 
   make "world -j #{workers}", env: env
-  make "install-world", env: env
+  make 'install-world', env: env
 end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -23,75 +23,26 @@ dependency "libedit"
 dependency "ncurses"
 dependency "libossp-uuid"
 
-version "9.2.14" do
-  source md5: "ce2e50565983a14995f5dbcd3c35b627"
-end
-
-version "9.2.10" do
-  source md5: "7b81646e2eaf67598d719353bf6ee936"
-end
-
-version "9.2.9" do
-  source md5: "38b0937c86d537d5044c599273066cfc"
-end
-
-version "9.2.8" do
-  source md5: "c5c65a9b45ee53ead0b659be21ca1b97"
-end
-
-version "9.5.1" do
-  source md5: "11e037afaa4bd0c90bb3c3d955e2b401"
-end
-
-version "9.5.0" do
-  source md5: "2f3264612ac32e5abdfb643fec934036"
-end
-
-version "9.5beta1" do
-  source md5: "4bd67bfa4dc148e3f9d09f6699b5931f"
-end
-
-version "9.4.6" do
-  source md5: "0371b9d4fb995062c040ea5c3c1c971e"
-end
-
-version "9.4.5" do
-  source md5: "8b2e3472a8dc786649b4d02d02e039a0"
-end
-
-version "9.4.1" do
-  source md5: "2cf30f50099ff1109d0aa517408f8eff"
-end
-
-version "9.4.0" do
-  source md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b"
-end
-
-version "9.3.10" do
-  source md5: "ec2365548d08f69c8023eddd4f2d1a28"
-end
-
-version "9.3.6" do
-  source md5: "0212b03f2835fdd33126a2e70996be8e"
-end
-
-version "9.3.5" do
-  source md5: "5059857c7d7e6ad83b6d55893a121b59"
-end
-
-version "9.3.4" do
-  source md5: "d0a41f54c377b2d2fab4a003b0dac762"
-end
-
-version "9.1.15" do
-  source md5: "6ac52cf13ecf6b09c7d42928d1219cae"
-end
-
-version "9.1.9" do
-  source md5: "6b5ea53dde48fcd79acfc8c196b83535"
-end
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+
+version('9.1.15')   { source md5: '6ac52cf13ecf6b09c7d42928d1219cae' }
+version('9.1.9')    { source md5: '6b5ea53dde48fcd79acfc8c196b83535' }
+version('9.2.10')   { source md5: '7b81646e2eaf67598d719353bf6ee936' }
+version('9.2.14')   { source md5: 'ce2e50565983a14995f5dbcd3c35b627' }
+version('9.2.8')    { source md5: 'c5c65a9b45ee53ead0b659be21ca1b97' }
+version('9.2.9')    { source md5: '38b0937c86d537d5044c599273066cfc' }
+version('9.3.10')   { source md5: 'ec2365548d08f69c8023eddd4f2d1a28' }
+version('9.3.4')    { source md5: 'd0a41f54c377b2d2fab4a003b0dac762' }
+version('9.3.5')    { source md5: '5059857c7d7e6ad83b6d55893a121b59' }
+version('9.3.6')    { source md5: '0212b03f2835fdd33126a2e70996be8e' }
+version('9.4.0')    { source md5: '8cd6e33e1f8d4d2362c8c08bd0e8802b' }
+version('9.4.1')    { source md5: '2cf30f50099ff1109d0aa517408f8eff' }
+version('9.4.5')    { source md5: '8b2e3472a8dc786649b4d02d02e039a0' }
+version('9.4.6')    { source md5: '0371b9d4fb995062c040ea5c3c1c971e' }
+version('9.5.0')    { source md5: '2f3264612ac32e5abdfb643fec934036' }
+version('9.5.1')    { source md5: '11e037afaa4bd0c90bb3c3d955e2b401' }
+version('9.5beta1') { source md5: '4bd67bfa4dc148e3f9d09f6699b5931f' }
 
 relative_path "postgresql-#{version}"
 

--- a/config/software/preparation.rb
+++ b/config/software/preparation.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "preparation"
-description "the steps required to preprare the build"
+name 'preparation'
+description 'the steps required to preprare the build'
 default_version '1.0.0'
 
 build do

--- a/config/software/pry.rb
+++ b/config/software/pry.rb
@@ -14,18 +14,18 @@
 # limitations under the License.
 #
 
-name "pry"
+name 'pry'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem_command = [ "install pry --no-ri --no-rdoc" ]
+  gem_command = [ 'install pry --no-ri --no-rdoc' ]
   gem_command << "--version '#{version}'" unless version.nil?
 
-  gem gem_command.join(" "), env: env
+  gem gem_command.join(' '), env: env
 
-  gem "install pry-remote pry-byebug pry-stack_explorer --no-ri --no-rdoc"
+  gem 'install pry-remote pry-byebug pry-stack_explorer --no-ri --no-rdoc'
 end

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -33,7 +33,7 @@ relative_path "Python-#{version}"
 build do
   env = {
     'CFLAGS'  => "-I#{install_dir}/embedded/include -O3 -g -pipe",
-    'LDFLAGS' => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+    'LDFLAGS' => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
   }
 
   command './configure' \

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -22,11 +22,12 @@ dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
 
-version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
-version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }
-version("2.7.5") { source md5: "b4f01a1d0ba0b46b05c73b2ac909b1df" }
 
 source url: "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
+
+version('2.7.11') { source md5: '6b6076ec9e93f05dd63e47eb9c15728b' }
+version('2.7.9')  { source md5: '5eebcaa0030dc4061156d3429657fb83' }
+version('2.7.5')  { source md5: 'b4f01a1d0ba0b46b05c73b2ac909b1df' }
 
 relative_path "Python-#{version}"
 

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
-name "python"
-default_version "2.7.9"
+name 'python'
+default_version '2.7.9'
 
-dependency "ncurses"
-dependency "zlib"
-dependency "openssl"
-dependency "bzip2"
-
+dependency 'ncurses'
+dependency 'zlib'
+dependency 'openssl'
+dependency 'bzip2'
 
 source url: "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
 
@@ -33,17 +32,17 @@ relative_path "Python-#{version}"
 
 build do
   env = {
-    "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+    'CFLAGS'  => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+    'LDFLAGS' => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
   }
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --enable-shared" \
-          " --with-dbmliborder=", env: env
+          ' --enable-shared' \
+          ' --with-dbmliborder=', env: env
 
   make env: env
-  make "install", env: env
+  make 'install', env: env
 
   # There exists no configure flag to tell Python to not compile readline
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "rabbitmq"
-default_version "2.7.1"
+name 'rabbitmq'
+default_version '2.7.1'
 
 dependency 'erlang'
 

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -17,14 +17,14 @@
 name "rabbitmq"
 default_version "2.7.1"
 
-dependency "erlang"
-
-version("3.6.0") { source md5: "61a3822f3af0aaa30da7230dccb17067" }
-version("3.3.4") { source md5: "61a3822f3af0aaa30da7230dccb17067" }
-version("2.8.7") { source md5: "35e8d78f8d7ae4372db23fe50db82c64" }
-version("2.7.1") { source md5: "34a5f9fb6f22e6681092443fcc80324f" }
+dependency 'erlang'
 
 source url: "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/rabbitmq-server-generic-unix-#{version}.tar.gz"
+
+version('3.6.0') { source md5: '61a3822f3af0aaa30da7230dccb17067' }
+version('3.3.4') { source md5: '61a3822f3af0aaa30da7230dccb17067' }
+version('2.8.7') { source md5: '35e8d78f8d7ae4372db23fe50db82c64' }
+version('2.7.1') { source md5: '34a5f9fb6f22e6681092443fcc80324f' }
 
 relative_path "rabbitmq_server-#{version}"
 

--- a/config/software/rb-readline.rb
+++ b/config/software/rb-readline.rb
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
-name "rb-readline"
-default_version "master"
+name 'rb-readline'
+default_version 'master'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
-source git: "https://github.com/ConnorAtherton/rb-readline.git"
+source git: 'https://github.com/ConnorAtherton/rb-readline.git'
 
 build do
   env = with_embedded_path
 
-  ruby "setup.rb", env: env
+  ruby 'setup.rb', env: env
 end

--- a/config/software/rebar.rb
+++ b/config/software/rebar.rb
@@ -14,25 +14,25 @@
 # limitations under the License.
 #
 
-name "rebar"
+name 'rebar'
 
 # Current version (2.3.0) suffers from a pretty bad bug that breaks tests.
 # (see https://github.com/rebar/rebar/pull/279 and https://github.com/rebar/rebar/pull/251)
 # Version 2.3.1 Fixes this; we should switch to that if later versions aren't workable.
 # Version 2.6.1 includes this fix.
-default_version "93621d0d0c98035f79790ffd24beac94581b0758"
+default_version '93621d0d0c98035f79790ffd24beac94581b0758'
 
-version "2.6.0"
+version '2.6.0'
 
-dependency "erlang"
+dependency 'erlang'
 
-source git: "https://github.com/rebar/rebar.git"
+source git: 'https://github.com/rebar/rebar.git'
 
-relative_path "rebar"
+relative_path 'rebar'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./bootstrap", env: env
+  command './bootstrap', env: env
   copy "#{project_dir}/rebar", "#{install_dir}/embedded/bin/"
 end

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "redis-gem"
-default_version "3.1.0"
+name 'redis-gem'
+default_version '3.1.0'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install redis" \
+  gem 'install redis' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -14,30 +14,16 @@
 # limitations under the License.
 #
 
-name "redis"
-default_version "3.0.4"
-
-version "3.0.7" do
-  source md5: "84ed3f486e7a6f0ebada6917370f3532"
-end
-
-version "3.0.4" do
-  source md5: "9e535dea3dc5301de012047bf3cca952"
-end
-
-version "2.8.21" do
-  source md5: "d059e2bf5315e2488ab679e09e55a9e7"
-end
-
-version "2.8.2" do
-  source md5: "ee527b0c37e1e2cbceb497f5f6b8112b"
-end
-
-version "2.4.7" do
-  source md5: "6afffb6120724183e40f1cac324ac71c"
-end
+name 'redis'
+default_version '3.0.4'
 
 source url: "http://download.redis.io/releases/redis-#{version}.tar.gz"
+
+version('3.0.7')  { source md5: '84ed3f486e7a6f0ebada6917370f3532' }
+version('3.0.4')  { source md5: '9e535dea3dc5301de012047bf3cca952' }
+version('2.8.21') { source md5: 'd059e2bf5315e2488ab679e09e55a9e7' }
+version('2.8.2')  { source md5: 'ee527b0c37e1e2cbceb497f5f6b8112b' }
+version('2.4.7')  { source md5: '6afffb6120724183e40f1cac324ac71c' }
 
 relative_path "redis-#{version}"
 

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -29,7 +29,7 @@ relative_path "redis-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    'PREFIX' => "#{install_dir}/embedded"
+    'PREFIX' => "#{install_dir}/embedded",
   )
 
   make "-j #{workers}", env: env

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -29,9 +29,9 @@ relative_path "redis-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
-    "PREFIX" => "#{install_dir}/embedded",
+    'PREFIX' => "#{install_dir}/embedded"
   )
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/relx.rb
+++ b/config/software/relx.rb
@@ -14,21 +14,21 @@
 # limitations under the License.
 #
 
-name "relx"
+name 'relx'
 
 # Release tags are available, which you can use via override in
 # project config.
-default_version "master"
+default_version 'master'
 
-dependency "erlang"
+dependency 'erlang'
 
 # NOTE: requires rebar > 2.2.0 Not sure what the minimum is, but
 # 837df640872d6a5d5d75a7308126e2769d7babad of rebar works.
-dependency "rebar"
+dependency 'rebar'
 
-source git: "https://github.com/erlware/relx.git"
+source git: 'https://github.com/erlware/relx.git'
 
-relative_path "relx"
+relative_path 'relx'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "rsync"
-default_version "3.1.1"
+name 'rsync'
+default_version '3.1.1'
 
 dependency 'popt'
 
@@ -29,10 +29,10 @@ relative_path "rsync-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded" \
-          " --disable-iconv", env: env
+          ' --disable-iconv', env: env
 
   make "-j #{workers}", env: env
-  make "install", env: env
+  make 'install', env: env
 end

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -17,17 +17,12 @@
 name "rsync"
 default_version "3.1.1"
 
-dependency "popt"
-
-version "3.1.2" do
-  source md5: "0f758d7e000c0f7f7d3792610fad70cb"
-end
-
-version "3.1.1" do
-  source md5: "43bd6676f0b404326eee2d63be3cdcfe"
-end
+dependency 'popt'
 
 source url: "https://rsync.samba.org/ftp/rsync/src/rsync-#{version}.tar.gz"
+
+version('3.1.2') { source md5: '0f758d7e000c0f7f7d3792610fad70cb' }
+version('3.1.1') { source md5: '43bd6676f0b404326eee2d63be3cdcfe' }
 
 relative_path "rsync-#{version}"
 

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -17,11 +17,11 @@
 name "rubocop"
 default_version "master"
 
-source git: "https://github.com/bbatsov/rubocop.git"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
+source git: 'https://github.com/bbatsov/rubocop.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "rubocop"
-default_version "master"
+name 'rubocop'
+default_version 'master'
 
 dependency 'ruby'
 dependency 'rubygems'
@@ -26,9 +26,9 @@ source git: 'https://github.com/bbatsov/rubocop.git'
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development test", env: env
+  bundle 'install --without development test', env: env
 
-  gem "build rubocop.gemspec", env: env
-  gem "install rubocop-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build rubocop.gemspec', env: env
+  gem 'install rubocop-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -18,9 +18,11 @@
 name "ruby-windows-devkit-bash"
 default_version "3.1.23-4-msys-1.0.18"
 
-dependency "ruby-windows-devkit"
-source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
-       md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"
+dependency 'ruby-windows-devkit'
+
+source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma"
+
+version('3.1.23-4-msys-1.0.18') { source md5: '22d5dbbd9bd0b3e0380d7a0e79c3108e' }
 
 relative_path 'bin'
 

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-name "ruby-windows-devkit-bash"
-default_version "3.1.23-4-msys-1.0.18"
+name 'ruby-windows-devkit-bash'
+default_version '3.1.23-4-msys-1.0.18'
 
 dependency 'ruby-windows-devkit'
 
@@ -28,7 +28,7 @@ relative_path 'bin'
 
 build do
   # Copy over the required bins into embedded/bin
-  ["bash.exe", "sh.exe"].each do |exe|
+  ['bash.exe', 'sh.exe'].each do |exe|
     copy "#{exe}", "#{install_dir}/embedded/bin/#{exe}"
   end
 end

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -14,25 +14,26 @@
 # limitations under the License.
 #
 
-name "ruby-windows-devkit"
-default_version "4.7.2-20130224"
+name 'ruby-windows-devkit'
+default_version '4.7.2-20130224'
 
 if windows_arch_i386?
-  version "4.5.2-20111229-1559" do
+  version '4.5.2-20111229-1559' do
     source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
-           md5: "4bf8f2dd1d582c8733a67027583e19a6"
+           md5: '4bf8f2dd1d582c8733a67027583e19a6'
   end
 
-  version "4.7.2-20130224" do
+  version '4.7.2-20130224' do
     source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-#{version}-1151-sfx.exe",
-           md5: "9383f12958aafc425923e322460a84de"
+           md5: '9383f12958aafc425923e322460a84de'
   end
 else
-  version "4.7.2-20130224" do
+  version '4.7.2-20130224' do
     source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-64-#{version}-1432-sfx.exe",
-           md5: "ce99d873c1acc8bffc639bd4e764b849"
+           md5: 'ce99d873c1acc8bffc639bd4e764b849'
   end
 end
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
@@ -41,7 +42,7 @@ build do
   command "#{project_file} -y -o#{windows_safe_path(embedded_dir)}", env: env
 
   command "echo - #{install_dir}/embedded > config.yml", cwd: embedded_dir
-  ruby "dk.rb install", env: env, cwd: embedded_dir
+  ruby 'dk.rb install', env: env, cwd: embedded_dir
 
   # Normally we would symlink the required unix tools.
   # However with the introduction of git-cache to speed up omnibus builds,
@@ -57,7 +58,7 @@ build do
     'libexpat-1.dll'   => 'libexpat-1.dll',
     'liblzma-1.dll'    => 'liblzma-1.dll',
     'libbz2-2.dll'     => 'libbz2-2.dll',
-    'libz-1.dll'       => 'libz-1.dll',
+    'libz-1.dll'       => 'libz-1.dll'
   }.each do |target, to|
     copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
   end

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -58,7 +58,7 @@ build do
     'libexpat-1.dll'   => 'libexpat-1.dll',
     'liblzma-1.dll'    => 'liblzma-1.dll',
     'libbz2-2.dll'     => 'libbz2-2.dll',
-    'libz-1.dll'       => 'libz-1.dll'
+    'libz-1.dll'       => 'libz-1.dll',
   }.each do |target, to|
     copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
   end

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -33,38 +33,45 @@ elsif windows_arch_i386?
   relative_path "ruby-#{version}-i386-mingw32"
   source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
 
-  version("2.2.4") { source md5: "392a3d4ebc8d0733508c8e70ec86d0fa" }
-  version("2.2.1") { source md5: "9f1beca535b2e60098d826eb7cb1b972" }
+  # 2.2.x
+  version('2.2.4') { source md5: '392a3d4ebc8d0733508c8e70ec86d0fa' }
+  version('2.2.1') { source md5: '9f1beca535b2e60098d826eb7cb1b972' }
 
-  version("2.1.8") { source md5: "8c2ff85d3318c2cfdaeb4f64f5bf4159" }
-  version("2.1.6") { source md5: "e3c345a73e5523677a1f301caa4142eb" }
-  version("2.1.5") { source md5: "fe6b596fc47f503b0c0c01ebed16cf65" }
-  version("2.1.3") { source md5: "60e39aaab140c3a22abdc04ec2017968" }
+  # 2.1.x
+  version('2.1.8') { source md5: '8c2ff85d3318c2cfdaeb4f64f5bf4159' }
+  version('2.1.6') { source md5: 'e3c345a73e5523677a1f301caa4142eb' }
+  version('2.1.5') { source md5: 'fe6b596fc47f503b0c0c01ebed16cf65' }
+  version('2.1.3') { source md5: '60e39aaab140c3a22abdc04ec2017968' }
 
-  version("2.0.0-p648") { source md5: "36de40a85256396280592b249e0ccb3d" }
-  version("2.0.0-p645") { source md5: "1a59c016a3ea0714b06d7a5f6aa4157a" }
-  version("2.0.0-p451") { source md5: "37feadb0230e7f475a8591d1807ecfec" }
+  # 2.0.x
+  version('2.0.0-p648') { source md5: '36de40a85256396280592b249e0ccb3d' }
+  version('2.0.0-p645') { source md5: '1a59c016a3ea0714b06d7a5f6aa4157a' }
+  version('2.0.0-p451') { source md5: '37feadb0230e7f475a8591d1807ecfec' }
 
-  version("1.9.3-p484") { source md5: "a0665113aaeea83f1c4bea02fcf16694" }
+  # 1.9.x
+  version('1.9.3-p484') { source md5: 'a0665113aaeea83f1c4bea02fcf16694' }
 else
   relative_path "ruby-#{version}-x64-mingw32"
+
   source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-x64-mingw32.7z?direct"
 
-  version("2.2.4") { source md5: "0cff85bfccdd6a1e772cdf362066199e" }
-  version("2.2.1") { source md5: "0e6fe9f27367123f738bf143f4bf04f6" }
+  # 2.2.x
+  version('2.2.4') { source md5: '0cff85bfccdd6a1e772cdf362066199e' }
+  version('2.2.1') { source md5: '0e6fe9f27367123f738bf143f4bf04f6' }
 
-  version("2.1.8") { source md5: "bbf553451fd1f5524c132517201902df" }
-  version("2.1.6") { source md5: "a443794bc4c22091193eccf0b02f763e" }
-  version("2.1.5") { source md5: "2ebc791db99858a0bd586968cddfcf0d" }
-  version("2.1.3") { source md5: "d339f956db4d4b1e8a30ac3e33014844" }
+  # 2.1.x
+  version('2.1.8') { source md5: 'bbf553451fd1f5524c132517201902df' }
+  version('2.1.6') { source md5: 'a443794bc4c22091193eccf0b02f763e' }
+  version('2.1.5') { source md5: '2ebc791db99858a0bd586968cddfcf0d' }
+  version('2.1.3') { source md5: 'd339f956db4d4b1e8a30ac3e33014844' }
 
-  version("2.0.0-p648") { source md5: "022f14d020eb2b7a19c6494f7e16d137" }
-  version("2.0.0-p645") { source md5: "d57d539b90f5bbf26550a9d1a3c33c33" }
-  version("2.0.0-p451") { source md5: "d4f6741138a26a4be12e684a16a19b75" }
+  # 2.0.x
+  version('2.0.0-p648') { source md5: '022f14d020eb2b7a19c6494f7e16d137' }
+  version('2.0.0-p645') { source md5: 'd57d539b90f5bbf26550a9d1a3c33c33' }
+  version('2.0.0-p451') { source md5: 'd4f6741138a26a4be12e684a16a19b75' }
 end
 
 build do
-
   sync "#{project_dir}/", "#{install_dir}/embedded"
 
   # Ruby 2.X dl.rb gives an annoying warning message on Windows:

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-name "ruby-windows"
+name 'ruby-windows'
 
-default_version "2.0.0-p451"
+default_version '2.0.0-p451'
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
@@ -26,11 +26,12 @@ if fips_enabled
     relative_path "ruby-#{version}-i386-mingw32"
     source url: "https://s3-us-west-2.amazonaws.com/yakyakyak/ruby-#{version}-i386-mingw32.7z"
 
-    default_version "2.0.0-p647"
-    version("2.0.0-p647") { source md5: "0b1e8f16580f26fd0992fad3834cb83d" }
+    default_version '2.0.0-p647'
+    version('2.0.0-p647') { source md5: '0b1e8f16580f26fd0992fad3834cb83d' }
   end
 elsif windows_arch_i386?
   relative_path "ruby-#{version}-i386-mingw32"
+
   source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
 
   # 2.2.x
@@ -79,13 +80,13 @@ build do
   # Since we don't have patch on windows we are manually patching the file
   # to turn off the warning message
   # We are only removing dl.rb:8
-  # => warn "DL is deprecated, please use Fiddle"
+  # => warn 'DL is deprecated, please use Fiddle'
   block do
     ABI_ver = version[/(^\d+\.\d+)/] + '.0'
-    dl_path = File.join(install_dir, "embedded/lib/ruby", ABI_ver, "dl.rb")
+    dl_path = File.join(install_dir, 'embedded/lib/ruby', ABI_ver, 'dl.rb')
 
-    if File.exist?(dl_path) && digest(dl_path) == "78c185a3fcc7b5e2c3db697c85110d8f"
-      File.open(dl_path, "w") do |f|
+    if File.exist?(dl_path) && digest(dl_path) == '78c185a3fcc7b5e2c3db697c85110d8f'
+      File.open(dl_path, 'w') do |f|
         f.print <<-E
   require 'dl.so'
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -56,35 +56,39 @@ dependency "libyaml"
 # they expect to see our libiconv instead of a system version.
 # Ignore on windows - TDM GCC comes with libiconv in the runtime
 # and that's the only one we will ever use.
-dependency "libiconv"
-
-
-version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
-
-version("2.2.4")      { source md5: "9a5e15f9d5255ba37ace18771b0a8dd2" }
-version("2.2.3")      { source md5: "150a5efc5f5d8a8011f30aa2594a7654" }
-version("2.2.2")      { source md5: "326e99ddc75381c7b50c85f7089f3260" }
-version("2.2.1")      { source md5: "b49fc67a834e4f77249eb73eecffb1c9" }
-version("2.2.0")      { source md5: "cd03b28fd0b555970f5c4fd481700852" }
-
-version("2.1.8")      { source md5: "091b62f0a9796a3c55de2a228a0e6ef3" }
-version("2.1.7")      { source md5: "2e143b8e19b056df46479ae4412550c9" }
-version("2.1.6")      { source md5: "6e5564364be085c45576787b48eeb75f" }
-version("2.1.5")      { source md5: "df4c1b23f624a50513c7a78cb51a13dc" }
-version("2.1.4")      { source md5: "89b2f4a197621346f6724a3c35535b19" }
-version("2.1.3")      { source md5: "74a37b9ad90e4ea63c0eed32b9d5b18f" }
-version("2.1.2")      { source md5: "a5b5c83565f8bd954ee522bd287d2ca1" }
-version("2.1.1")      { source md5: "e57fdbb8ed56e70c43f39c79da1654b2" }
-
-version("2.0.0-p645") { source md5: "49919bba0c855eaf8e247108c7933a62" }
-version("2.0.0-p594") { source md5: "a9caa406da5d72f190e28344e747ee74" }
-version("2.0.0-p576") { source md5: "2e1f4355981b754d92f7e2cc456f843d" }
-
-version("1.9.3-p550") { source md5: "e05135be8f109b2845229c4f47f980fd" }
-version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
-version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
+dependency 'libiconv'
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
+
+# 2.3.x
+version('2.3.0')      { source md5: 'e81740ac7b14a9f837e9573601db3162' }
+
+# 2.2.x
+version('2.2.4')      { source md5: '9a5e15f9d5255ba37ace18771b0a8dd2' }
+version('2.2.3')      { source md5: '150a5efc5f5d8a8011f30aa2594a7654' }
+version('2.2.2')      { source md5: '326e99ddc75381c7b50c85f7089f3260' }
+version('2.2.1')      { source md5: 'b49fc67a834e4f77249eb73eecffb1c9' }
+version('2.2.0')      { source md5: 'cd03b28fd0b555970f5c4fd481700852' }
+
+# 2.1.x
+version('2.1.8')      { source md5: '091b62f0a9796a3c55de2a228a0e6ef3' }
+version('2.1.7')      { source md5: '2e143b8e19b056df46479ae4412550c9' }
+version('2.1.6')      { source md5: '6e5564364be085c45576787b48eeb75f' }
+version('2.1.5')      { source md5: 'df4c1b23f624a50513c7a78cb51a13dc' }
+version('2.1.4')      { source md5: '89b2f4a197621346f6724a3c35535b19' }
+version('2.1.3')      { source md5: '74a37b9ad90e4ea63c0eed32b9d5b18f' }
+version('2.1.2')      { source md5: 'a5b5c83565f8bd954ee522bd287d2ca1' }
+version('2.1.1')      { source md5: 'e57fdbb8ed56e70c43f39c79da1654b2' }
+
+# 2.0.x
+version('2.0.0-p645') { source md5: '49919bba0c855eaf8e247108c7933a62' }
+version('2.0.0-p594') { source md5: 'a9caa406da5d72f190e28344e747ee74' }
+version('2.0.0-p576') { source md5: '2e1f4355981b754d92f7e2cc456f843d' }
+
+# 1.9.x
+version('1.9.3-p550') { source md5: 'e05135be8f109b2845229c4f47f980fd' }
+version('1.9.3-p547') { source md5: '7531f9b1b35b16f3eb3d7bea786babfd' }
+version('1.9.3-p484') { source md5: '8ac0dee72fe12d75c8b2d0ef5d0c2968' }
 
 relative_path "ruby-#{version}"
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-name "ruby"
+name 'ruby'
 
 # This is now the main software project for anything ruby related.
 # Even if you want a pre-built version of ruby from ruby-installer, include
@@ -22,36 +22,36 @@ name "ruby"
 # it redirects to depend on the ruby-windows project.
 
 if windows?
-  default_version "ruby-windows"
+  default_version 'ruby-windows'
 else
   # - chef-client cannot use 2.2.x yet due to a bug in IRB that affects chef-shell on linux:
   #   https://bugs.ruby-lang.org/issues/11869
   # - the current status of 2.3.x is that it downloads but fails to compile.
-  default_version "2.1.6"
+  default_version '2.1.6'
 end
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
-if windows? && version == "ruby-windows"
-    dependency "ruby-windows"
-    dependency "ruby-windows-devkit"
-    dependency "ruby-windows-devkit-bash"
+if windows? && version == 'ruby-windows'
+    dependency 'ruby-windows'
+    dependency 'ruby-windows-devkit'
+    dependency 'ruby-windows-devkit-bash'
     # The custom yakyakyak ruby build comes with openssl and the FIPS module.
     # Don't clobber it.
-    dependency "openssl-windows" unless fips_enabled
-    dependency "cacerts"
+    dependency 'openssl-windows' unless fips_enabled
+    dependency 'cacerts'
 else
 
 unless windows?
-  dependency "patch" if solaris2?
-  dependency "ncurses"
-  dependency "libedit"
+  dependency 'patch' if solaris2?
+  dependency 'ncurses'
+  dependency 'libedit'
 end
 
-dependency "zlib"
-dependency "openssl"
-dependency "libffi"
-dependency "libyaml"
+dependency 'zlib'
+dependency 'openssl'
+dependency 'libffi'
+dependency 'libyaml'
 # Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
 # they expect to see our libiconv instead of a system version.
 # Ignore on windows - TDM GCC comes with libiconv in the runtime
@@ -95,49 +95,49 @@ relative_path "ruby-#{version}"
 env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
 
 if mac_os_x?
-  # -Qunused-arguments suppresses "argument unused during compilation"
+  # -Qunused-arguments suppresses 'argument unused during compilation'
   # warnings. These can be produced if you compile a program that doesn't
   # link to anything in a path given with -Lextra-libs. Normally these
   # would be harmless, except that autoconf treats any output to stderr as
   # a failure when it makes a test program to check your CFLAGS (regardless
   # of the actual exit code from the compiler).
   env['CFLAGS'] << " -I#{install_dir}/embedded/include/ncurses -arch x86_64 -m64 -O3 -g -pipe -Qunused-arguments"
-  env['LDFLAGS'] << " -arch x86_64"
+  env['LDFLAGS'] << ' -arch x86_64'
 elsif freebsd?
-  # Stops "libtinfo.so.5.9: could not read symbols: Bad value" error when
+  # Stops 'libtinfo.so.5.9: could not read symbols: Bad value' error when
   # compiling ext/readline. See the following for more info:
   #
   #   https://lists.freebsd.org/pipermail/freebsd-current/2013-October/045425.html
   #   http://mailing.freebsd.ports-bugs.narkive.com/kCgK8sNQ/ports-183106-patch-sysutils-libcdio-does-not-build-on-10-0-and-head
   #
-  env['LDFLAGS'] << " -ltinfow"
+  env['LDFLAGS'] << ' -ltinfow'
 elsif aix?
   # this magic per IBM
-  env['LDSHARED'] = "xlc -G"
+  env['LDSHARED'] = 'xlc -G'
   env['CFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
   # this magic per IBM
-  env['XCFLAGS'] = "-DRUBY_EXPORT"
+  env['XCFLAGS'] = '-DRUBY_EXPORT'
   # need CPPFLAGS set so ruby doesn't try to be too clever
   env['CPPFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
-  env['SOLIBS'] = "-lm -lc"
+  env['SOLIBS'] = '-lm -lc'
   # need to use GNU m4, default m4 doesn't work
-  env['M4'] = "/opt/freeware/bin/m4"
+  env['M4'] = '/opt/freeware/bin/m4'
 elsif solaris2?
   if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env['CFLAGS'] << " -std=c99 -O0 -g -pipe -mcpu=v9"
-    env['LDFLAGS'] << " -mcpu=v9"
+    env['CFLAGS'] << ' -std=c99 -O0 -g -pipe -mcpu=v9'
+    env['LDFLAGS'] << ' -mcpu=v9'
   else
-    env['CFLAGS'] << " -std=c99 -O3 -g -pipe"
+    env['CFLAGS'] << ' -std=c99 -O3 -g -pipe'
   end
 elsif windows?
-  env['CPPFLAGS'] << " -DFD_SETSIZE=2048"
-else  # including linux
-  if version.satisfies?(">= 2.3.0") &&
-    rhel? && platform_version.satisfies?("< 6.0")
-    env['CFLAGS'] << " -O2 -g -pipe"
+  env['CPPFLAGS'] << ' -DFD_SETSIZE=2048'
+else # including linux
+  if version.satisfies?('>= 2.3.0') &&
+    rhel? && platform_version.satisfies?('< 6.0')
+    env['CFLAGS'] << ' -O2 -g -pipe'
   else
-    env['CFLAGS'] << " -O3 -g -pipe"
+    env['CFLAGS'] << ' -O3 -g -pipe'
   end
 end
 
@@ -147,19 +147,19 @@ build do
   patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
 
   if solaris2? && version.satisfies?('>= 2.1')
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-no-stack-protector.patch', plevel: 1, env: patch_env
     if platform_version.satisfies?('>= 5.11')
-      patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1, env: patch_env
+      patch source: 'ruby-solaris-linux-socket-compat.patch', plevel: 1, env: patch_env
     end
   elsif solaris2? && version =~ /^1.9/
-    patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-sparc-1.9.3-c99.patch', plevel: 1, env: patch_env
   end
 
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.
   if ios_xr? && version.satisfies?('>= 2.1')
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-no-stack-protector.patch', plevel: 1, env: patch_env
   end
 
   # disable libpath in mkmf across all platforms, it trolls omnibus and
@@ -170,7 +170,7 @@ build do
   # embedded and non-embedded libs get into a fight (libiconv, openssl, etc)
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
   if version.satisfies?('>= 2.1')
-    patch source: "ruby-2_1_3-no-mkmf.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-2_1_3-no-mkmf.patch', plevel: 1, env: patch_env
     # should intentionally break and fail to apply on 2.2, patch will need to
     # be fixed.
   end
@@ -190,52 +190,52 @@ build do
      patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env
   end
 
-  configure_command = ["--with-out-ext=dbm",
-                       "--enable-shared",
-                       "--disable-install-doc",
-                       "--without-gmp",
-                       "--without-gdbm",
-                       "--disable-dtrace"]
-  configure_command << "--with-ext=psych" if version.satisfies?('< 2.3')
-  configure_command << "--enable-libedit" unless windows?
-  configure_command << "--with-bundled-md5" if fips_enabled
+  configure_command = ['--with-out-ext=dbm',
+                       '--enable-shared',
+                       '--disable-install-doc',
+                       '--without-gmp',
+                       '--without-gdbm',
+                       '--disable-dtrace']
+  configure_command << '--with-ext=psych' if version.satisfies?('< 2.3')
+  configure_command << '--enable-libedit' unless windows?
+  configure_command << '--with-bundled-md5' if fips_enabled
 
   if aix?
     # need to patch ruby's configure file so it knows how to find shared libraries
-    patch source: "ruby-aix-configure.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-aix-configure.patch', plevel: 1, env: patch_env
     # have ruby use zlib on AIX correctly
-    patch source: "ruby_aix_openssl.patch", plevel: 1, env: patch_env
+    patch source: 'ruby_aix_openssl.patch', plevel: 1, env: patch_env
     # AIX has issues with ssl retries, need to patch to have it retry
-    patch source: "ruby_aix_2_1_3_ssl_EAGAIN.patch", plevel: 1, env: patch_env
+    patch source: 'ruby_aix_2_1_3_ssl_EAGAIN.patch', plevel: 1, env: patch_env
     # the next two patches are because xlc doesn't deal with long vs int types well
-    patch source: "ruby-aix-atomic.patch", plevel: 1, env: patch_env
-    patch source: "ruby-aix-vm-core.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-aix-atomic.patch', plevel: 1, env: patch_env
+    patch source: 'ruby-aix-vm-core.patch', plevel: 1, env: patch_env
 
     # per IBM, just help ruby along on what it's running on
-    configure_command << "--host=powerpc-ibm-aix6.1.0.0 --target=powerpc-ibm-aix6.1.0.0 --build=powerpc-ibm-aix6.1.0.0 --enable-pthread"
+    configure_command << '--host=powerpc-ibm-aix6.1.0.0 --target=powerpc-ibm-aix6.1.0.0 --build=powerpc-ibm-aix6.1.0.0 --enable-pthread'
 
   elsif freebsd?
     # Disable optional support C level backtrace support. This requires the
     # optional devel/libexecinfo port to be installed.
-    configure_command << "ac_cv_header_execinfo_h=no"
+    configure_command << 'ac_cv_header_execinfo_h=no'
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   elsif smartos?
     # Opscode patch - someara@opscode.com
     # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
-    patch source: "ruby-openssl-1.0.1c.patch", plevel: 1, env: patch_env
+    patch source: 'ruby-openssl-1.0.1c.patch', plevel: 1, env: patch_env
 
     # Patches taken from RVM.
     # http://bugs.ruby-lang.org/issues/5384
     # https://www.illumos.org/issues/1587
     # https://github.com/wayneeseguin/rvm/issues/719
-    patch source: "rvm-cflags.patch", plevel: 1, env: patch_env
+    patch source: 'rvm-cflags.patch', plevel: 1, env: patch_env
 
     # From RVM forum
     # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
-    configure_command << "ac_cv_func_dl_iterate_phdr=no"
+    configure_command << 'ac_cv_func_dl_iterate_phdr=no'
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   elsif windows?
-    configure_command << " debugflags=-g"
+    configure_command << ' debugflags=-g'
   else
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end
@@ -243,18 +243,17 @@ build do
   # FFS: works around a bug that infects AIX when it picks up our pkg-config
   # AFAIK, ruby does not need or use this pkg-config it just causes the build to fail.
   # The alternative would be to patch configure to remove all the pkg-config garbage entirely
-  env.merge!("PKG_CONFIG" => "/bin/true") if aix?
+  env['PKG_CONFIG'] = '/bin/true' if aix?
 
   configure(*configure_command, env: env)
   if windows?
     # On windows, msys make 3.81 breaks with parallel builds.
     make env: env
-    make "install", env: env
+    make 'install', env: env
   else
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env
   end
-
 end
 
 end # if windows? && version == 'ruby-windows'

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -14,27 +14,27 @@
 # limitations under the License.
 #
 
-name "rubygems"
+name 'rubygems'
 
-dependency "ruby"
+dependency 'ruby'
 
 source git: 'https://github.com/rubygems/rubygems.git' if version
 
 # NOTE: Originally we always installed rubygems from tarballs, but now we want
-# to default to pulling from git. Rubygems uses the leading "v" in their
+# to default to pulling from git. Rubygems uses the leading 'v' in their
 # version tags, e.g., v2.4.4 (instead of just 2.4.4). There are a lot of
 # omnibus projects using this, and we don't want to force everyone to change
-# their version pins to include the leading "v", so we need to set the source
+# their version pins to include the leading 'v', so we need to set the source
 # URL on a per-version basis.
 tarball_url = "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
 
-version "1.8.29" do
-  source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269", url: tarball_url
+version '1.8.29' do
+  source md5: 'a57fec0af33e2e2e1dbb3a68f6cc7269', url: tarball_url
   source.delete(:git)
 end
 
-version "1.8.24" do
-  source md5: "3a555b9d579f6a1a1e110628f5110c6b", url: tarball_url
+version '1.8.24' do
+  source md5: '3a555b9d579f6a1a1e110628f5110c6b', url: tarball_url
   source.delete(:git)
 end
 
@@ -43,46 +43,46 @@ end
 #  https://github.com/rubygems/rubygems/issues/874
 #
 # This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
-version "2.1.11" do
-  source md5: "b561b7aaa70d387e230688066e46e448", url: tarball_url
+version '2.1.11' do
+  source md5: 'b561b7aaa70d387e230688066e46e448', url: tarball_url
   source.delete(:git)
 end
 
-version "2.2.1" do
-  source md5: "1f0017af0ad3d3ed52665132f80e7443", url: tarball_url
+version '2.2.1' do
+  source md5: '1f0017af0ad3d3ed52665132f80e7443', url: tarball_url
   source.delete(:git)
 end
 
-version "2.4.1" do
-  source md5: "7e39c31806bbf9268296d03bd97ce718", url: tarball_url
+version '2.4.1' do
+  source md5: '7e39c31806bbf9268296d03bd97ce718', url: tarball_url
   source.delete(:git)
 end
 
-version "2.4.4" do
-  source md5: "440a89ad6a3b1b7a69b034233cc4658e", url: tarball_url
+version '2.4.4' do
+  source md5: '440a89ad6a3b1b7a69b034233cc4658e', url: tarball_url
   source.delete(:git)
 end
 
-version "2.4.5" do
-  source md5: "5918319a439c33ac75fbbad7fd60749d", url: tarball_url
+version '2.4.5' do
+  source md5: '5918319a439c33ac75fbbad7fd60749d', url: tarball_url
   source.delete(:git)
 end
 
-version "2.4.8" do
-  source md5: "dc77b51449dffe5b31776bff826bf559", url: tarball_url
+version '2.4.8' do
+  source md5: 'dc77b51449dffe5b31776bff826bf559', url: tarball_url
   source.delete(:git)
 end
 
-version "v2.4.4_plus_debug" do
+version 'v2.4.4_plus_debug' do
   source git: 'https://github.com/danielsdeleo/rubygems.git'
 end
 
-version "2.4.4.debug.1" do
+version '2.4.4.debug.1' do
   source git: 'https://github.com/danielsdeleo/rubygems.git'
 end
 
-version "2.5.2" do
-  source md5: "59d25b2148cc950fb2fd2b441d23954d", url: tarball_url
+version '2.5.2' do
+  source md5: '59d25b2148cc950fb2fd2b441d23954d', url: tarball_url
   source.delete(:git)
 end
 
@@ -90,7 +90,7 @@ end
 # windows so things like `gem install 'pry'` still
 # work
 #
-version "jdm/2.4.8-patched" do
+version 'jdm/2.4.8-patched' do
   source git: 'https://github.com/jaym/rubygems.git'
 end
 
@@ -98,31 +98,36 @@ end
 if source && source.key?(:url)
   relative_path "rubygems-#{version}"
 else
-  relative_path "rubygems"
+  relative_path 'rubygems'
 end
-
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if version
-    ruby "setup.rb --no-ri --no-rdoc", env: env
+    ruby 'setup.rb --no-ri --no-rdoc', env: env
 
     if windows?
       # Our poor man's way of detecting which compiler suite got used
       # because we can't ask if ruby-windows-devkit got included in the project.
       if File.exist?("#{install_dir}/embedded/msys/1.0/bin")
         # Render our registration script and run it in the context of the embedded ruby.
-        erb source: 'register_devtools.rb.erb', dest: "#{project_dir}/register_devtools.rb",
-          vars: { paths: [ "#{install_dir}/embedded/bin", "#{install_dir}/embedded/msys/1.0/bin" ] }
-        ruby "register_devtools.rb", env: env
+        erb source: 'register_devtools.rb.erb',
+            dest: "#{project_dir}/register_devtools.rb",
+            vars: {
+              paths: [
+                "#{install_dir}/embedded/bin",
+                "#{install_dir}/embedded/msys/1.0/bin"
+              ]
+            }
+        ruby 'register_devtools.rb', env: env
       elsif File.exist?("#{install_dir}/embedded/dk.rb")
         # After installing ruby, we need to rerun the command that patches devkit
         # functionality into rubygems.
-        ruby "dk.rb install", env: env, cwd: "#{install_dir}/embedded"
+        ruby 'dk.rb install', env: env, cwd: "#{install_dir}/embedded"
       end
     end
   else
-    gem "update --system", env: env
+    gem 'update --system', env: env
   end
 end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -117,8 +117,8 @@ build do
             vars: {
               paths: [
                 "#{install_dir}/embedded/bin",
-                "#{install_dir}/embedded/msys/1.0/bin"
-              ]
+                "#{install_dir}/embedded/msys/1.0/bin",
+              ],
             }
         ruby 'register_devtools.rb', env: env
       elsif File.exist?("#{install_dir}/embedded/dk.rb")

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -17,14 +17,13 @@
 name "runit"
 default_version "2.1.1"
 
-version "2.1.2" do
-  source md5: "6c985fbfe3a34608eb3c53dc719172c4"
-end
-version "2.1.1" do
-  source md5: "8fa53ea8f71d88da9503f62793336bc3"
-end
+name 'runit'
+default_version '2.1.1'
 
 source url: "http://smarden.org/runit/runit-#{version}.tar.gz"
+
+version('2.1.2') { source md5: '6c985fbfe3a34608eb3c53dc719172c4' }
+version('2.1.1') { source md5: '8fa53ea8f71d88da9503f62793336bc3' }
 
 relative_path "admin/runit-#{version}/src"
 

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-name "runit"
-default_version "2.1.1"
-
 name 'runit'
 default_version '2.1.1'
 
@@ -34,11 +31,11 @@ build do
   command 'sed -i -e "s/^char\ \*varservice\ \=\"\/service\/\";$/char\ \*varservice\ \=\"' + install_dir.gsub("/", "\\/") + '\/service\/\";/" sv.c', env: env
 
   # TODO: the following is not idempotent
-  command "sed -i -e s:-static:: Makefile", env: env
+  command 'sed -i -e s:-static:: Makefile', env: env
 
   # Build it
   make env: env
-  make "check", env: env
+  make 'check', env: env
 
   # Move it
   mkdir "#{install_dir}/embedded/bin"
@@ -52,7 +49,7 @@ build do
   copy "#{project_dir}/svlogd",     "#{install_dir}/embedded/bin"
   copy "#{project_dir}/utmpset",    "#{install_dir}/embedded/bin"
 
-  erb source: "runsvdir-start.erb",
+  erb source: 'runsvdir-start.erb',
       dest: "#{install_dir}/embedded/bin/runsvdir-start",
       mode: 0755,
       vars: { install_dir: install_dir }

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-name "sequel-gem"
-default_version "4.13.0"
+name 'sequel-gem'
+default_version '4.13.0'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install sequel" \
+  gem 'install sequel' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -14,53 +14,53 @@
 # limitations under the License.
 #
 
-name "server-jre"
-default_version "8u74"
+name 'server-jre'
+default_version '8u74'
 
-raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
+raise 'Server-jre can only be installed on x86_64 systems.' unless _64_bit?
 
-whitelist_file "jre/bin/javaws"
-whitelist_file "jre/bin/policytool"
-whitelist_file "jre/lib"
-whitelist_file "jre/plugin"
-whitelist_file "jre/bin/appletviewer"
+whitelist_file 'jre/bin/javaws'
+whitelist_file 'jre/bin/policytool'
+whitelist_file 'jre/lib'
+whitelist_file 'jre/plugin'
+whitelist_file 'jre/bin/appletviewer'
 
-version "8u74" do
+version '8u74' do
   # https://www.oracle.com/webfolder/s/digest/8u74checksum.html
-  source url: "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/server-jre-8u74-linux-x64.tar.gz",
-         md5: "2c244c8071b7997219fe664ef1968adf",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+  source url: 'http://download.oracle.com/otn-pub/java/jdk/8u74-b02/server-jre-8u74-linux-x64.tar.gz',
+         md5: '2c244c8071b7997219fe664ef1968adf',
+         cookie:  'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+         warning: 'By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html',
          unsafe:  true
-  relative_path "jdk1.8.0_74"
+  relative_path 'jdk1.8.0_74'
 end
 
-version "8u31" do
-  source url:     "http://download.oracle.com/otn-pub/java/jdk/8u31-b13/server-jre-8u31-linux-x64.tar.gz",
-         md5:     "9d69cdc00c536b8c9f5b26a3128bd2a1",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+version '8u31' do
+  source url:     'http://download.oracle.com/otn-pub/java/jdk/8u31-b13/server-jre-8u31-linux-x64.tar.gz',
+         md5:     '9d69cdc00c536b8c9f5b26a3128bd2a1',
+         cookie:  'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+         warning: 'By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html',
          unsafe:  true
-  relative_path "jdk1.8.0_31"
+  relative_path 'jdk1.8.0_31'
 end
 
-version "7u80" do
+version '7u80' do
   # https://www.oracle.com/webfolder/s/digest/7u80checksum.html
-  source url:     "http://download.oracle.com/otn-pub/java/jdk/7u80-b15/server-jre-7u80-linux-x64.tar.gz",
-         md5:     "6152f8a7561acf795ca4701daa10a965",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+  source url:     'http://download.oracle.com/otn-pub/java/jdk/7u80-b15/server-jre-7u80-linux-x64.tar.gz',
+         md5:     '6152f8a7561acf795ca4701daa10a965',
+         cookie:  'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+         warning: 'By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html',
          unsafe:  true
-  relative_path "jdk1.7.0_80"
+  relative_path 'jdk1.7.0_80'
 end
 
-version "7u25" do
-  source url:     "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
-         md5:     "7164bd8619d731a2e8c01d0c60110f80",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+version '7u25' do
+  source url:     'http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz',
+         md5:     '7164bd8619d731a2e8c01d0c60110f80',
+         cookie:  'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+         warning: 'By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html',
          unsafe:  true
-  relative_path "jdk1.7.0_25"
+  relative_path 'jdk1.7.0_25'
 end
 
 build do

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "setuptools"
-default_version "0.7.7"
+name 'setuptools'
+default_version '0.7.7'
 
 dependency 'python'
 

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -17,21 +17,13 @@
 name "setuptools"
 default_version "0.7.7"
 
-dependency "python"
-
-version "0.9.8" do
-  source md5: "243076241781935f7fcad370195a4291"
-end
-
-version "0.7.7" do
-  source md5: "0d7bc0e1a34b70a97e706ef74aa7f37f"
-end
-
-version "20.0" do
-  source md5: "fb22b2474ca037e0b08f3c3b293e02e6"
-end
+dependency 'python'
 
 source url: "https://pypi.python.org/packages/source/s/setuptools/setuptools-#{version}.tar.gz"
+
+version('0.9.8') { source md5: '243076241781935f7fcad370195a4291' }
+version('0.7.7') { source md5: '0d7bc0e1a34b70a97e706ef74aa7f37f' }
+version('20.0')  { source md5: 'fb22b2474ca037e0b08f3c3b293e02e6' }
 
 relative_path "setuptools-#{version}"
 

--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -33,7 +33,7 @@ build do
                        require 'rubygems/format'
                        Gem::Format.method(:from_file_by_path)
                      end
-      Dir["#{install_dir.gsub(/\\/, '/')}/embedded/lib/ruby/gems/**/cache/*.gem"].each do |gem_file|
+      Dir["#{install_dir.tr('\\', '/')}/embedded/lib/ruby/gems/**/cache/*.gem"].each do |gem_file|
         load_gemspec.call(gem_file).spec.executables.each do |bin|
           if File.exist?("#{install_dir}/bin/#{bin}")
             File.open("#{install_dir}/bin/#{bin}.bat", "w") do |f|

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -17,18 +17,13 @@
 name "sqitch"
 default_version "0.973"
 
-dependency "perl"
-dependency "cpanminus"
-
-version "0.9994" do
-  source md5: "7227dfcd141440f23d99f01a2b01e0f2"
-end
-
-version "0.973" do
-  source md5: "0994e9f906a7a4a2e97049c8dbaef584"
-end
+dependency 'perl'
+dependency 'cpanminus'
 
 source url: "http://www.cpan.org/authors/id/D/DW/DWHEELER/App-Sqitch-#{version}.tar.gz"
+
+version('0.9994') { source md5: "7227dfcd141440f23d99f01a2b01e0f2" }
+version('0.973')  { source md5: "0994e9f906a7a4a2e97049c8dbaef584" }
 
 relative_path "App-Sqitch-#{version}"
 

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-name "sqitch"
-default_version "0.973"
+name 'sqitch'
+default_version '0.973'
 
 dependency 'perl'
 dependency 'cpanminus'
@@ -31,8 +31,8 @@ relative_path "App-Sqitch-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "perl Build.PL", env: env
-  command "./Build installdeps --cpan_client 'cpanm -v --notest'", env: env
-  command "./Build", env: env
-  command "./Build install", env: env
+  command 'perl Build.PL', env: env
+  command './Build installdeps --cpan_client "cpanm -v --notest"', env: env
+  command './Build', env: env
+  command './Build install', env: env
 end

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -18,11 +18,11 @@ name "test-kitchen"
 default_version "master"
 relative_path "test-kitchen"
 
-source git: "https://github.com/test-kitchen/test-kitchen.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"
+source git: 'https://github.com/test-kitchen/test-kitchen.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -14,22 +14,22 @@
 # limitations under the License.
 #
 
-name "test-kitchen"
-default_version "master"
-relative_path "test-kitchen"
+name 'test-kitchen'
+default_version 'master'
+relative_path 'test-kitchen'
 
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'nokogiri'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "nokogiri"
 source git: 'https://github.com/test-kitchen/test-kitchen.git'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without guard", env: env
-  bundle "exec rake build", env: env
+  bundle 'install --without guard', env: env
+  bundle 'exec rake build', env: env
 
-  gem "install pkg/test-kitchen-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'install pkg/test-kitchen-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/unicorn.rb
+++ b/config/software/unicorn.rb
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-name "unicorn"
-default_version "4.2.0"
+name 'unicorn'
+default_version '4.2.0'
 
-dependency "rubygems"
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install unicorn" \
+  gem 'install unicorn' \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -27,7 +27,7 @@ relative_path "util-macros-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -14,18 +14,13 @@
 # limitations under the License.
 #
 
-name "util-macros"
-default_version "1.18.0"
-
-version "1.19.0" do
-  source md5: "40e1caa49a71a26e0aa68ddd00203717"
-end
-
-version "1.18.0" do
-  source md5: "fd0ba21b3179703c071bbb4c3e5fb0f4"
-end
+name 'util-macros'
+default_version '1.18.0'
 
 source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz"
+
+version('1.19.0') { source md5: '40e1caa49a71a26e0aa68ddd00203717' }
+version('1.18.0') { source md5: 'fd0ba21b3179703c071bbb4c3e5fb0f4' }
 
 relative_path "util-macros-#{version}"
 

--- a/config/software/uuidtools.rb
+++ b/config/software/uuidtools.rb
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
-name "uuidtools"
-default_version "2.1.5"
+name 'uuidtools'
+default_version '2.1.5'
 
-dependency "ruby"
-dependency "rubygems"
+dependency 'ruby'
+dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install uuidtools" \
+  gem 'install uuidtools' \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-name "version-manifest"
-description "generates a version manifest file"
-default_version "0.0.1"
+name 'version-manifest'
+description 'generates a version manifest file'
+default_version '0.0.1'
 
 build do
   block do

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -14,21 +14,21 @@
 # limitations under the License.
 #
 
-name "winrm-transport"
-default_version "master"
+name 'winrm-transport'
+default_version 'master'
 
-source git: "https://github.com/test-kitchen/winrm-transport.git"
+source git: 'https://github.com/test-kitchen/winrm-transport.git'
 
-dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development test guard", env: env
+  bundle 'install --without development test guard', env: env
 
-  gem "build winrm-transport.gemspec", env: env
-  gem "install winrm-transport-*.gem" \
-      " --no-ri --no-rdoc", env: env
+  gem 'build winrm-transport.gemspec', env: env
+  gem 'install winrm-transport-*.gem' \
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -27,7 +27,7 @@ relative_path "xproto-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
+  command './configure' \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -14,18 +14,13 @@
 # limitations under the License.
 #
 
-name "xproto"
-default_version "7.0.25"
-
-version "7.0.28" do
-  source md5: "0b42843b99aee3e4f6a9cc7710143f86"
-end
-
-version "7.0.25" do
-  source md5: "a47db46cb117805bd6947aa5928a7436"
-end
+name 'xproto'
+default_version '7.0.25'
 
 source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz"
+
+version('7.0.28') { source md5: '0b42843b99aee3e4f6a9cc7710143f86' }
+version('7.0.25') { source md5: 'a47db46cb117805bd6947aa5928a7436' }
 
 relative_path "xproto-#{version}"
 

--- a/config/software/yajl.rb
+++ b/config/software/yajl.rb
@@ -14,18 +14,18 @@
 # limitations under the License.
 #
 
-name "yajl"
-default_version "1.1.0"
+name 'yajl'
+default_version '1.1.0'
 
-dependency "rubygems"
+dependency 'rubygems'
 
-relative_path "yajl-ruby"
+relative_path 'yajl-ruby'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install yajl-ruby" \
+  gem 'install yajl-ruby' \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/bin'" \
-      " --no-ri --no-rdoc", env: env
+      ' --no-ri --no-rdoc', env: env
 end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -49,7 +49,7 @@ build do
       "ASFLAGS='#{env['CFLAGS']} -Wall'",
       "LDFLAGS='#{env['LDFLAGS']}'",
       "ARFLAGS='rcs #{env['ARFLAGS']}'",
-      "RCFLAGS='--define GCC_WINDRES #{env['RCFLAGS']}'"
+      "RCFLAGS='--define GCC_WINDRES #{env['RCFLAGS']}'",
     ]
 
     # On windows, msys make 3.81 doesn't support -j.

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -45,11 +45,11 @@ build do
     make_args = [
       "-fwin32/Makefile.gcc",
       "SHARED_MODE=1",
-      "CFLAGS=\"#{env['CFLAGS']} -Wall\"",
-      "ASFLAGS=\"#{env['CFLAGS']} -Wall\"",
-      "LDFLAGS=\"#{env['LDFLAGS']}\"",
-      "ARFLAGS=\"rcs #{env['ARFLAGS']}\"",
-      "RCFLAGS=\"--define GCC_WINDRES #{env['RCFLAGS']}\"",
+      "CFLAGS='#{env['CFLAGS']} -Wall'",
+      "ASFLAGS='#{env['CFLAGS']} -Wall'",
+      "LDFLAGS='#{env['LDFLAGS']}'",
+      "ARFLAGS='rcs #{env['ARFLAGS']}'",
+      "RCFLAGS='--define GCC_WINDRES #{env['RCFLAGS']}'"
     ]
 
     # On windows, msys make 3.81 doesn't support -j.


### PR DESCRIPTION
This PR aims to do a couple things:
- refactor berkshelf2, openssl-windows, and erlang
- add a project def: 'validation' which loads all defs (forces Omnibus DSL syntax check)
- Quotepocalypse 2016 (standardize quotations across all software defs)
- standardize 'version' statements within the defs:
  - favor inline-block style for simple (1-liners) version blocks when possible
  - favor do/end block style for more complex blocks (2+ lines)
  - favor ordered defs (top down): name, default_version, deps, source url, versions, relative_path

I was left with a couple of things: Python as a dep of nodejs?

There shouldn't be any major functionality changes apart from in Erlang's dep which used to set `relative_path` to `otp_src_R16B03-1` for that version:
```ruby
version "R16B03-1" do
  source md5:   "e5ece977375197338c1b93b3d88514f8"
  relative_path "otp_src_#{version}"
end
```

And now will set it to `otp_src_R16B03` to make things more unilateral across all versions:
```ruby
relative_path "otp_src_#{version.split('-')[0]}"
```