### PR TITLE
First round of license updates - all Chef Server dependencies

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -17,6 +17,9 @@
 name "appbundler"
 default_version "master"
 
+license "Apache 2.0"
+license_file "LICENSE.txt"
+
 source git: "https://github.com/chef/appbundler.git"
 
 dependency "rubygems"

--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -17,6 +17,9 @@
 name "autoconf"
 default_version "2.68"
 
+license "GPL v3"
+license_file "COPYING.EXCEPTION"
+
 dependency "m4"
 
 version "2.69" do

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -17,6 +17,9 @@
 name "berkshelf"
 default_version "master"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/berkshelf/berkshelf.git"
 
 relative_path "berkshelf"

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -21,6 +21,9 @@ end
 name "berkshelf2"
 default_version "2.0.18"
 
+license "Apache 2.0"
+license_file "https://github.com/berkshelf/berkshelf/blob/2-0-stable/LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 dependency "nokogiri"

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -16,6 +16,9 @@
 
 name "bundler"
 
+license "MIT"
+license_file "https://raw.githubusercontent.com/bundler/bundler/master/LICENSE.md"
+
 dependency "rubygems"
 
 build do

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -20,6 +20,9 @@
 name "bzip2"
 default_version "1.0.6"
 
+license "BSD"
+license_file "LICENSE"
+
 dependency "zlib"
 dependency "openssl"
 

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,6 +16,9 @@
 
 name "cacerts"
 
+license "MPL 2.0"
+license_file "https://github.com/bagder/ca-bundle/blob/master/README.md"
+
 default_version "2016.01.20"
 
 version "2016.01.20" do

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -17,6 +17,9 @@
 name "chef-gem"
 default_version "11.12.2"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/chef/blob/master/LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 dependency "libffi"

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -16,6 +16,9 @@
 name "chef"
 default_version "master"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 # For the specific super-special version "local_source", build the source from
 # the local git checkout. This is what you'd want to occur by default if you
 # just ran omnibus build locally.

--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -19,6 +19,11 @@ default_version "master"
 
 source git: "http://git.savannah.gnu.org/r/config.git"
 
+# http://savannah.gnu.org/projects/config
+license "GPL v3 (with exception)"
+license_file "config.guess"
+license_file "config.sub"
+
 relative_path "config_guess-#{version}"
 
 build do

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -17,6 +17,9 @@
 name "cpanminus"
 default_version "1.7004"
 
+license "Artistic"
+license_file "http://dev.perl.org/licenses/artistic.html"
+
 dependency "perl"
 
 version "1.7040" do

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -17,6 +17,9 @@
 name "dep-selector-libgecode"
 default_version "1.0.2"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE.txt"
+
 dependency "rubygems"
 
 build do

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -17,6 +17,9 @@
 name "erlang"
 default_version "R15B03-1"
 
+license "Erlang Public License"
+license_file "EPLICENCE"
+
 dependency "zlib"
 dependency "openssl"
 dependency "ncurses"

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -69,11 +69,15 @@ end
 version '18.1' do
   source md5: 'fa64015fdd133e155b5b19bf90ac8678'
   relative_path 'otp_src_18.1'
+  license "Apache 2.0"
+  license_file "LICENSE.txt"
 end
 
 version '18.2' do
   source md5: 'b336d2a8ccfbe60266f71d102e99f7ed'
   relative_path 'otp_src_18.2'
+  license "Apache 2.0"
+  license_file "LICENSE.txt"
 end
 
 build do

--- a/config/software/gecode.rb
+++ b/config/software/gecode.rb
@@ -17,6 +17,9 @@
 name "gecode"
 default_version "3.7.3"
 
+license "MIT"
+license_file "LICENSE"
+
 version "3.7.3" do
   source md5: "7a5cb9945e0bb48f222992f2106130ac"
 end

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -17,6 +17,10 @@
 name "highline-gem"
 default_version "1.6.21"
 
+license "Ruby"
+license_file "https://github.com/JEG2/highline/blob/master/LICENSE"
+license_file "http://www.ruby-lang.org/en/LICENSE.txt"
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -17,6 +17,9 @@
 name "keepalived"
 default_version "1.2.9"
 
+license "GPL v2"
+license_file "COPYING"
+
 dependency "popt"
 dependency "openssl"
 

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -20,6 +20,9 @@
 name "libarchive"
 default_version "3.1.2"
 
+license "BSD 2-Clause"
+license_file "COPYING"
+
 source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
        md5: 'efad5a503f66329bb9d2f4308b5de98a'
 

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -17,6 +17,9 @@
 name "libedit"
 default_version "20120601-3.0"
 
+license "BSD 3-Clause"
+license_file "COPYING"
+
 dependency "ncurses"
 
 version("20150325-3.1") { source md5: "43cdb5df3061d78b5e9d59109871b4f6" }

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -18,6 +18,9 @@ name "libffi"
 
 default_version "3.2.1"
 
+license "MIT"
+license_file "LICENSE"
+
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?
 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -20,6 +20,9 @@
 name "libiconv"
 default_version "1.14"
 
+license "LGPL"
+license_file "COPYING.LIB"
+
 dependency "patch" if solaris2?
 
 source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -17,6 +17,9 @@
 name "liblzma"
 default_version "5.2.2"
 
+license "Public Domain"
+license_file "COPYING"
+
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
        md5: "7cf6a8544a7dae8e8106fdf7addfa28c"
 

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -17,6 +17,9 @@
 name "libossp-uuid"
 default_version "1.6.2"
 
+license "MIT"
+license_file "README"
+
 version "1.6.2" do
   source md5: "5db0d43a9022a6ebbbc25337ae28942f"
 end

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -17,6 +17,9 @@
 name "libtool"
 default_version "2.4"
 
+license "GPL v2"
+license_file "COPYING"
+
 # NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet
 version("2.4.6") { source md5: "addf44b646ddb4e3919805aa88fa7c5e" }
 version("2.4.2") { source md5: "d2f3b7d4627e69e13514a40e72a24d50" }

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -17,6 +17,9 @@
 name "libxml2"
 default_version "2.9.3"
 
+license "MIT"
+license_file "COPYING"
+
 dependency "zlib"
 dependency "libiconv"
 dependency "liblzma"

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -17,6 +17,9 @@
 name "libxslt"
 default_version "1.1.28"
 
+license "MIT"
+license_file "COPYING"
+
 dependency "libxml2"
 dependency "liblzma"
 dependency "libtool" if solaris2?

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -26,6 +26,9 @@
 name "libyaml-windows"
 default_version "0.1.6"
 
+license "MIT"
+license_file "COPYING"
+
 dependency "ruby-windows"
 
 source url: "https://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -17,6 +17,9 @@
 name "libyaml"
 default_version '0.1.6'
 
+license "MIT"
+license_file "LICENSE"
+
 source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
        md5: '5fe00cda18ca5daeb43762b80c38e06e'
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -17,6 +17,9 @@
 name "logrotate"
 default_version "3.8.5"
 
+license "GPL v2"
+license_file "COPYING"
+
 dependency "popt"
 
 source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -17,6 +17,9 @@
 name "m4"
 default_version "1.4.17"
 
+license "GPL v3"
+license_file "COPYING"
+
 source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
        md5: "a5e9954b1dae036762f7b13673a2cf76"
 

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -17,6 +17,9 @@
 name "make"
 default_version "4.1"
 
+license "libpng"
+license_file "LICENSE"
+
 source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
        md5: "654f9117957e6fa6a1c49a8f08270ec9"
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -17,6 +17,9 @@
 name "makedepend"
 default_version "1.0.5"
 
+license "MIT"
+license_file "COPYING"
+
 source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
        md5: "efb2d7c7e22840947863efaedc175747"
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -17,6 +17,10 @@
 name "ncurses"
 default_version "5.9"
 
+license "MIT"
+license_file "http://invisible-island.net/ncurses/ncurses-license.html"
+license_file "http://invisible-island.net/ncurses/ncurses.faq.html"
+
 dependency "libtool" if aix?
 dependency "patch" if solaris2?
 

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -17,6 +17,9 @@
 name "nodejs"
 default_version "0.10.10"
 
+license "MIT"
+license_file "LICENSE"
+
 dependency "python"
 
 version "0.10.10" do

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -16,6 +16,9 @@
 
 name "nokogiri"
 
+license "MIT"
+license_file "https://github.com/sparklemotion/nokogiri/blob/master/LICENSE.txt"
+
 dependency "ruby"
 
 using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -18,6 +18,9 @@
 name "ohai"
 default_version "master"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/opscode/ohai.git"
 
 relative_path "ohai"

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -17,6 +17,9 @@
 name "omnibus-ctl"
 default_version "0.3.6"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/omnibus-ctl/blob/master/LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -17,6 +17,9 @@
 name "openresty"
 default_version "1.9.7.2"
 
+license "2-Clause BSD"
+license_file "README.markdown"
+
 dependency "pcre"
 dependency "openssl"
 dependency "zlib"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -16,6 +16,9 @@
 
 name "openssl"
 
+license "OpenSSL"
+license_file "LICENSE"
+
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
 dependency "zlib"

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -17,6 +17,9 @@
 name "pcre"
 default_version "8.38"
 
+license "BSD"
+license_file "LICENCE"
+
 dependency "libedit"
 dependency "ncurses"
 

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -16,6 +16,9 @@
 
 name "perl"
 
+license "Artistic"
+license_file "Artistic"
+
 if windows?
   default_version "5.8.8"
   dependency "mingw-get"

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -17,6 +17,11 @@
 name "pg-gem"
 default_version "0.17.1"
 
+license "2-Clause BSD"
+license_file "https://github.com/ged/ruby-pg/blob/master/LICENSE"
+license_file "https://github.com/ged/ruby-pg/blob/master/BSDL"
+
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -17,6 +17,9 @@
 name "pkg-config-lite"
 default_version "0.28-1"
 
+license "GPL v2"
+license_file "COPYING"
+
 version "0.28-1" do
   source md5: "61f05feb6bab0a6bbfab4b6e3b2f44b6"
 end

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -17,6 +17,9 @@
 name "popt"
 default_version "1.16"
 
+license "MIT"
+license_file "COPYING"
+
 source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz",
        md5: "3743beefa3dd6247a73f8f7a32c14c33"
 

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -17,6 +17,9 @@
 name "postgresql"
 default_version "9.2.10"
 
+license "Postgresql"
+license_file "COPYRIGHT"
+
 dependency "zlib"
 dependency "openssl"
 dependency "libedit"

--- a/config/software/preparation.rb
+++ b/config/software/preparation.rb
@@ -18,6 +18,8 @@ name "preparation"
 description "the steps required to preprare the build"
 default_version '1.0.0'
 
+license :project_license
+
 build do
   block do
     touch "#{install_dir}/embedded/lib/.gitkeep"

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -17,6 +17,9 @@
 name "python"
 default_version "2.7.9"
 
+license "Python"
+license_file "LICENSE"
+
 dependency "ncurses"
 dependency "zlib"
 dependency "openssl"

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -17,6 +17,9 @@
 name "rabbitmq"
 default_version "2.7.1"
 
+license "MPL"
+license_file "LICENSE"
+
 dependency "erlang"
 
 version("3.6.0") { source md5: "61a3822f3af0aaa30da7230dccb17067" }

--- a/config/software/rebar.rb
+++ b/config/software/rebar.rb
@@ -22,6 +22,9 @@ name "rebar"
 # Version 2.6.1 includes this fix.
 default_version "93621d0d0c98035f79790ffd24beac94581b0758"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 version "2.6.0"
 
 dependency "erlang"

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -17,6 +17,9 @@
 name "redis-gem"
 default_version "3.1.0"
 
+license "MIT"
+license_file "https://github.com/redis/redis-rb/blob/master/LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -37,6 +37,9 @@ version "2.4.7" do
   source md5: "6afffb6120724183e40f1cac324ac71c"
 end
 
+license "BSD 3-Clause"
+license_file "COPYING"
+
 source url: "http://download.redis.io/releases/redis-#{version}.tar.gz"
 
 relative_path "redis-#{version}"

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -17,6 +17,9 @@
 name "rsync"
 default_version "3.1.1"
 
+license "GPL v3"
+license_file "COPYING"
+
 dependency "popt"
 
 version "3.1.2" do

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -18,6 +18,11 @@ name "ruby-windows"
 
 default_version "2.0.0-p451"
 
+license "2-Clause BSD"
+license_file "BSDL"
+license_file "COPYING"
+license_file "LEGAL"
+
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
 if fips_enabled

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -16,6 +16,11 @@
 
 name "ruby"
 
+license "2-Clause BSD"
+license_file "BSDL"
+license_file "COPYING"
+license_file "LEGAL"
+
 # This is now the main software project for anything ruby related.
 # Even if you want a pre-built version of ruby from ruby-installer, include
 # this project as a dependency. If the version is set to ruby-windows,

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -16,6 +16,9 @@
 
 name "rubygems"
 
+license "MIT"
+license_file "LICENSE.txt"
+
 dependency "ruby"
 
 source git: 'https://github.com/rubygems/rubygems.git' if version

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -17,6 +17,9 @@
 name "runit"
 default_version "2.1.1"
 
+license "New BSD"
+license_file "../package/COPYING"
+
 version "2.1.2" do
   source md5: "6c985fbfe3a34608eb3c53dc719172c4"
 end

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -17,6 +17,9 @@
 name "sequel-gem"
 default_version "4.13.0"
 
+license "MIT"
+license_file "https://github.com/jeremyevans/sequel/blob/master/MIT-LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -19,6 +19,10 @@ default_version "8u74"
 
 raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
 
+license "Oracle Binary Code License"
+license_file "LICENSE"
+license_file "http://java.com/license"
+
 whitelist_file "jre/bin/javaws"
 whitelist_file "jre/bin/policytool"
 whitelist_file "jre/lib"

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -17,6 +17,8 @@
 name "setuptools"
 default_version "0.7.7"
 
+license "Python Software Foundation"
+
 dependency "python"
 
 version "0.9.8" do

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -17,6 +17,9 @@
 name "sqitch"
 default_version "0.973"
 
+license "MIT"
+license_file "https://github.com/theory/sqitch/blob/master/README.md"
+
 dependency "perl"
 dependency "cpanminus"
 

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -27,6 +27,9 @@ end
 
 source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz"
 
+license "MIT"
+license_file "COPYING"
+
 relative_path "util-macros-#{version}"
 
 build do

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -18,6 +18,8 @@ name "version-manifest"
 description "generates a version manifest file"
 default_version "0.0.1"
 
+license "Apache 2.0"
+
 build do
   block do
     File.open("#{install_dir}/version-manifest.txt", "w") do |f|

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -27,6 +27,9 @@ end
 
 source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz"
 
+license "MIT"
+license_file "COPYING"
+
 relative_path "xproto-#{version}"
 
 build do

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -26,6 +26,9 @@ end
 
 source url: "http://iweb.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
 
+license "Zlib"
+license_file "README"
+
 relative_path "zlib-#{version}"
 
 build do

--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
-  s.add_dependency "omnibus", ">= 5.1.0"
+  s.add_dependency "omnibus", ">= 5.2.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This PR works with https://github.com/chef/omnibus/pull/635 and adds license information for Chef Server's dependencies. You can see an example output at https://gist.github.com/sersut/e1012c38e55a3890232b. For a detailed description of this feature please see https://github.com/chef/omnibus/pull/635.

Because this PR makes omnibus-software use a new DSL method that is not available in the older versions of omnibus we will need to make a new omnibus release and bump the minimum dependency in our gemspec. The exact same situation that we faced in https://github.com/chef/omnibus-software/pull/614. I think we really need to move this project to https://github.com/chef/omnibus.

/cc: @chef/omnibus-maintainers, @jamesc 