### PR TITLE
Require 2 :+1:'s to approve changes

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,8 @@
 # Maintainers
 
-This file lists how the Omnibus project is maintained. When making changes
-to the system, this file tells you who needs to review your patch - you need a
-simple majority of maintainers for the relevant subsystems to provide a :+1: on
+This file lists how the `omnibus-software` project is maintained.
+
+When making changes to the system, you need two maintainers to provide a :+1: on
 your pull request. Additionally, you need to not receive a veto from a
 Lieutenant or the Project Lead.
 


### PR DESCRIPTION
cc @chef/omnibus-maintainers 

Change the number of maintainers required to approve a change to 2, for two reasons:

* The number of maintainers has grown sufficiently that seeking a simple majority can be onerous, and
* Consistency with policy on `chef/chef`.