### PR TITLE
License definitions for Analytics dependencies

### DIFF
--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -17,7 +17,8 @@
 name "autoconf"
 default_version "2.68"
 
-license "GPL v3"
+license "GPL-3.0"
+license_file "COPYING"
 license_file "COPYING.EXCEPTION"
 
 dependency "m4"

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -19,6 +19,9 @@ default_version "1.11.2"
 
 dependency "autoconf"
 
+license "GPL-2.0"
+license_file "COPYING"
+
 version "1.15" do
   source md5: "716946a105ca228ab545fc37a70df3a3"
 end

--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -20,7 +20,7 @@ default_version "master"
 source git: "http://git.savannah.gnu.org/r/config.git"
 
 # http://savannah.gnu.org/projects/config
-license "GPL-v3 (with exception)"
+license "GPL-3.0 (with exception)"
 license_file "config.guess"
 license_file "config.sub"
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -20,6 +20,9 @@ default_version "7.47.1"
 dependency "zlib"
 dependency "openssl"
 
+license "MIT"
+license_file "COPYING"
+
 version "7.47.1" do
   source md5: "3f9d1be7bf33ca4b8c8602820525302b"
 end

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -20,7 +20,7 @@
 name "libarchive"
 default_version "3.1.2"
 
-license "BSD 2-Clause"
+license "BSD-2-Clause"
 license_file "COPYING"
 
 source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -17,7 +17,7 @@
 name "m4"
 default_version "1.4.17"
 
-license "GPL v3"
+license "GPL-3.0"
 license_file "COPYING"
 
 source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",

--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -20,6 +20,9 @@ default_version "1.8.1"
 dependency "pcre"
 dependency "openssl"
 
+license "BSD-2-Clause"
+license_file "LICENSE"
+
 source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
 
 version("1.9.1") { source md5: "fc054d51effa7c80a2e143bc4e2ae6a7" }

--- a/config/software/perl_pg_driver.rb
+++ b/config/software/perl_pg_driver.rb
@@ -21,6 +21,10 @@ dependency "perl"
 dependency "cpanminus"
 dependency "postgresql"
 
+license "Artistic"
+license_file "README"
+license_file "LICENSES/artistic.txt"
+
 version "3.5.3" do
   source md5: "21cdf31a8d1f77466920375aa766c164"
 end


### PR DESCRIPTION
Added license definitions (and fixed some old-style ones) for all common dependencies of Chef analytics

/cc: @chef/omnibus-maintainers, @sersut 