### PR TITLE
revert the TK Gemfile changes after build

### DIFF
--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -26,12 +26,16 @@ dependency "nokogiri"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  gemfile = "#{project_dir}/Gemfile"
+  tmp_gemfile = "#{gemfile}_old"
 
   block do
     # make sure test-kitchen build honors chef constraints
+    require 'fileutils'
+    FileUtils.cp(gemfile, tmp_gemfile)
     chef_gem_line = "gem \"chef\", path: \"../../chef/chef\""
-    unless IO.readlines("#{project_dir}/Gemfile")[-1] =~ /#{chef_gem_line}/
-      open("#{project_dir}/Gemfile", 'a') { |f| f.puts chef_gem_line }
+    unless IO.readlines(gemfile)[-1] =~ /#{chef_gem_line}/
+      open(gemfile, 'a') { |f| f.puts chef_gem_line }
     end
   end
 
@@ -40,4 +44,9 @@ build do
 
   gem "install pkg/test-kitchen-*.gem" \
       " --no-ri --no-rdoc", env: env
+
+  block do
+    File.delete(gemfile)
+    File.rename(tmp_gemfile, gemfile)
+  end
 end


### PR DESCRIPTION
The chenges in #634 fixed the `net-ssh` version pinned to kitchen but verify blew up trying to bundle install because the added chef gem source was no longer present. This reverts the gemfile change after build.

I have run a build with this change and a `chef verify` on the installed build passed.