### PR TITLE
Use omnibus certified license names.

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -17,7 +17,7 @@
 name "appbundler"
 default_version "master"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE.txt"
 
 source git: "https://github.com/chef/appbundler.git"

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -17,7 +17,7 @@
 name "berkshelf"
 default_version "master"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 source git: "https://github.com/berkshelf/berkshelf.git"

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -21,7 +21,7 @@ end
 name "berkshelf2"
 default_version "2.0.18"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/berkshelf/berkshelf/blob/2-0-stable/LICENSE"
 
 dependency "ruby"

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -20,7 +20,7 @@
 name "bzip2"
 default_version "1.0.6"
 
-license "BSD"
+license "BSD-2-Clause"
 license_file "LICENSE"
 
 dependency "zlib"

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -16,7 +16,7 @@
 
 name "cacerts"
 
-license "MPL 2.0"
+license "MPL-2.0"
 license_file "https://github.com/bagder/ca-bundle/blob/master/README.md"
 
 default_version "2016.01.20"

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -17,7 +17,7 @@
 name "chef-gem"
 default_version "11.12.2"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/chef/blob/master/LICENSE"
 
 dependency "ruby"

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -16,7 +16,7 @@
 name "chef"
 default_version "master"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 # For the specific super-special version "local_source", build the source from

--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -20,7 +20,7 @@ default_version "master"
 source git: "http://git.savannah.gnu.org/r/config.git"
 
 # http://savannah.gnu.org/projects/config
-license "GPL v3 (with exception)"
+license "GPL-v3 (with exception)"
 license_file "config.guess"
 license_file "config.sub"
 

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -17,7 +17,7 @@
 name "cpanminus"
 default_version "1.7004"
 
-license "Artistic"
+license "Artistic-2.0"
 license_file "http://dev.perl.org/licenses/artistic.html"
 
 dependency "perl"

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -17,7 +17,7 @@
 name "dep-selector-libgecode"
 default_version "1.0.2"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE.txt"
 
 dependency "rubygems"

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -17,7 +17,7 @@
 name "erlang"
 default_version "R15B03-1"
 
-license "Erlang Public License"
+license "Erlang-Public"
 license_file "EPLICENCE"
 
 dependency "zlib"
@@ -69,14 +69,14 @@ end
 version '18.1' do
   source md5: 'fa64015fdd133e155b5b19bf90ac8678'
   relative_path 'otp_src_18.1'
-  license "Apache 2.0"
+  license "Apache-2.0"
   license_file "LICENSE.txt"
 end
 
 version '18.2' do
   source md5: 'b336d2a8ccfbe60266f71d102e99f7ed'
   relative_path 'otp_src_18.2'
-  license "Apache 2.0"
+  license "Apache-2.0"
   license_file "LICENSE.txt"
 end
 

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -17,7 +17,7 @@
 name "keepalived"
 default_version "1.2.9"
 
-license "GPL v2"
+license "GPL-2.0"
 license_file "COPYING"
 
 dependency "popt"

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -17,7 +17,7 @@
 name "libedit"
 default_version "20120601-3.0"
 
-license "BSD 3-Clause"
+license "BSD-3-Clause"
 license_file "COPYING"
 
 dependency "ncurses"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -20,7 +20,7 @@
 name "libiconv"
 default_version "1.14"
 
-license "LGPL"
+license "LGPL-2.1"
 license_file "COPYING.LIB"
 
 dependency "patch" if solaris2?

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -17,7 +17,7 @@
 name "liblzma"
 default_version "5.2.2"
 
-license "Public Domain"
+license "Public-Domain"
 license_file "COPYING"
 
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -17,7 +17,7 @@
 name "libtool"
 default_version "2.4"
 
-license "GPL v2"
+license "GPL-2.0"
 license_file "COPYING"
 
 # NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -17,7 +17,7 @@
 name "logrotate"
 default_version "3.8.5"
 
-license "GPL v2"
+license "GPL-2.0"
 license_file "COPYING"
 
 dependency "popt"

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -18,7 +18,7 @@
 name "ohai"
 default_version "master"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 source git: "https://github.com/opscode/ohai.git"

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -17,7 +17,7 @@
 name "omnibus-ctl"
 default_version "0.3.6"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/omnibus-ctl/blob/master/LICENSE"
 
 dependency "ruby"

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -17,7 +17,7 @@
 name "openresty"
 default_version "1.9.7.2"
 
-license "2-Clause BSD"
+license "BSD-2-Clause"
 license_file "README.markdown"
 
 dependency "pcre"

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -17,7 +17,7 @@
 name "pcre"
 default_version "8.38"
 
-license "BSD"
+license "BSD-2-Clause"
 license_file "LICENCE"
 
 dependency "libedit"

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -16,7 +16,7 @@
 
 name "perl"
 
-license "Artistic"
+license "Artistic-2.0"
 license_file "Artistic"
 
 if windows?

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -17,7 +17,7 @@
 name "pg-gem"
 default_version "0.17.1"
 
-license "2-Clause BSD"
+license "BSD-2-Clause"
 license_file "https://github.com/ged/ruby-pg/blob/master/LICENSE"
 license_file "https://github.com/ged/ruby-pg/blob/master/BSDL"
 

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -17,7 +17,7 @@
 name "pkg-config-lite"
 default_version "0.28-1"
 
-license "GPL v2"
+license "GPL-2.0"
 license_file "COPYING"
 
 version "0.28-1" do

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -17,7 +17,7 @@
 name "postgresql"
 default_version "9.2.10"
 
-license "Postgresql"
+license "PostgreSQL"
 license_file "COPYRIGHT"
 
 dependency "zlib"

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -17,7 +17,7 @@
 name "python"
 default_version "2.7.9"
 
-license "Python"
+license "Python-2.0"
 license_file "LICENSE"
 
 dependency "ncurses"

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -17,7 +17,7 @@
 name "rabbitmq"
 default_version "2.7.1"
 
-license "MPL"
+license "MPL-2.0"
 license_file "LICENSE"
 
 dependency "erlang"

--- a/config/software/rebar.rb
+++ b/config/software/rebar.rb
@@ -22,7 +22,7 @@ name "rebar"
 # Version 2.6.1 includes this fix.
 default_version "93621d0d0c98035f79790ffd24beac94581b0758"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 version "2.6.0"

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -37,7 +37,7 @@ version "2.4.7" do
   source md5: "6afffb6120724183e40f1cac324ac71c"
 end
 
-license "BSD 3-Clause"
+license "BSD-3-Clause"
 license_file "COPYING"
 
 source url: "http://download.redis.io/releases/redis-#{version}.tar.gz"

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -18,7 +18,7 @@ name "ruby-windows"
 
 default_version "2.0.0-p451"
 
-license "2-Clause BSD"
+license "BSD-2-Clause"
 license_file "BSDL"
 license_file "COPYING"
 license_file "LEGAL"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -16,7 +16,7 @@
 
 name "ruby"
 
-license "2-Clause BSD"
+license "BSD-2-Clause"
 license_file "BSDL"
 license_file "COPYING"
 license_file "LEGAL"

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -17,7 +17,7 @@
 name "runit"
 default_version "2.1.1"
 
-license "New BSD"
+license "BSD-3-Clause"
 license_file "../package/COPYING"
 
 version "2.1.2" do

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -19,7 +19,7 @@ default_version "8u74"
 
 raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
 
-license "Oracle Binary Code License"
+license "Oracle-Binary"
 license_file "LICENSE"
 license_file "http://java.com/license"
 

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -18,7 +18,7 @@ name "version-manifest"
 description "generates a version manifest file"
 default_version "0.0.1"
 
-license "Apache 2.0"
+license :project_license
 
 build do
   block do


### PR DESCRIPTION
This PR fixes the warnings created after some standardization in omnibus licensing checks. See https://github.com/chef/omnibus/pull/638 for more information.

/cc: @chef/omnibus-maintainers, @jamesc 