### PR TITLE
We bring in libintl sometimes with this, that's bad because it usuall…

### DIFF
--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -26,6 +26,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   command "./configure" \
+          " --disable-nls" \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env


### PR DESCRIPTION
…y ends up messing with libiconv

@chef/omnibus-maintainers @chef/engineering-services 