### PR TITLE
append chef gem constraint to test-kitchen gem file

### DIFF
--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -27,6 +27,14 @@ dependency "nokogiri"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  block do
+    # make sure test-kitchen build honors chef constraints
+    chef_gem_line = "gem \"chef\", path: \"../../chef/chef\""
+    unless IO.readlines("#{project_dir}/Gemfile")[-1] =~ /#{chef_gem_line}/
+      open("#{project_dir}/Gemfile", 'a') { |f| f.puts chef_gem_line }
+    end
+  end
+
   bundle "install --without guard", env: env
   bundle "exec rake build", env: env
 


### PR DESCRIPTION
chef-dk builds are currently broken because `net-ssh` released 3.1.0. `specinfra` also required by `chef` constrains `net-ssh` to `<3.1`. Because `test-kitchen` has no `specinfra` dependency and also no `chef` dependency declared, it picks up `net-ssh` 3.1.0 and sets that pin in its binstub. This results in a gem conflict later when kitchen loads plugins with a chef dependency.

Test-Kitchen intentionally omits chef from its Gemfile to keep itself CM agnostic. This appends a chef constraint to its Gemfile at build time to ensure that any transitive dependencies in chef are honored.