### PR TITLE
Standardize order/version format

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -17,10 +17,10 @@
 name "appbundler"
 default_version "master"
 
-source git: "https://github.com/chef/appbundler.git"
-
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/chef/appbundler.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -19,12 +19,8 @@ default_version "2.68"
 
 dependency "m4"
 
-version "2.69" do
-  source md5: "82d05e03b93e45f5a39b828dc9c6c29b"
-end
-version "2.68" do
-  source md5: "c3b5247592ce694f7097873aa07d66fe"
-end
+version("2.69") { source md5: "82d05e03b93e45f5a39b828dc9c6c29b" }
+version("2.68") { source md5: "c3b5247592ce694f7097873aa07d66fe" }
 
 source url: "https://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz"
 

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -19,15 +19,10 @@ default_version "1.11.2"
 
 dependency "autoconf"
 
-version "1.15" do
-  source md5: "716946a105ca228ab545fc37a70df3a3"
-end
-
-version "1.11.2" do
-  source md5: "79ad64a9f6e83ea98d6964cef8d8a0bc"
-end
-
 source url: "https://ftp.gnu.org/gnu/automake/automake-#{version}.tar.gz"
+
+version("1.15")   { source md5: "716946a105ca228ab545fc37a70df3a3" }
+version("1.11.2") { source md5: "79ad64a9f6e83ea98d6964cef8d8a0bc" }
 
 relative_path "automake-#{version}"
 

--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -20,9 +20,9 @@ default_version "4.3.30"
 dependency "libiconv"
 dependency "ncurses"
 
-version("4.3.30") { source md5: "a27b3ee9be83bd3ba448c0ff52b28447" }
-
 source url: "https://ftp.gnu.org/gnu/bash/bash-#{version}.tar.gz"
+
+version("4.3.30") { source md5: "a27b3ee9be83bd3ba448c0ff52b28447" }
 
 relative_path "bash-#{version}"
 

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -17,10 +17,6 @@
 name "berkshelf"
 default_version "master"
 
-source git: "https://github.com/berkshelf/berkshelf.git"
-
-relative_path "berkshelf"
-
 dependency "ruby"
 dependency "rubygems"
 
@@ -31,6 +27,10 @@ end
 dependency "nokogiri"
 dependency "bundler"
 dependency "dep-selector-libgecode"
+
+source git: "https://github.com/berkshelf/berkshelf.git"
+
+relative_path "berkshelf"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/binutils.rb
+++ b/config/software/binutils.rb
@@ -20,6 +20,7 @@ default_version "2.25-tdm64-1"
 dependency "msys-base"
 
 source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-#{version}.tar.lzma"
+
 version("2.25-tdm64-1") { source sha256: "4722bb7b4d46cef714234109e25e5d1cfd29f4e53365b6d615c8a00735f60e40" }
 
 build do

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -23,10 +23,9 @@ default_version "1.0.6"
 dependency "zlib"
 dependency "openssl"
 
-version "1.0.6" do
-  source md5: "00b516f4704d4a7cb50a1d97e6e8e15b"
-end
 source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz"
+
+version("1.0.6") { source md5: "00b516f4704d4a7cb50a1d97e6e8e15b" }
 
 relative_path "#{name}-#{version}"
 

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-aws"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-aws.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/chef-provisioning-aws.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-azure"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-azure.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/chef-provisioning-azure.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -17,14 +17,13 @@
 name "chef-provisioning-fog"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-fog.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"
 dependency "bundler"
 dependency "chef"
 
+source git: "https://github.com/chef/chef-provisioning-fog.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning-vagrant"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning-vagrant.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/chef-provisioning-vagrant.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -17,12 +17,12 @@
 name "chef-provisioning"
 default_version "master"
 
-source git: "https://github.com/chef/chef-provisioning.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/chef-provisioning.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -17,14 +17,14 @@
 name "chef-vault"
 default_version "master"
 
-source git: "https://github.com/chef/chef-vault.git"
-
-relative_path "chef-vault"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/chef-vault.git"
+
+relative_path "chef-vault"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -38,13 +38,13 @@ if version != "local_source"
   source git: "https://github.com/chef/chef.git"
 end
 
-relative_path "chef"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "ohai"
 dependency "appbundler"
+
+relative_path "chef"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -17,13 +17,13 @@
 name "chefspec"
 default_version "master"
 
-source git: "https://github.com/sethvargo/chefspec.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
 dependency "fauxhai"
+
+source git: "https://github.com/sethvargo/chefspec.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -19,15 +19,10 @@ default_version "1.7004"
 
 dependency "perl"
 
-version "1.7040" do
-  source md5: "4fabebffe22eaaf584b345b082a8a9c1"
-end
-
-version "1.7004" do
-  source md5: "02fe90392f33a12979e188ea110dae67"
-end
-
 source url: "https://github.com/miyagawa/cpanminus/archive/#{version}.tar.gz"
+
+version("1.7040") { source md5: "4fabebffe22eaaf584b345b082a8a9c1" }
+version("1.7004") { source md5: "02fe90392f33a12979e188ea110dae67" }
 
 relative_path "cpanminus-#{version}"
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -20,15 +20,10 @@ default_version "7.47.1"
 dependency "zlib"
 dependency "openssl"
 
-version "7.47.1" do
-  source md5: "3f9d1be7bf33ca4b8c8602820525302b"
-end
-
-version "7.36.0" do
-  source md5: "643a7030b27449e76413d501d4b8eb57"
-end
-
 source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz"
+
+version("7.47.1") { source md5: "3f9d1be7bf33ca4b8c8602820525302b" }
+version("7.36.0") { source md5: "643a7030b27449e76413d501d4b8eb57" }
 
 relative_path "curl-#{version}"
 

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -17,10 +17,11 @@
 name "expat"
 default_version "2.1.0"
 
-relative_path "expat-#{version}"
+source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
-       md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
+version('2.1.0') { source md5: "dd7dab7a5fea97d2a6a43f511449b7cd" }
+
+relative_path "expat-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -17,12 +17,12 @@
 name "fauxhai"
 default_version "master"
 
-source git: "https://github.com/customink/fauxhai.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/customink/fauxhai.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -18,13 +18,12 @@ name "ffi-yajl"
 default_version "master"
 relative_path "ffi-yajl"
 
-source git: "https://github.com/opscode/ffi-yajl.git"
-
 dependency "ruby"
-
 dependency "rubygems"
 dependency "libyajl2-gem"
 dependency "bundler"
+
+source git: "https://github.com/opscode/ffi-yajl.git"
 
 build do
   env = with_embedded_path()

--- a/config/software/figlet.rb
+++ b/config/software/figlet.rb
@@ -17,9 +17,9 @@
 name "figlet"
 default_version "2.2.5"
 
-version("2.2.5") { source md5: "eaaeb356007755c9770a842aefd8ed5f" }
-
 source url: "https://github.com/cmatsuoka/figlet/archive/#{version}.tar.gz"
+
+version("2.2.5") { source md5: "eaaeb356007755c9770a842aefd8ed5f" }
 
 relative_path "figlet-#{version}"
 

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -17,13 +17,13 @@
 name "foodcritic"
 default_version "v6.0.0"
 
-source git: "https://github.com/acrmp/foodcritic.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "nokogiri"
 dependency "chef"
+
+source git: "https://github.com/acrmp/foodcritic.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -22,12 +22,11 @@ dependency "mpfr"
 dependency "mpc"
 dependency "libiconv"
 
+source url: "https://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
+
 version("4.9.3")      { source md5: "648bfba342bb41a4b5350fb685f85bc5" }
 version("4.9.2")      { source md5: "76f464e0511c26c93425a9dcdc9134cf" }
-
 version("5.3.0")      { source md5: "39b5b6a0e769716a8e0a339adc79d8ad" }
-
-source url: "https://mirrors.kernel.org/gnu/gcc/gcc-#{version}/gcc-#{version}.tar.gz"
 
 relative_path "gcc-#{version}"
 

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -17,10 +17,10 @@
 name "gdbm"
 default_version "1.8.3"
 
+source url: "https://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
+
 # Version 1.9 and above are GPLv3, do NOT add later versions in
 version("1.8.3") { source md5: "1d1b1d5c0245b1c00aff92da751e9aa1" }
-
-source url: "https://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
 
 relative_path "gdbm-#{version}"
 

--- a/config/software/gecode.rb
+++ b/config/software/gecode.rb
@@ -17,20 +17,13 @@
 name "gecode"
 default_version "3.7.3"
 
-version "3.7.3" do
-  source md5: "7a5cb9945e0bb48f222992f2106130ac"
-end
+source url: "http://www.gecode.org/download/gecode-#{version}.tar.gz"
 
-version "3.7.1" do
-  source md5: "b4191d8cfafa18bd9b78594544be2a04"
-end
+version("3.7.3") { source md5: "7a5cb9945e0bb48f222992f2106130ac" }
+version("3.7.1") { source md5: "b4191d8cfafa18bd9b78594544be2a04" }
 
 # Major version, have not tried yet
-version "4.4.0" do
-  source md5: "a892852927b12ed291b435c72c085834"
-end
-
-source url: "http://www.gecode.org/download/gecode-#{version}.tar.gz"
+version("4.4.0") { source md5: "a892852927b12ed291b435c72c085834" }
 
 relative_path "gecode-#{version}"
 

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -24,29 +24,15 @@ dependency "pcre"
 dependency "libiconv"
 dependency "expat"
 
-relative_path "git-#{version}"
-
-version "2.7.1" do
-  source md5: "846ac45a1638e9a6ff3a9b790f6c8d99"
-end
-
-version "2.6.2" do
-  source md5: "da293290da69f45a86a311ad3cd43dc8"
-end
-
-version "2.2.1" do
-  source md5: "ff41fdb094eed1ec430aed8ee9b9849c"
-end
-
-version "1.9.5" do
-  source md5: "e9c82e71bec550e856cccd9548902885"
-end
-
-version "1.9.0" do
-  source md5: "0e00839539fc43cd2c350589744f254a"
-end
-
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
+
+version("2.7.1") { source md5: "846ac45a1638e9a6ff3a9b790f6c8d99" }
+version("2.6.2") { source md5: "da293290da69f45a86a311ad3cd43dc8" }
+version("2.2.1") { source md5: "ff41fdb094eed1ec430aed8ee9b9849c" }
+version("1.9.5") { source md5: "e9c82e71bec550e856cccd9548902885" }
+version("1.9.0") { source md5: "0e00839539fc43cd2c350589744f254a" }
+
+relative_path "git-#{version}"
 
 build do
 

--- a/config/software/gmp.rb
+++ b/config/software/gmp.rb
@@ -17,10 +17,10 @@
 name "gmp"
 default_version "6.0.0a"
 
+source url: "https://ftp.gnu.org/gnu/gmp/gmp-#{version}.tar.bz2"
+
 version("6.1.0")  { source md5: "86ee6e54ebfc4a90b643a65e402c4048" }
 version("6.0.0a") { source md5: "b7ff2d88cae7f8085bd5006096eed470" }
-
-source url: "https://ftp.gnu.org/gnu/gmp/gmp-#{version}.tar.bz2"
 
 if version == "6.0.0a"
   # version 6.0.0a expands to 6.0.0

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -17,15 +17,10 @@
 name "help2man"
 default_version "1.40.5"
 
-version "1.47.3" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.47.3.tar.xz",
-         md5: "d1d44a7a7b2bd61755a2045d96ecaea0"
-end
+source url: "https://ftp.gnu.org/gnu/help2man/help2man-#{version}.tar.gz"
 
-version "1.40.5" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
-         md5: "75a7d2f93765cd367aab98986a75f88c"
-end
+version("1.47.3") { source md5: "d1d44a7a7b2bd61755a2045d96ecaea0" }
+version("1.40.5") { source md5: "75a7d2f93765cd367aab98986a75f88c" }
 
 relative_path "help2man-1.40.5"
 

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -17,11 +17,11 @@
 name "inspec"
 default_version "master"
 
-source git: "https://github.com/chef/inspec.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/chef/inspec.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -22,17 +22,9 @@ dependency "openssl"
 
 source url: "http://www.keepalived.org/software/keepalived-#{version}.tar.gz"
 
-version "1.2.19" do
-  source md5: "5c98b06639dd50a6bff76901b53febb6"
-end
-
-version "1.2.9" do
-  source md5: "adfad98a2cc34230867d794ebc633492"
-end
-
-version "1.1.20" do
-  source md5: "6c3065c94bb9e2187c4b5a80f6d8be31"
-end
+version("1.2.19") { source  md5: "5c98b06639dd50a6bff76901b53febb6" }
+version("1.2.9")  { source  md5: "adfad98a2cc34230867d794ebc633492" }
+version("1.1.20") { source  md5: "6c3065c94bb9e2187c4b5a80f6d8be31" }
 
 relative_path "keepalived-#{version}"
 

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -17,13 +17,13 @@
 name "kitchen-inspec"
 default_version "master"
 
-source git: "https://github.com/chef/kitchen-inspec.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "test-kitchen"
 dependency "inspec"
+
+source git: "https://github.com/chef/kitchen-inspec.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -17,12 +17,12 @@
 name "knife-spork"
 default_version "master"
 
-source git: "https://github.com/jonlives/knife-spork.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/jonlives/knife-spork.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -17,12 +17,12 @@
 name "knife-windows"
 default_version "master"
 
-source git: "https://github.com/chef/knife-windows.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "chef"
+
+source git: "https://github.com/chef/knife-windows.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -20,8 +20,9 @@
 name "libarchive"
 default_version "3.1.2"
 
-source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
-       md5: 'efad5a503f66329bb9d2f4308b5de98a'
+source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
+
+version("3.1.2") { source md5: "efad5a503f66329bb9d2f4308b5de98a" }
 
 relative_path "libarchive-#{version}"
 

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -19,12 +19,12 @@ default_version "20120601-3.0"
 
 dependency "ncurses"
 
+source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
+
 version("20150325-3.1") { source md5: "43cdb5df3061d78b5e9d59109871b4f6" }
 version("20141030-3.1") { source md5: "5f18e63346d31b877cdf36b5c59b810b" }
 version("20130712-3.1") { source md5: "0891336c697362727a1fa7e60c5cb96c" }
 version("20120601-3.0") { source md5: "e50f6a7afb4de00c81650f7b1a0f5aea" }
-
-source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
 
 if version == "20141030-3.1"
   # released tar file has name discrepency in folder name for this version

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -21,10 +21,10 @@ default_version "3.2.1"
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?
 
+source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
+
 version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
 version("3.2.1")  { source md5: "83b89587607e3eb65c70d361f13bab43" }
-
-source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
 
 relative_path "libffi-#{version}"
 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -22,8 +22,9 @@ default_version "1.14"
 
 dependency "patch" if solaris2?
 
-source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
-       md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
+source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz"
+
+version("1.14") { source md5: "e34509b1623cec449dfeb73d7ce9c6c6" }
 
 relative_path "libiconv-#{version}"
 

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -17,8 +17,9 @@
 name "liblzma"
 default_version "5.2.2"
 
-source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
-       md5: "7cf6a8544a7dae8e8106fdf7addfa28c"
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz"
+
+version("5.2.2") { source md5: "7cf6a8544a7dae8e8106fdf7addfa28c" }
 
 relative_path "xz-#{version}"
 

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -17,12 +17,10 @@
 name "libossp-uuid"
 default_version "1.6.2"
 
-version "1.6.2" do
-  source md5: "5db0d43a9022a6ebbbc25337ae28942f"
-end
-
 # ftp on ftp.ossp.org is unavaiable so we must use another mirror site.
 source url: "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-#{version}.tar.gz"
+
+version("1.6.2") { source  md5: "5db0d43a9022a6ebbbc25337ae28942f" }
 
 relative_path "uuid-#{version}"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -23,19 +23,12 @@ dependency "autoconf"
 dependency "automake"
 dependency "libtool"
 
+source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
 # perhaps use git https://github.com/jedisct1/libsodium/
-version "1.0.8" do
-  source md5: "0a66b86fd3aab3fe4c858edcd2772760"
-end
-version "1.0.2" do
-  source md5: "dc40eb23e293448c6fc908757738003f"
-end
-version "0.7.1" do
-  source md5: "c224fe3923d1dcfe418c65c8a7246316"
-end
-
-source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+version("1.0.8") { source  md5: "0a66b86fd3aab3fe4c858edcd2772760" }
+version("1.0.2") { source  md5: "dc40eb23e293448c6fc908757738003f" }
+version("0.7.1") { source  md5: "c224fe3923d1dcfe418c65c8a7246316" }
 
 relative_path "libsodium-#{version}"
 

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -17,12 +17,12 @@
 name "libtool"
 default_version "2.4"
 
+source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
+
 # NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet
 version("2.4.6") { source md5: "addf44b646ddb4e3919805aa88fa7c5e" }
 version("2.4.2") { source md5: "d2f3b7d4627e69e13514a40e72a24d50" }
 version("2.4")   { source md5: "b32b04148ecdd7344abc6fe8bd1bb021" }
-
-source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
 
 relative_path "libtool-#{version}"
 

--- a/config/software/libuuid.rb
+++ b/config/software/libuuid.rb
@@ -24,10 +24,8 @@ version "2.27.1" do
   source md5: "e9c73747eadf5201b2a198530add4f87",
          url: "https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.gz"
 end
-version "2.21" do
-  source md5: "4222aa8c2a1b78889e959a4722f1881a"
-end
 
+version("2.21") { source  md5: "4222aa8c2a1b78889e959a4722f1881a" }
 
 relative_path "util-linux-#{version}"
 

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -21,11 +21,9 @@ dependency "zlib"
 dependency "libiconv"
 dependency "liblzma"
 
-version "2.9.3" do
-  source md5: "daece17e045f1c107610e137ab50c179"
-end
-
 source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
+
+version("2.9.3") { source  md5: "daece17e045f1c107610e137ab50c179" }
 
 relative_path "libxml2-#{version}"
 

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -22,15 +22,10 @@ dependency "liblzma"
 dependency "libtool" if solaris2?
 dependency "patch" if solaris2?
 
-version "1.1.28" do
-  source md5: "9667bf6f9310b957254fdcf6596600b7"
-end
-
-version "1.1.26" do
-  source md5: "e61d0364a30146aaa3001296f853b2b9"
-end
-
 source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+
+version("1.1.28") { source  md5: "9667bf6f9310b957254fdcf6596600b7" }
+version("1.1.26") { source  md5: "e61d0364a30146aaa3001296f853b2b9" }
 
 relative_path "libxslt-#{version}"
 

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -16,13 +16,14 @@
 
 name "libyajl2-gem"
 default_version "master"
-relative_path "libyajl2-gem"
-
-source git: "https://github.com/opscode/libyajl2-gem.git"
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/opscode/libyajl2-gem.git"
+
+relative_path "libyajl2-gem"
 
 build do
   env = with_embedded_path()

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -28,8 +28,9 @@ default_version "0.1.6"
 
 dependency "ruby-windows"
 
-source url: "https://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
-       md5: "8bb5d8e43cf18ec48b4751bdd0111c84"
+source url: "https://packages.openknapsack.org/libyaml/libyaml-#{version}-x86-windows.tar.lzma",
+
+verison("0.1.6") { md5: "8bb5d8e43cf18ec48b4751bdd0111c84" }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -28,9 +28,9 @@ default_version "0.1.6"
 
 dependency "ruby-windows"
 
-source url: "https://packages.openknapsack.org/libyaml/libyaml-#{version}-x86-windows.tar.lzma",
+source url: "https://packages.openknapsack.org/libyaml/libyaml-#{version}-x86-windows.tar.lzma"
 
-verison("0.1.6") { md5: "8bb5d8e43cf18ec48b4751bdd0111c84" }
+version("0.1.6") { source md5: "8bb5d8e43cf18ec48b4751bdd0111c84" }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -17,8 +17,9 @@
 name "libyaml"
 default_version '0.1.6'
 
-source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
-       md5: '5fe00cda18ca5daeb43762b80c38e06e'
+source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz"
+
+version("0.1.6") { source md5: '5fe00cda18ca5daeb43762b80c38e06e' }
 
 relative_path "yaml-#{version}"
 

--- a/config/software/libzmq-windows.rb
+++ b/config/software/libzmq-windows.rb
@@ -19,8 +19,9 @@ default_version "2.2.0"
 
 zmq_installer = "ZeroMQ-#{version}~miru1.0-win32.exe"
 
-source url: "https://miru.hk/archive/#{zmq_installer}",
-       md5: "207a322228f90f61bfb67e3f335db06e"
+source url: "https://miru.hk/archive/#{zmq_installer}"
+
+version("2.2.0") { source md5: "207a322228f90f61bfb67e3f335db06e" }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -18,34 +18,25 @@
 name "libzmq"
 default_version "2.1.11"
 
-dependency "autoconf"
-dependency "automake"
-dependency "libtool"
+dependency 'autoconf'
+dependency 'automake'
+dependency 'libtool'
 
-version "2.2.0" do
-  source md5: "1b11aae09b19d18276d0717b2ea288f6"
-  dependency "libuuid"
-end
-version "2.1.11" do
-  source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
-  dependency "libuuid"
-end
+source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
-version "4.1.4" do
-  source md5: "a611ecc93fffeb6d058c0e6edf4ad4fb"
-  dependency "libsodium"
-end
-version "4.0.5" do
-  source md5: "73c39f5eb01b9d7eaf74a5d899f1d03d"
-  dependency "libsodium"
-end
-version "4.0.4" do
-  source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"
-  dependency "libsodium"
+version('2.2.0')  { source md5: '1b11aae09b19d18276d0717b2ea288f6' }
+version('2.1.11') { source md5: 'f0f9fd62acb1f0869d7aa80379b1f6b7' }
+version('4.1.4')  { source md5: 'a611ecc93fffeb6d058c0e6edf4ad4fb' }
+version('4.0.5')  { source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d' }
+version('4.0.4')  { source md5: 'f3c3defbb5ef6cc000ca65e529fdab3b' }
+
+if version <= '2.2.0'
+  dependency 'libuuid'
+elsif version >= '4.0.4'
+  dependency 'libsodium'
 end
 
 relative_path "zeromq-#{version}"
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -17,7 +17,7 @@
 name "libzmq4x-windows"
 default_version "1.0.21"
 
-source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip",
+source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip"
 
 # Longer term we need to move this to a chef internal build pipeline
 # https://github.com/jdmundrawala/zeromq4-x/releases/download/libzmq4x-1.0.21/libzmq4x-windows.zip

--- a/config/software/libzmq4x-windows.rb
+++ b/config/software/libzmq4x-windows.rb
@@ -17,13 +17,11 @@
 name "libzmq4x-windows"
 default_version "1.0.21"
 
+source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip",
+
 # Longer term we need to move this to a chef internal build pipeline
 # https://github.com/jdmundrawala/zeromq4-x/releases/download/libzmq4x-1.0.21/libzmq4x-windows.zip
-#
-version("1.0.21") do
-  source url: "https://github.com/jaym/zeromq4-x/releases/download/libzmq4x-#{version}/libzmq4x-windows.zip",
-         md5: "f75bb49580c7563f890d1fcfdd415553"
-end
+version("1.0.21") { source md5: "f75bb49580c7563f890d1fcfdd415553" }
 
 relative_path "libzmq4x-windows"
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -21,9 +21,8 @@ dependency "popt"
 
 source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
-version "3.9.2" do
-  source md5: "584bca013dcceeb23b06b27d6d0342fb"
-end
+version("3.9.2") { source  md5: "584bca013dcceeb23b06b27d6d0342fb" }
+
 version "3.8.5" do
   source md5: "d3c13e2a963a55c584cfaa83e96b173d",
          url: "https://fedorahosted.org/releases/l/o/logrotate/logrotate-#{version}.tar.gz"

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -17,8 +17,9 @@
 name "m4"
 default_version "1.4.17"
 
-source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
-       md5: "a5e9954b1dae036762f7b13673a2cf76"
+source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz"
+
+version("1.4.17") { source md5: "a5e9954b1dae036762f7b13673a2cf76" }
 
 relative_path "m4-#{version}"
 

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -19,7 +19,7 @@ default_version "4.1"
 
 source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz"
 
-verison("4.1") { source md5: "654f9117957e6fa6a1c49a8f08270ec9" }
+version("4.1") { source md5: "654f9117957e6fa6a1c49a8f08270ec9" }
 
 relative_path "make-#{version}"
 

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -17,8 +17,9 @@
 name "make"
 default_version "4.1"
 
-source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
-       md5: "654f9117957e6fa6a1c49a8f08270ec9"
+source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz"
+
+verison("4.1") { source md5: "654f9117957e6fa6a1c49a8f08270ec9" }
 
 relative_path "make-#{version}"
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -17,14 +17,15 @@
 name "makedepend"
 default_version "1.0.5"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
-       md5: "efb2d7c7e22840947863efaedc175747"
-
-relative_path "makedepend-1.0.5"
-
 dependency "xproto"
 dependency "util-macros"
 dependency "pkg-config-lite"
+
+source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz"
+
+version("1.0.5") { source md5: "efb2d7c7e22840947863efaedc175747" }
+
+relative_path "makedepend-1.0.5"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/mpc.rb
+++ b/config/software/mpc.rb
@@ -20,10 +20,10 @@ default_version "1.0.2"
 dependency "gmp"
 dependency "mpfr"
 
+source url: "https://ftp.gnu.org/gnu/mpc/mpc-#{version}.tar.gz"
+
 version("1.0.2") { source md5: "68fadff3358fb3e7976c7a398a0af4c3" }
 version("1.0.3") { source md5: "d6a1d5f8ddea3abd2cc3e98f58352d26" }
-
-source url: "https://ftp.gnu.org/gnu/mpc/mpc-#{version}.tar.gz"
 
 relative_path "mpc-#{version}"
 

--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -19,10 +19,10 @@ default_version "3.1.2"
 
 dependency "gmp"
 
+source url: "http://www.mpfr.org/mpfr-#{version}/mpfr-#{version}.tar.gz"
+
 version("3.1.2") { source md5: "181aa7bb0e452c409f2788a4a7f38476" }
 version("3.1.3") { source md5: "7b650781f0a7c4a62e9bc8bdaaa0018b" }
-
-source url: "http://www.mpfr.org/mpfr-#{version}/mpfr-#{version}.tar.gz"
 
 relative_path "mpfr-#{version}"
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -116,7 +116,7 @@ build do
     # see http://invisible-island.net/ncurses/NEWS.html#t20140621
 
     # let libtool deal with library silliness
-    configure_command << "--with-libtool="#{install_dir}/embedded/bin/libtool""
+    configure_command << "--with-libtool=\"#{install_dir}/embedded/bin/libtool\""
 
     # stick with just the shared libs on AIX
     configure_command << "--without-normal"

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,10 +20,16 @@ default_version "5.9"
 dependency "libtool" if aix?
 dependency "patch" if solaris2?
 
-version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
-version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
-version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150613.tgz" }
-version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150810.tgz" }
+source url: "ftp://invisible-island.net/ncurses/current/ncurses-#{version}.tgz"
+
+version "5.9" do
+  source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1",
+         url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz"
+end
+
+version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43" }
+version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563" }
+version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f" }
 
 relative_path "ncurses-#{version}"
 
@@ -44,7 +50,7 @@ relative_path "ncurses-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env.delete('CPPFLAGS')
+  env.delete("CPPFLAGS")
 
   if smartos?
     # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
@@ -64,7 +70,7 @@ build do
     patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0, env: env
   end
 
-  # AIX's old version of patch doesn't like the patches here
+  # AIX"s old version of patch doesn"t like the patches here
   unless aix?
     if version == "5.9"
       # Update config.guess to support platforms made after 2010 (like aarch64)
@@ -77,7 +83,7 @@ build do
 
   if mac_os_x? ||
     # Clang became the default compiler in FreeBSD 10+
-    (freebsd? && ohai['os_version'].to_i >= 1000024)
+    (freebsd? && ohai["os_version"].to_i >= 1000024)
     # References:
     # https://github.com/Homebrew/homebrew-dupes/issues/43
     # http://invisible-island.net/ncurses/NEWS.html#t20110409
@@ -110,7 +116,7 @@ build do
     # see http://invisible-island.net/ncurses/NEWS.html#t20140621
 
     # let libtool deal with library silliness
-    configure_command << "--with-libtool=\"#{install_dir}/embedded/bin/libtool\""
+    configure_command << "--with-libtool="#{install_dir}/embedded/bin/libtool""
 
     # stick with just the shared libs on AIX
     configure_command << "--without-normal"
@@ -118,10 +124,10 @@ build do
     # ncurses's ./configure incorrectly
     # "figures out" ARFLAGS if you try
     # to set them yourself
-    env.delete('ARFLAGS')
+    env.delete("ARFLAGS")
 
     # use gnu install from the coreutils IBM rpm package
-    env['INSTALL'] = "/opt/freeware/bin/install"
+    env["INSTALL"] = "/opt/freeware/bin/install"
   end
 
   # only Solaris 10 sh has a problem with
@@ -146,7 +152,7 @@ build do
   make "-j #{workers}", env: env
 
   # Installing the non-wide libraries will also install the non-wide
-  # binaries, which doesn't happen to be a problem since we don't
+  # binaries, which doesn"t happen to be a problem since we don"t
   # utilize the ncurses binaries in private-chef (or oss chef)
   make "-j #{workers} install", env: env
 

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -19,25 +19,13 @@ default_version "0.10.10"
 
 dependency "python"
 
-version "0.10.10" do
-  source md5: "a47a9141567dd591eec486db05b09e1c"
-end
-
-version "0.10.26" do
-  source md5: "15e9018dadc63a2046f61eb13dfd7bd6"
-end
-
-version "0.10.35" do
-  source md5: "2c00d8cf243753996eecdc4f6e2a2d11"
-end
-
-version "4.1.2" do
-  source md5: "31a3ee2f51bb2018501048f543ea31c7"
-end
+source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
 # Warning: NodeJS 5.6.0 requires GCC >= 4.8
-
-source url: "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
+version("0.10.10") { source  md5: "a47a9141567dd591eec486db05b09e1c" }
+version("0.10.26") { source  md5: "15e9018dadc63a2046f61eb13dfd7bd6" }
+version("0.10.35") { source  md5: "2c00d8cf243753996eecdc4f6e2a2d11" }
+version("4.1.2")   { source  md5: "31a3ee2f51bb2018501048f543ea31c7" }
 
 relative_path "node-v#{version}"
 

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -18,13 +18,13 @@
 name "ohai"
 default_version "master"
 
-source git: "https://github.com/opscode/ohai.git"
-
-relative_path "ohai"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/opscode/ohai.git"
+
+relative_path "ohai"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -77,7 +77,7 @@ build do
   if rhel? &&
      platform_version.satisfies?("< 6.0") &&
      version.satisfies?(">= 1.7")
-    configure << "--with-luajit-xcflags="-std=gnu99""
+    configure << "--with-luajit-xcflags=\"-std=gnu99\""
   end
 
   command configure.join(" "), env: env

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -21,38 +21,26 @@ dependency "pcre"
 dependency "openssl"
 dependency "zlib"
 
-source_package_name = "openresty"
-
-version("1.9.7.3") { source md5: "33579b96a8c22bedee97eadfc99d9564" }
-
-version("1.9.7.2") do
-  source md5: "78a263de11ff43c95e847f208cce0899"
+if version < "1.9.7.2"
   source_package_name = "ngx_openresty"
-end
-version("1.9.3.1") do
-  source md5: "cde1f7127f6ba413ee257003e49d6d0a"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.2") do
-  source md5: "bca1744196acfb9e986f1fdbee92641e"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.1") do
-  source md5: "1093b89459922634a818e05f80c1e18a"
-  source_package_name = "ngx_openresty"
-end
-version("1.4.3.6") do
-  source md5: "5e5359ae3f1b8db4046b358d84fabbc8"
-  source_package_name = "ngx_openresty"
+else
+  source_package_name = "openresty"
 end
 
 source url: "https://openresty.org/download/#{source_package_name}-#{version}.tar.gz"
+
+version("1.9.7.3")  { source md5: "33579b96a8c22bedee97eadfc99d9564" }
+version("1.9.7.2")  { source md5: "78a263de11ff43c95e847f208cce0899" }
+version("1.9.3.1")  { source md5: "cde1f7127f6ba413ee257003e49d6d0a" }
+version("1.7.10.2") { source md5: "bca1744196acfb9e986f1fdbee92641e" }
+version("1.7.10.1") { source md5: "1093b89459922634a818e05f80c1e18a" }
+version("1.4.3.6")  { source md5: "5e5359ae3f1b8db4046b358d84fabbc8" }
 
 relative_path "#{source_package_name}-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['PATH'] += "#{env['PATH']}:/usr/sbin:/sbin"
+  env["PATH"] += "#{env["PATH"]}:/usr/sbin:/sbin"
 
   configure = [
     "./configure",
@@ -67,29 +55,29 @@ build do
     "--with-ld-opt=\"-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz\"",
     "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"",
     # Options inspired by the OpenResty Cookbook
-    '--with-md5-asm',
-    '--with-sha1-asm',
-    '--with-pcre-jit',
-    '--with-luajit',
-    '--without-http_ssi_module',
-    '--without-mail_smtp_module',
-    '--without-mail_imap_module',
-    '--without-mail_pop3_module',
-    '--with-ipv6',
+    "--with-md5-asm",
+    "--with-sha1-asm",
+    "--with-pcre-jit",
+    "--with-luajit",
+    "--without-http_ssi_module",
+    "--without-mail_smtp_module",
+    "--without-mail_imap_module",
+    "--without-mail_pop3_module",
+    "--with-ipv6"
     # AIO support define in Openresty cookbook. Requires Kernel >= 2.6.22
     # Ubuntu 10.04 reports: 2.6.32-38-server #83-Ubuntu SMP
     # However, they require libatomic-ops-dev and libaio
-    #'--with-file-aio',
-    #'--with-libatomic'
+    #"--with-file-aio",
+    #"--with-libatomic"
   ]
 
   # OpenResty 1.7 + RHEL5 Fixes:
   # According to https://github.com/openresty/ngx_openresty/issues/85, OpenResty
-  # fails to compile on RHEL5 without the "--with-luajit-xcflags='-std=gnu99'" flags
+  # fails to compile on RHEL5 without the "--with-luajit-xcflags="-std=gnu99"" flags
   if rhel? &&
-     platform_version.satisfies?('< 6.0') &&
-     version.satisfies?('>= 1.7')
-    configure << "--with-luajit-xcflags='-std=gnu99'"
+     platform_version.satisfies?("< 6.0") &&
+     version.satisfies?(">= 1.7")
+    configure << "--with-luajit-xcflags="-std=gnu99""
   end
 
   command configure.join(" "), env: env

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -20,9 +20,9 @@
 # tools can be used with https URLs out of the box.
 name "openssl-customization"
 
-source path: "#{project.files_path}/#{name}"
-
 dependency "ruby"
+
+source path: "#{project.files_path}/#{name}"
 
 build do
   block "Add OpenSSL customization file" do

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -17,18 +17,17 @@
 name "openssl-fips"
 default_version "2.0.10"
 
-version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
-version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
-version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
-
 # HAHAHA According to the FIPS manual, you need to "securely" fetch the source
 # such as asking some humans to mail you a CD-ROM or something.
 # You are then supposed to manually verify the PGP signatures.
 # When making an "official" build - make sure you go do that...
 source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
 
-relative_path "openssl-fips-#{version}"
+version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
+version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
+version("2.0.9")  { source md5: "c8256051d7a76471c6ad4fb771404e60" }
 
+relative_path "openssl-fips-#{version}"
 
 build do
   # According to the FIPS manual, this is the only environment you are allowed

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -21,27 +21,20 @@ default_version "1.0.1r"
 
 dependency "ruby-windows"
 
-if windows_arch_i386?
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x86-windows.tar.lzma",
-           md5: "72e2cab647192ddc5314760feca6b424"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x86-windows.tar.lzma",
-           md5: "971abfe54d89d79b34c7444dcab8e17b"
-  end
+if i386?
+  arch = "x86"
 else
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x64-windows.tar.lzma",
-           md5: "d1aa3c43f21eaf42abf321cbfd9de331"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x64-windows.tar.lzma",
-           md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b"
-  end
+  arch = "x64"
 end
 
-relative_path 'bin'
+source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-#{version}/openssl-#{version}-#{arch}-windows.tar.lzma"
+
+version("1.0.1r") { source md5: "72e2cab647192ddc5314760feca6b424" }
+version("1.0.1s") { source md5: "971abfe54d89d79b34c7444dcab8e17b" }
+version("1.0.1r") { source md5: "d1aa3c43f21eaf42abf321cbfd9de331" }
+version("1.0.1s") { source md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b" }
+
+relative_path "bin"
 
 build do
   # Copy over the required dlls into embedded/bin

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -15,6 +15,7 @@
 #
 
 name "openssl"
+default_version "1.0.1s"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
@@ -23,8 +24,6 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "patch" if solaris2?
 dependency "openssl-fips" if fips_enabled
-
-default_version "1.0.1s"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -19,13 +19,16 @@ name "patch"
 if windows?
   # TODO more recent version now?
   default_version "2.6.1"
+
   dependency "mingw-get"
 else
   default_version "2.7"
 
   version("2.7.5") { source md5: "ed4d5674ef4543b4eb463db168886dc7" }
-  version("2.7") { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
+  version("2.7")   { source md5: "1cbaa223ff4991be9fae8ec1d11fb5ab" }
+
   source url: "https://ftp.gnu.org/gnu/patch/patch-#{version}.tar.gz"
+
   relative_path "patch-#{version}"
 end
 

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -20,15 +20,10 @@ default_version "8.38"
 dependency "libedit"
 dependency "ncurses"
 
-version "8.38" do
-  source md5: "8a353fe1450216b6655dfcf3561716d9"
-end
-
-version "8.31" do
-  source md5: "fab1bb3b91a4c35398263a5c1e0858c1"
-end
-
 source url: "http://iweb.dl.sourceforge.net/project/pcre/pcre/#{version}/pcre-#{version}.tar.gz"
+
+version("8.38") { source  md5: "8a353fe1450216b6655dfcf3561716d9" }
+version("8.31") { source  md5: "fab1bb3b91a4c35398263a5c1e0858c1" }
 
 relative_path "pcre-#{version}"
 

--- a/config/software/perl-extutils-embed.rb
+++ b/config/software/perl-extutils-embed.rb
@@ -19,8 +19,9 @@ default_version "1.14"
 
 dependency "perl"
 
-source url: "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed-#{version}.tar.gz",
-       md5: "b2a2c26a18bca3ce69f8a0b1b54a0105"
+source url: "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed-#{version}.tar.gz"
+
+version("1.14") { source md5: "b2a2c26a18bca3ce69f8a0b1b54a0105" }
 
 relative_path "ExtUtils-Embed-#{version}"
 

--- a/config/software/perl-extutils-makemaker.rb
+++ b/config/software/perl-extutils-makemaker.rb
@@ -19,18 +19,11 @@ default_version "6.78"
 
 dependency "perl"
 
-version "6.98" do
-  source md5: "3eb83b59e33159ecc700bf60ac3c357a"
-end
-version "6.78" do
-  source md5: "843886bc1060b5e5c619e34029343eba"
-end
-version "7.10" do
-  source md5: "2639a21adee5e0a903730c12dcba08ec"
-end
-
 source url: "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-#{version}.tar.gz"
 
+version("6.98") { source  md5: "3eb83b59e33159ecc700bf60ac3c357a" }
+version("6.78") { source  md5: "843886bc1060b5e5c619e34029343eba" }
+version("7.10") { source  md5: "2639a21adee5e0a903730c12dcba08ec" }
 
 relative_path "ExtUtils-MakeMaker-#{version}"
 

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -22,13 +22,11 @@ if windows?
 else
   default_version "5.18.1"
 
-  version "5.22.1" do
-    source md5: "19295bbb775a3c36123161b9bf4892f1"
-  end
-  version "5.18.1" do
-    source md5: "304cb5bd18e48c44edd6053337d3386d"
-  end
   source url: "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz"
+
+  version("5.22.1") { source  md5: "19295bbb775a3c36123161b9bf4892f1" }
+  version("5.18.1") { source  md5: "304cb5bd18e48c44edd6053337d3386d" }
+
   relative_path "perl-#{version}"
 end
 

--- a/config/software/perl_pg_driver.rb
+++ b/config/software/perl_pg_driver.rb
@@ -21,14 +21,10 @@ dependency "perl"
 dependency "cpanminus"
 dependency "postgresql"
 
-version "3.5.3" do
-  source md5: "21cdf31a8d1f77466920375aa766c164"
-end
-version "3.3.0" do
-  source md5: "547de1382a47d66872912fe64282ff55"
-end
-
 source url: "http://search.cpan.org/CPAN/authors/id/T/TU/TURNSTEP/DBD-Pg-#{version}.tar.gz"
+
+version("3.5.3") { source  md5: "21cdf31a8d1f77466920375aa766c164" }
+version("3.3.0") { source  md5: "547de1382a47d66872912fe64282ff55" }
 
 relative_path "DBD-Pg-#{version}"
 

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -17,11 +17,9 @@
 name "pkg-config-lite"
 default_version "0.28-1"
 
-version "0.28-1" do
-  source md5: "61f05feb6bab0a6bbfab4b6e3b2f44b6"
-end
-
 source url: "http://downloads.sourceforge.net/project/pkgconfiglite/#{version}/pkg-config-lite-#{version}.tar.gz"
+
+version("0.28-1") { source  md5: "61f05feb6bab0a6bbfab4b6e3b2f44b6" }
 
 relative_path "pkg-config-lite-#{version}"
 

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -19,15 +19,10 @@ default_version "0.28"
 
 dependency "libiconv"
 
-version "0.29" do
-  source md5: "77f27dce7ef88d0634d0d6f90e03a77f"
-end
-
-version "0.28" do
-  source md5: "aa3c86e67551adc3ac865160e34a2a0d"
-end
-
 source url: "https://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
+
+version("0.29") { source  md5: "77f27dce7ef88d0634d0d6f90e03a77f" }
+version("0.28") { source  md5: "aa3c86e67551adc3ac865160e34a2a0d" }
 
 relative_path "pkg-config-#{version}"
 

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -17,8 +17,9 @@
 name "popt"
 default_version "1.16"
 
-source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz",
-       md5: "3743beefa3dd6247a73f8f7a32c14c33"
+source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz"
+
+version("1.16") { source md5: "3743beefa3dd6247a73f8f7a32c14c33" }
 
 relative_path "popt-#{version}"
 

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -23,75 +23,25 @@ dependency "libedit"
 dependency "ncurses"
 dependency "libossp-uuid"
 
-version "9.2.14" do
-  source md5: "ce2e50565983a14995f5dbcd3c35b627"
-end
-
-version "9.2.10" do
-  source md5: "7b81646e2eaf67598d719353bf6ee936"
-end
-
-version "9.2.9" do
-  source md5: "38b0937c86d537d5044c599273066cfc"
-end
-
-version "9.2.8" do
-  source md5: "c5c65a9b45ee53ead0b659be21ca1b97"
-end
-
-version "9.5.1" do
-  source md5: "11e037afaa4bd0c90bb3c3d955e2b401"
-end
-
-version "9.5.0" do
-  source md5: "2f3264612ac32e5abdfb643fec934036"
-end
-
-version "9.5beta1" do
-  source md5: "4bd67bfa4dc148e3f9d09f6699b5931f"
-end
-
-version "9.4.6" do
-  source md5: "0371b9d4fb995062c040ea5c3c1c971e"
-end
-
-version "9.4.5" do
-  source md5: "8b2e3472a8dc786649b4d02d02e039a0"
-end
-
-version "9.4.1" do
-  source md5: "2cf30f50099ff1109d0aa517408f8eff"
-end
-
-version "9.4.0" do
-  source md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b"
-end
-
-version "9.3.10" do
-  source md5: "ec2365548d08f69c8023eddd4f2d1a28"
-end
-
-version "9.3.6" do
-  source md5: "0212b03f2835fdd33126a2e70996be8e"
-end
-
-version "9.3.5" do
-  source md5: "5059857c7d7e6ad83b6d55893a121b59"
-end
-
-version "9.3.4" do
-  source md5: "d0a41f54c377b2d2fab4a003b0dac762"
-end
-
-version "9.1.15" do
-  source md5: "6ac52cf13ecf6b09c7d42928d1219cae"
-end
-
-version "9.1.9" do
-  source md5: "6b5ea53dde48fcd79acfc8c196b83535"
-end
-
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+
+version("9.2.14")   { source  md5: "ce2e50565983a14995f5dbcd3c35b627" }
+version("9.2.10")   { source  md5: "7b81646e2eaf67598d719353bf6ee936" }
+version("9.2.9")    { source  md5: "38b0937c86d537d5044c599273066cfc" }
+version("9.2.8")    { source  md5: "c5c65a9b45ee53ead0b659be21ca1b97" }
+version("9.5.1")    { source  md5: "11e037afaa4bd0c90bb3c3d955e2b401" }
+version("9.5.0")    { source  md5: "2f3264612ac32e5abdfb643fec934036" }
+version("9.5beta1") { source  md5: "4bd67bfa4dc148e3f9d09f6699b5931f" }
+version("9.4.6")    { source  md5: "0371b9d4fb995062c040ea5c3c1c971e" }
+version("9.4.5")    { source  md5: "8b2e3472a8dc786649b4d02d02e039a0" }
+version("9.4.1")    { source  md5: "2cf30f50099ff1109d0aa517408f8eff" }
+version("9.4.0")    { source  md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b" }
+version("9.3.10")   { source  md5: "ec2365548d08f69c8023eddd4f2d1a28" }
+version("9.3.6")    { source  md5: "0212b03f2835fdd33126a2e70996be8e" }
+version("9.3.5")    { source  md5: "5059857c7d7e6ad83b6d55893a121b59" }
+version("9.3.4")    { source  md5: "d0a41f54c377b2d2fab4a003b0dac762" }
+version("9.1.15")   { source  md5: "6ac52cf13ecf6b09c7d42928d1219cae" }
+version("9.1.9")    { source  md5: "6b5ea53dde48fcd79acfc8c196b83535" }
 
 relative_path "postgresql-#{version}"
 

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -22,11 +22,11 @@ dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
 
-version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
-version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }
-version("2.7.5") { source md5: "b4f01a1d0ba0b46b05c73b2ac909b1df" }
-
 source url: "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
+
+version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
+version("2.7.9")  { source md5: "5eebcaa0030dc4061156d3429657fb83" }
+version("2.7.5")  { source md5: "b4f01a1d0ba0b46b05c73b2ac909b1df" }
 
 relative_path "Python-#{version}"
 

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -19,12 +19,12 @@ default_version "2.7.1"
 
 dependency "erlang"
 
+source url: "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/rabbitmq-server-generic-unix-#{version}.tar.gz"
+
 version("3.6.0") { source md5: "61a3822f3af0aaa30da7230dccb17067" }
 version("3.3.4") { source md5: "61a3822f3af0aaa30da7230dccb17067" }
 version("2.8.7") { source md5: "35e8d78f8d7ae4372db23fe50db82c64" }
 version("2.7.1") { source md5: "34a5f9fb6f22e6681092443fcc80324f" }
-
-source url: "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/rabbitmq-server-generic-unix-#{version}.tar.gz"
 
 relative_path "rabbitmq_server-#{version}"
 

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -17,27 +17,13 @@
 name "redis"
 default_version "3.0.4"
 
-version "3.0.7" do
-  source md5: "84ed3f486e7a6f0ebada6917370f3532"
-end
-
-version "3.0.4" do
-  source md5: "9e535dea3dc5301de012047bf3cca952"
-end
-
-version "2.8.21" do
-  source md5: "d059e2bf5315e2488ab679e09e55a9e7"
-end
-
-version "2.8.2" do
-  source md5: "ee527b0c37e1e2cbceb497f5f6b8112b"
-end
-
-version "2.4.7" do
-  source md5: "6afffb6120724183e40f1cac324ac71c"
-end
-
 source url: "http://download.redis.io/releases/redis-#{version}.tar.gz"
+
+version("3.0.7")  { source  md5: "84ed3f486e7a6f0ebada6917370f3532" }
+version("3.0.4")  { source  md5: "9e535dea3dc5301de012047bf3cca952" }
+version("2.8.21") { source  md5: "d059e2bf5315e2488ab679e09e55a9e7" }
+version("2.8.2")  { source  md5: "ee527b0c37e1e2cbceb497f5f6b8112b" }
+version("2.4.7")  { source  md5: "6afffb6120724183e40f1cac324ac71c" }
 
 relative_path "redis-#{version}"
 

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -19,15 +19,10 @@ default_version "3.1.1"
 
 dependency "popt"
 
-version "3.1.2" do
-  source md5: "0f758d7e000c0f7f7d3792610fad70cb"
-end
-
-version "3.1.1" do
-  source md5: "43bd6676f0b404326eee2d63be3cdcfe"
-end
-
 source url: "https://rsync.samba.org/ftp/rsync/src/rsync-#{version}.tar.gz"
+
+version("3.1.2") { source  md5: "0f758d7e000c0f7f7d3792610fad70cb" }
+version("3.1.1") { source  md5: "43bd6676f0b404326eee2d63be3cdcfe" }
 
 relative_path "rsync-#{version}"
 

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -17,11 +17,11 @@
 name "rubocop"
 default_version "master"
 
-source git: "https://github.com/bbatsov/rubocop.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/bbatsov/rubocop.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -19,8 +19,10 @@ name "ruby-windows-devkit-bash"
 default_version "3.1.23-4-msys-1.0.18"
 
 dependency "ruby-windows-devkit"
-source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
-       md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"
+
+source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma"
+
+version("3.1.23-4-msys-1.0.18") { source md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e" }
 
 relative_path 'bin'
 

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -33,6 +33,7 @@ else
            md5: "ce99d873c1acc8bffc639bd4e764b849"
   end
 end
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -23,14 +23,15 @@ fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) 
 if fips_enabled
   # We only currently support 32-bit FIPS builds
   if windows_arch_i386?
-    relative_path "ruby-#{version}-i386-mingw32"
+    default_version "2.0.0-p647"
+
     source url: "https://s3-us-west-2.amazonaws.com/yakyakyak/ruby-#{version}-i386-mingw32.7z"
 
-    default_version "2.0.0-p647"
     version("2.0.0-p647") { source md5: "0b1e8f16580f26fd0992fad3834cb83d" }
+
+    relative_path "ruby-#{version}-i386-mingw32"
   end
 elsif windows_arch_i386?
-  relative_path "ruby-#{version}-i386-mingw32"
   source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct"
 
   version("2.2.4") { source md5: "392a3d4ebc8d0733508c8e70ec86d0fa" }
@@ -46,8 +47,9 @@ elsif windows_arch_i386?
   version("2.0.0-p451") { source md5: "37feadb0230e7f475a8591d1807ecfec" }
 
   version("1.9.3-p484") { source md5: "a0665113aaeea83f1c4bea02fcf16694" }
+
+  relative_path "ruby-#{version}-i386-mingw32"
 else
-  relative_path "ruby-#{version}-x64-mingw32"
   source url: "https://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-x64-mingw32.7z?direct"
 
   version("2.2.4") { source md5: "0cff85bfccdd6a1e772cdf362066199e" }
@@ -61,6 +63,8 @@ else
   version("2.0.0-p648") { source md5: "022f14d020eb2b7a19c6494f7e16d137" }
   version("2.0.0-p645") { source md5: "d57d539b90f5bbf26550a9d1a3c33c33" }
   version("2.0.0-p451") { source md5: "d4f6741138a26a4be12e684a16a19b75" }
+
+  relative_path "ruby-#{version}-x64-mingw32"
 end
 
 build do

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -58,6 +58,7 @@ dependency "libyaml"
 # and that's the only one we will ever use.
 dependency "libiconv"
 
+source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
 version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 
@@ -83,8 +84,6 @@ version("2.0.0-p576") { source md5: "2e1f4355981b754d92f7e2cc456f843d" }
 version("1.9.3-p550") { source md5: "e05135be8f109b2845229c4f47f980fd" }
 version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
-
-source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
 relative_path "ruby-#{version}"
 

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -17,14 +17,10 @@
 name "runit"
 default_version "2.1.1"
 
-version "2.1.2" do
-  source md5: "6c985fbfe3a34608eb3c53dc719172c4"
-end
-version "2.1.1" do
-  source md5: "8fa53ea8f71d88da9503f62793336bc3"
-end
-
 source url: "http://smarden.org/runit/runit-#{version}.tar.gz"
+
+version("2.1.2") { source  md5: "6c985fbfe3a34608eb3c53dc719172c4" }
+version("2.1.1") { source  md5: "8fa53ea8f71d88da9503f62793336bc3" }
 
 relative_path "admin/runit-#{version}/src"
 

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -19,19 +19,11 @@ default_version "0.7.7"
 
 dependency "python"
 
-version "0.9.8" do
-  source md5: "243076241781935f7fcad370195a4291"
-end
-
-version "0.7.7" do
-  source md5: "0d7bc0e1a34b70a97e706ef74aa7f37f"
-end
-
-version "20.0" do
-  source md5: "fb22b2474ca037e0b08f3c3b293e02e6"
-end
-
 source url: "https://pypi.python.org/packages/source/s/setuptools/setuptools-#{version}.tar.gz"
+
+version("0.9.8") { source  md5: "243076241781935f7fcad370195a4291" }
+version("0.7.7") { source  md5: "0d7bc0e1a34b70a97e706ef74aa7f37f" }
+version("20.0")  { source  md5: "fb22b2474ca037e0b08f3c3b293e02e6" }
 
 relative_path "setuptools-#{version}"
 

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -20,15 +20,10 @@ default_version "0.973"
 dependency "perl"
 dependency "cpanminus"
 
-version "0.9994" do
-  source md5: "7227dfcd141440f23d99f01a2b01e0f2"
-end
-
-version "0.973" do
-  source md5: "0994e9f906a7a4a2e97049c8dbaef584"
-end
-
 source url: "http://www.cpan.org/authors/id/D/DW/DWHEELER/App-Sqitch-#{version}.tar.gz"
+
+version("0.9994") { source  md5: "7227dfcd141440f23d99f01a2b01e0f2" }
+version("0.973")  { source  md5: "0994e9f906a7a4a2e97049c8dbaef584" }
 
 relative_path "App-Sqitch-#{version}"
 

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -18,11 +18,11 @@ name "test-kitchen"
 default_version "master"
 relative_path "test-kitchen"
 
-source git: "https://github.com/test-kitchen/test-kitchen.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"
+
+source git: "https://github.com/test-kitchen/test-kitchen.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -17,15 +17,10 @@
 name "util-macros"
 default_version "1.18.0"
 
-version "1.19.0" do
-  source md5: "40e1caa49a71a26e0aa68ddd00203717"
-end
-
-version "1.18.0" do
-  source md5: "fd0ba21b3179703c071bbb4c3e5fb0f4"
-end
-
 source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz"
+
+version("1.19.0") { source  md5: "40e1caa49a71a26e0aa68ddd00203717" }
+version("1.18.0") { source  md5: "fd0ba21b3179703c071bbb4c3e5fb0f4" }
 
 relative_path "util-macros-#{version}"
 

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -17,11 +17,11 @@
 name "winrm-transport"
 default_version "master"
 
-source git: "https://github.com/test-kitchen/winrm-transport.git"
-
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
+
+source git: "https://github.com/test-kitchen/winrm-transport.git"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -17,15 +17,10 @@
 name "xproto"
 default_version "7.0.25"
 
-version "7.0.28" do
-  source md5: "0b42843b99aee3e4f6a9cc7710143f86"
-end
-
-version "7.0.25" do
-  source md5: "a47db46cb117805bd6947aa5928a7436"
-end
-
 source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz"
+
+version("7.0.28") { source  md5: "0b42843b99aee3e4f6a9cc7710143f86" }
+version("7.0.25") { source  md5: "a47db46cb117805bd6947aa5928a7436" }
 
 relative_path "xproto-#{version}"
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -17,14 +17,10 @@
 name "zlib"
 default_version "1.2.8"
 
-version "1.2.8" do
-  source md5: "44d667c142d7cda120332623eab69f40"
-end
-version "1.2.6" do
-  source md5: "618e944d7c7cd6521551e30b32322f4a"
-end
-
 source url: "http://iweb.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
+
+version("1.2.8") { source  md5: "44d667c142d7cda120332623eab69f40" }
+version("1.2.6") { source  md5: "618e944d7c7cd6521551e30b32322f4a" }
 
 relative_path "zlib-#{version}"
 


### PR DESCRIPTION
Standardize 'version' statements within the defs:
- favor inline-block style for simple (1-liners) version blocks when possible
- favor do/end block style for more complex blocks (2+ lines)
- favor ordered defs (top down):
  - `name`
  - `default_version`
  - `deps`
  - `source url`
  - `versions`
  - `relative_path`

Some untouchable black sheep:
- server-jre
- rubygems
- ruby-windows-devkit
- rebar

/cc @stevendanna @tas50 