### PR TITLE
use rb-readline on unix as well

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -45,7 +45,6 @@ else
 unless windows?
   dependency "patch" if solaris2?
   dependency "ncurses"
-  dependency "libedit"
 end
 
 dependency "zlib"
@@ -186,14 +185,13 @@ build do
      patch source: 'ruby-fix-reserve-stack-segfault.patch', plevel: 1, env: patch_env
   end
 
-  configure_command = ["--with-out-ext=dbm",
+  configure_command = ["--with-out-ext=dbm,readline",
                        "--enable-shared",
                        "--disable-install-doc",
                        "--without-gmp",
                        "--without-gdbm",
                        "--disable-dtrace"]
   configure_command << "--with-ext=psych" if version.satisfies?('< 2.3')
-  configure_command << "--enable-libedit" unless windows?
   configure_command << "--with-bundled-md5" if fips_enabled
 
   if aix?


### PR DESCRIPTION
@chef/omnibus-maintainers this is necessary to build ruby-2.2.4, makes unix and windows more similar, and reduces our native library/gem usage, and removes the whole libreadline/libedit mess.

@stevendanna this may allow nuking the libedit software definition entirely.