### PR TITLE
Order/format friendly refactors

### DIFF
--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-Omnibus.logger.deprecated('berkshelf2') do
-  'Please upgrade to Berkshelf 3. Continued use of Berkshelf 2 will not be supported in the future.'
+Omnibus.logger.deprecated("berkshelf2") do
+  "Please upgrade to Berkshelf 3. Continued use of Berkshelf 2 will not be supported in the future."
 end
 
 name "berkshelf2"
@@ -29,27 +29,18 @@ dependency "libffi"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install celluloid" \
-      " --version '~> 0.16.0'" \
-      " --no-ri --no-rdoc", env: env
+  gems = {
+    "celluloid"    => "0.16.0",
+    "celluloid-io" => "0.16.1",
+    "hashie"       => "2.0.0",
+    "varia_model"  => "0.3.2",
+    "i18n"         => "0.6.11",
+    "berkshelf"    => "#{version}",
+  }
 
-  gem "install celluloid-io" \
-      " --version '~> 0.16.1'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install hashie" \
-      " --version '~> 2.0.0'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install varia_model" \
-      " --version '0.3.2'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install i18n" \
-      " --version '0.6.11'" \
-      " --no-ri --no-rdoc", env: env
-
-  gem "install berkshelf" \
-      " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+  gems.map do |name, version|
+    gem "install #{name}" \
+        " --version #{version}" \
+        " --no-ri --no-rdoc", env: env
+  end
 end

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -23,8 +23,15 @@ dependency "ncurses"
 
 source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 
-version("R15B03-1") { source md5: "eccd1e6dda6132993555e088005019f2" }
 version("R16B03-1") { source md5: "e5ece977375197338c1b93b3d88514f8" }
+
+# R15B03-1, and R15B03-1 alone appears to extract to a directory
+# called 'R15B03'. Versus R16B03-1 which extracts to 'R16B03'
+version "R15B03-1" do
+  source md5: "eccd1e6dda6132993555e088005019f2"
+  relative_path "otp_src_R15B03"
+end
+
 version("R15B02")   { source md5: "ccbe5e032a2afe2390de8913bfe737a1" }
 version("17.0")     { source md5: "a5f78c1cf0eb7724de3a59babc1a28e5" }
 version("17.1")     { source md5: "9c90706ce70e01651adde34a2b79bf4c" }

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -23,55 +23,18 @@ dependency "ncurses"
 
 source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 
-version "R15B03-1" do
-  source md5:   "eccd1e6dda6132993555e088005019f2"
-  relative_path "otp_src_R15B03"
-end
+version("R15B03-1") { source md5: "eccd1e6dda6132993555e088005019f2" }
+version("R16B03-1") { source md5: "e5ece977375197338c1b93b3d88514f8" }
+version("R15B02")   { source md5: "ccbe5e032a2afe2390de8913bfe737a1" }
+version("17.0")     { source md5: "a5f78c1cf0eb7724de3a59babc1a28e5" }
+version("17.1")     { source md5: "9c90706ce70e01651adde34a2b79bf4c" }
+version("17.3")     { source md5: "1d0bb2d54dfe1bb6844756b99902ba20" }
+version("17.4")     { source md5: "3d33c4c6bd7950240dcd7479edd9c7d8" }
+version("17.5")     { source md5: "346dd0136bf1cc28cebc140e505206bb" }
+version("18.1")     { source md5: "fa64015fdd133e155b5b19bf90ac8678" }
+version("18.2")     { source md5: "b336d2a8ccfbe60266f71d102e99f7ed" }
 
-version "R16B03-1" do
-  source md5:   "e5ece977375197338c1b93b3d88514f8"
-  relative_path "otp_src_#{version}"
-end
-
-version "R15B02" do
-  source md5:   "ccbe5e032a2afe2390de8913bfe737a1"
-  relative_path "otp_src_#{version}"
-end
-
-version '17.0' do
-  source md5: 'a5f78c1cf0eb7724de3a59babc1a28e5'
-  relative_path 'otp_src_17.0'
-end
-
-version '17.1' do
-  source md5: '9c90706ce70e01651adde34a2b79bf4c'
-  relative_path 'otp_src_17.1'
-end
-
-version '17.3' do
-  source md5: '1d0bb2d54dfe1bb6844756b99902ba20'
-  relative_path 'otp_src_17.3'
-end
-
-version '17.4' do
-  source md5: '3d33c4c6bd7950240dcd7479edd9c7d8'
-  relative_path 'otp_src_17.4'
-end
-
-version '17.5' do
-  source md5: '346dd0136bf1cc28cebc140e505206bb'
-  relative_path 'otp_src_17.5'
-end
-
-version '18.1' do
-  source md5: 'fa64015fdd133e155b5b19bf90ac8678'
-  relative_path 'otp_src_18.1'
-end
-
-version '18.2' do
-  source md5: 'b336d2a8ccfbe60266f71d102e99f7ed'
-  relative_path 'otp_src_18.2'
-end
+relative_path "otp_src_#{version.split('-')[0]}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
@@ -79,7 +42,7 @@ build do
     "CFLAGS"  => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
     "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
   )
-  env.delete('CPPFLAGS')
+  env.delete("CPPFLAGS")
 
   # Setup the erlang include dir
   mkdir "#{install_dir}/embedded/erlang/include"
@@ -90,7 +53,7 @@ build do
   #
   # In future releases of erlang, someone should check if these flags (or
   # environment variables) are avaiable to remove this ugly hack.
-  %w(ncurses openssl zlib.h zconf.h).each do |name|
+  %w{ncurses openssl zlib.h zconf.h}.each do |name|
     link "#{install_dir}/embedded/include/#{name}", "#{install_dir}/embedded/erlang/include/#{name}"
   end
 

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -17,15 +17,10 @@
 name "help2man"
 default_version "1.40.5"
 
-version "1.47.3" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.47.3.tar.xz",
-         md5: "d1d44a7a7b2bd61755a2045d96ecaea0"
-end
+source url: "https://ftp.gnu.org/gnu/help2man/help2man-#{version}.tar.gz"
 
-version "1.40.5" do
-  source url: "https://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
-         md5: "75a7d2f93765cd367aab98986a75f88c"
-end
+version("1.47.3") { source md5: "d1d44a7a7b2bd61755a2045d96ecaea0" }
+version("1.40.5") { source md5: "75a7d2f93765cd367aab98986a75f88c" }
 
 relative_path "help2man-1.40.5"
 

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -18,34 +18,25 @@
 name "libzmq"
 default_version "2.1.11"
 
-dependency "autoconf"
-dependency "automake"
-dependency "libtool"
+dependency 'autoconf'
+dependency 'automake'
+dependency 'libtool'
 
-version "2.2.0" do
-  source md5: "1b11aae09b19d18276d0717b2ea288f6"
-  dependency "libuuid"
-end
-version "2.1.11" do
-  source md5: "f0f9fd62acb1f0869d7aa80379b1f6b7"
-  dependency "libuuid"
-end
+source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
-version "4.1.4" do
-  source md5: "a611ecc93fffeb6d058c0e6edf4ad4fb"
-  dependency "libsodium"
-end
-version "4.0.5" do
-  source md5: "73c39f5eb01b9d7eaf74a5d899f1d03d"
-  dependency "libsodium"
-end
-version "4.0.4" do
-  source md5: "f3c3defbb5ef6cc000ca65e529fdab3b"
-  dependency "libsodium"
+version('2.2.0')  { source md5: '1b11aae09b19d18276d0717b2ea288f6' }
+version('2.1.11') { source md5: 'f0f9fd62acb1f0869d7aa80379b1f6b7' }
+version('4.1.4')  { source md5: 'a611ecc93fffeb6d058c0e6edf4ad4fb' }
+version('4.0.5')  { source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d' }
+version('4.0.4')  { source md5: 'f3c3defbb5ef6cc000ca65e529fdab3b' }
+
+if version <= '2.2.0'
+  dependency 'libuuid'
+elsif version >= '4.0.4'
+  dependency 'libsodium'
 end
 
 relative_path "zeromq-#{version}"
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -116,7 +116,7 @@ build do
     # see http://invisible-island.net/ncurses/NEWS.html#t20140621
 
     # let libtool deal with library silliness
-    configure_command << "--with-libtool="#{install_dir}/embedded/bin/libtool""
+    configure_command << "--with-libtool=\"#{install_dir}/embedded/bin/libtool\""
 
     # stick with just the shared libs on AIX
     configure_command << "--without-normal"

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -70,7 +70,7 @@ build do
     patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0, env: env
   end
 
-  # AIX"s old version of patch doesn"t like the patches here
+  # AIX"s old version of patch doesn't like the patches here
   unless aix?
     if version == "5.9"
       # Update config.guess to support platforms made after 2010 (like aarch64)
@@ -90,7 +90,7 @@ build do
       #
       # Patches ncurses for clang compiler. Changes have been accepted into
       # upstream, but occurred shortly after the 5.9 release. We should be able
-      # to remove this after upgrading to any release created after June 2012
+    # to remove this after upgrading to any release created after June 2012
     patch source: "ncurses-clang.patch", env: env
   end
 
@@ -152,7 +152,7 @@ build do
   make "-j #{workers}", env: env
 
   # Installing the non-wide libraries will also install the non-wide
-  # binaries, which doesn"t happen to be a problem since we don"t
+  # binaries, which doesn't happen to be a problem since we don't
   # utilize the ncurses binaries in private-chef (or oss chef)
   make "-j #{workers} install", env: env
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,10 +20,16 @@ default_version "5.9"
 dependency "libtool" if aix?
 dependency "patch" if solaris2?
 
-version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
-version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
-version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150613.tgz" }
-version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f", url: "ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150810.tgz" }
+source url: "ftp://invisible-island.net/ncurses/current/ncurses-#{version}.tgz"
+
+version "5.9" do
+  source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1",
+         url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz"
+end
+
+version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43" }
+version("6.0-20150613") { source md5: "0c6a0389d004c78f4a995bc61884a563" }
+version("6.0-20150810") { source md5: "78bfcb4634a87b4cda390956586f8f1f" }
 
 relative_path "ncurses-#{version}"
 
@@ -44,7 +50,7 @@ relative_path "ncurses-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env.delete('CPPFLAGS')
+  env.delete("CPPFLAGS")
 
   if smartos?
     # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
@@ -64,7 +70,7 @@ build do
     patch source: "ncurses-5.9-solaris-xopen_source_extended-detection.patch", plevel: 0, env: env
   end
 
-  # AIX's old version of patch doesn't like the patches here
+  # AIX"s old version of patch doesn"t like the patches here
   unless aix?
     if version == "5.9"
       # Update config.guess to support platforms made after 2010 (like aarch64)
@@ -76,15 +82,15 @@ build do
   end
 
   if mac_os_x? ||
-    # Clang became the default compiler in FreeBSD 10+
-    (freebsd? && ohai['os_version'].to_i >= 1000024)
-    # References:
-    # https://github.com/Homebrew/homebrew-dupes/issues/43
-    # http://invisible-island.net/ncurses/NEWS.html#t20110409
-    #
-    # Patches ncurses for clang compiler. Changes have been accepted into
-    # upstream, but occurred shortly after the 5.9 release. We should be able
-    # to remove this after upgrading to any release created after June 2012
+      # Clang became the default compiler in FreeBSD 10+
+      (freebsd? && ohai["os_version"].to_i >= 1000024)
+      # References:
+      # https://github.com/Homebrew/homebrew-dupes/issues/43
+      # http://invisible-island.net/ncurses/NEWS.html#t20110409
+      #
+      # Patches ncurses for clang compiler. Changes have been accepted into
+      # upstream, but occurred shortly after the 5.9 release. We should be able
+      # to remove this after upgrading to any release created after June 2012
     patch source: "ncurses-clang.patch", env: env
   end
 
@@ -110,7 +116,7 @@ build do
     # see http://invisible-island.net/ncurses/NEWS.html#t20140621
 
     # let libtool deal with library silliness
-    configure_command << "--with-libtool=\"#{install_dir}/embedded/bin/libtool\""
+    configure_command << "--with-libtool="#{install_dir}/embedded/bin/libtool""
 
     # stick with just the shared libs on AIX
     configure_command << "--without-normal"
@@ -118,10 +124,10 @@ build do
     # ncurses's ./configure incorrectly
     # "figures out" ARFLAGS if you try
     # to set them yourself
-    env.delete('ARFLAGS')
+    env.delete("ARFLAGS")
 
     # use gnu install from the coreutils IBM rpm package
-    env['INSTALL'] = "/opt/freeware/bin/install"
+    env["INSTALL"] = "/opt/freeware/bin/install"
   end
 
   # only Solaris 10 sh has a problem with
@@ -146,7 +152,7 @@ build do
   make "-j #{workers}", env: env
 
   # Installing the non-wide libraries will also install the non-wide
-  # binaries, which doesn't happen to be a problem since we don't
+  # binaries, which doesn"t happen to be a problem since we don"t
   # utilize the ncurses binaries in private-chef (or oss chef)
   make "-j #{workers} install", env: env
 

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -77,7 +77,7 @@ build do
   if rhel? &&
      platform_version.satisfies?("< 6.0") &&
      version.satisfies?(">= 1.7")
-    configure << "--with-luajit-xcflags="-std=gnu99""
+    configure << "--with-luajit-xcflags=\"-std=gnu99\""
   end
 
   command configure.join(" "), env: env

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -21,38 +21,26 @@ dependency "pcre"
 dependency "openssl"
 dependency "zlib"
 
-source_package_name = "openresty"
-
-version("1.9.7.3") { source md5: "33579b96a8c22bedee97eadfc99d9564" }
-
-version("1.9.7.2") do
-  source md5: "78a263de11ff43c95e847f208cce0899"
+if version < "1.9.7.2"
   source_package_name = "ngx_openresty"
-end
-version("1.9.3.1") do
-  source md5: "cde1f7127f6ba413ee257003e49d6d0a"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.2") do
-  source md5: "bca1744196acfb9e986f1fdbee92641e"
-  source_package_name = "ngx_openresty"
-end
-version("1.7.10.1") do
-  source md5: "1093b89459922634a818e05f80c1e18a"
-  source_package_name = "ngx_openresty"
-end
-version("1.4.3.6") do
-  source md5: "5e5359ae3f1b8db4046b358d84fabbc8"
-  source_package_name = "ngx_openresty"
+else
+  source_package_name = "openresty"
 end
 
 source url: "https://openresty.org/download/#{source_package_name}-#{version}.tar.gz"
+
+version("1.9.7.3")  { source md5: "33579b96a8c22bedee97eadfc99d9564" }
+version("1.9.7.2")  { source md5: "78a263de11ff43c95e847f208cce0899" }
+version("1.9.3.1")  { source md5: "cde1f7127f6ba413ee257003e49d6d0a" }
+version("1.7.10.2") { source md5: "bca1744196acfb9e986f1fdbee92641e" }
+version("1.7.10.1") { source md5: "1093b89459922634a818e05f80c1e18a" }
+version("1.4.3.6")  { source md5: "5e5359ae3f1b8db4046b358d84fabbc8" }
 
 relative_path "#{source_package_name}-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['PATH'] += "#{env['PATH']}:/usr/sbin:/sbin"
+  env["PATH"] += "#{env["PATH"]}:/usr/sbin:/sbin"
 
   configure = [
     "./configure",
@@ -67,29 +55,29 @@ build do
     "--with-ld-opt=\"-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz\"",
     "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"",
     # Options inspired by the OpenResty Cookbook
-    '--with-md5-asm',
-    '--with-sha1-asm',
-    '--with-pcre-jit',
-    '--with-luajit',
-    '--without-http_ssi_module',
-    '--without-mail_smtp_module',
-    '--without-mail_imap_module',
-    '--without-mail_pop3_module',
-    '--with-ipv6',
+    "--with-md5-asm",
+    "--with-sha1-asm",
+    "--with-pcre-jit",
+    "--with-luajit",
+    "--without-http_ssi_module",
+    "--without-mail_smtp_module",
+    "--without-mail_imap_module",
+    "--without-mail_pop3_module",
+    "--with-ipv6"
     # AIO support define in Openresty cookbook. Requires Kernel >= 2.6.22
     # Ubuntu 10.04 reports: 2.6.32-38-server #83-Ubuntu SMP
     # However, they require libatomic-ops-dev and libaio
-    #'--with-file-aio',
-    #'--with-libatomic'
+    #"--with-file-aio",
+    #"--with-libatomic"
   ]
 
   # OpenResty 1.7 + RHEL5 Fixes:
   # According to https://github.com/openresty/ngx_openresty/issues/85, OpenResty
-  # fails to compile on RHEL5 without the "--with-luajit-xcflags='-std=gnu99'" flags
+  # fails to compile on RHEL5 without the "--with-luajit-xcflags="-std=gnu99"" flags
   if rhel? &&
-     platform_version.satisfies?('< 6.0') &&
-     version.satisfies?('>= 1.7')
-    configure << "--with-luajit-xcflags='-std=gnu99'"
+     platform_version.satisfies?("< 6.0") &&
+     version.satisfies?(">= 1.7")
+    configure << "--with-luajit-xcflags="-std=gnu99""
   end
 
   command configure.join(" "), env: env

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -21,27 +21,20 @@ default_version "1.0.1r"
 
 dependency "ruby-windows"
 
-if windows_arch_i386?
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x86-windows.tar.lzma",
-           md5: "72e2cab647192ddc5314760feca6b424"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x86-windows.tar.lzma",
-           md5: "971abfe54d89d79b34c7444dcab8e17b"
-  end
+if i386?
+  arch = "x86"
 else
-  version('1.0.1r') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x64-windows.tar.lzma",
-           md5: "d1aa3c43f21eaf42abf321cbfd9de331"
-  end
-  version('1.0.1s') do
-    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x64-windows.tar.lzma",
-           md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b"
-  end
+  arch = "x64"
 end
 
-relative_path 'bin'
+source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-#{version}/openssl-#{version}-#{arch}-windows.tar.lzma"
+
+version("1.0.1r") { source md5: "72e2cab647192ddc5314760feca6b424" }
+version("1.0.1s") { source md5: "971abfe54d89d79b34c7444dcab8e17b" }
+version("1.0.1r") { source md5: "d1aa3c43f21eaf42abf321cbfd9de331" }
+version("1.0.1s") { source md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b" }
+
+relative_path "bin"
 
 build do
   # Copy over the required dlls into embedded/bin

--- a/config/software/openssl-windows.rb
+++ b/config/software/openssl-windows.rb
@@ -21,20 +21,27 @@ default_version "1.0.1r"
 
 dependency "ruby-windows"
 
-if i386?
-  arch = "x86"
+if windows_arch_i386?
+  version('1.0.1r') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x86-windows.tar.lzma",
+           md5: "72e2cab647192ddc5314760feca6b424"
+  end
+  version('1.0.1s') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x86-windows.tar.lzma",
+           md5: "971abfe54d89d79b34c7444dcab8e17b"
+  end
 else
-  arch = "x64"
+  version('1.0.1r') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1r/openssl-1.0.1r-x64-windows.tar.lzma",
+           md5: "d1aa3c43f21eaf42abf321cbfd9de331"
+  end
+  version('1.0.1s') do
+    source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-1.0.1s/openssl-1.0.1s-x64-windows.tar.lzma",
+           md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b"
+  end
 end
 
-source url: "https://github.com/jaym/windows-openssl-build/releases/download/openssl-#{version}/openssl-#{version}-#{arch}-windows.tar.lzma"
-
-version("1.0.1r") { source md5: "72e2cab647192ddc5314760feca6b424" }
-version("1.0.1s") { source md5: "971abfe54d89d79b34c7444dcab8e17b" }
-version("1.0.1r") { source md5: "d1aa3c43f21eaf42abf321cbfd9de331" }
-version("1.0.1s") { source md5: "0a8d444d22ab43ecf8ae29ec8d31fa1b" }
-
-relative_path "bin"
+relative_path 'bin'
 
 build do
   # Copy over the required dlls into embedded/bin


### PR DESCRIPTION
Refactors that potentially alter functionality.

Erlang's dep which used to set `relative_path` to `otp_src_R16B03-1` for that version:
```ruby
version "R16B03-1" do
  source md5:   "e5ece977375197338c1b93b3d88514f8"
  relative_path "otp_src_#{version}"
end
```

And now will set it to `otp_src_R16B03` to make things more unilateral across all versions:
```ruby
relative_path "otp_src_#{version.split('-')[0]}"
```

help2man previously used .xz for one version and .tar.gz for another when both are available for both. Refactor uses .tar.gz for both.

OpenResty shouldn't have changed functionality.
Ncurses just unifies the `source url` used
libzmq unifies dependency statement
openssl-windows just unifies the `source url` used
berkshelf2 saves space

/cc @stevendanna @tas50 