### PR TITLE
Build dep-selector-libgecode with `bfd_flags` on Windows

### DIFF
--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -23,7 +23,7 @@ license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE
 dependency "rubygems"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
+  env = with_standard_compiler_flags(with_embedded_path, bfd_flags: true)
 
   # On some RHEL-based systems, the default GCC that's installed is 4.1. We
   # need to use 4.4, which is provided by the gcc44 and gcc44-c++ packages.

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -36,6 +36,7 @@ build do
 
   # Ruby DevKit ships with BSD Tar
   env["PROG_TAR"] = "bsdtar" if windows?
+  env["ARFLAGS"] = "rv #{env["ARFLAGS"]}" if env["ARFLAGS"]
 
   gem "install dep-selector-libgecode" \
       " --version '#{version}'" \


### PR DESCRIPTION
Now that we're using compiled ruby, we want to pass the appropriate architecture flags to `dep-selector-libgecode`. This PR adds that, and allows `dep-selector-libgecode` to be pointed at git.