### PR TITLE
Updated library files for Solaris 11 support

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -50,7 +50,7 @@ build do
 
   configure(*configure_command, env: env)
 
-  if solaris2?
+  if solaris_10?
     # run old make :(
     make env: env, bin: "/usr/ccs/bin/make"
     make "install", env: env, bin: "/usr/ccs/bin/make"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -23,7 +23,7 @@ default_version "1.14"
 license "LGPL-2.1"
 license_file "COPYING.LIB"
 
-dependency "patch" if solaris2?
+dependency "patch" if solaris_10?
 
 source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        md5: 'e34509b1623cec449dfeb73d7ce9c6c6'

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -43,7 +43,7 @@ build do
   ]
 
   # solaris 10 ipv6 support is broken due to no inet_ntop() in -lnsl
-  configure_command << "--enable-ipv6=no" if solaris2?
+  configure_command << "--enable-ipv6=no" if solaris_10?
 
   configure(*configure_command, env: env)
 

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -22,8 +22,8 @@ license_file "COPYING"
 
 dependency "libxml2"
 dependency "liblzma"
-dependency "libtool" if solaris2?
-dependency "patch" if solaris2?
+dependency "libtool" if solaris_10?
+dependency "patch" if solaris_10?
 
 version "1.1.28" do
   source md5: "9667bf6f9310b957254fdcf6596600b7"
@@ -41,7 +41,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
 
   patch source: "libxslt-cve-2015-7995.patch", env: env
-  patch source: "libxslt-solaris-configure.patch", env: env if solaris?
+  patch source: "libxslt-solaris-configure.patch", env: env if solaris2?
   patch source: "libxslt-mingw32.patch", env: env if windows?
 
   configure_commands = [

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -41,7 +41,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path({}, msys: true), bfd_flags: true)
 
   patch source: "libxslt-cve-2015-7995.patch", env: env
-  patch source: "libxslt-solaris-configure.patch", env: env if solaris2?
+  patch source: "libxslt-solaris-configure.patch", env: env if solaris?
   patch source: "libxslt-mingw32.patch", env: env if windows?
 
   configure_commands = [

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -32,7 +32,7 @@ dependency "pkg-config-lite"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if solaris2?
+  if solaris_10?
     env['PKG_CONFIG'] = "#{install_dir}/embedded/bin/pkg-config"
   end
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -22,7 +22,7 @@ license_file "http://invisible-island.net/ncurses/ncurses-license.html"
 license_file "http://invisible-island.net/ncurses/ncurses.faq.html"
 
 dependency "libtool" if aix?
-dependency "patch" if solaris2?
+dependency "patch" if solaris_10?
 
 version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
 version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
@@ -130,7 +130,7 @@ build do
 
   # only Solaris 10 sh has a problem with
   # parens enclosed case statement conditions the configure script
-  configure_command.unshift "bash" if solaris2?
+  configure_command.unshift "bash" if solaris_10?
 
   command configure_command.join(" "), env: env
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) 
 dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
-dependency "patch" if solaris2?
+dependency "patch" if solaris?
 dependency "openssl-fips" if fips_enabled
 
 default_version "1.0.1s"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) 
 dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
-dependency "patch" if solaris?
+dependency "patch" if solaris_10?
 dependency "openssl-fips" if fips_enabled
 
 default_version "1.0.1s"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -88,11 +88,13 @@ build do
       "./Configure darwin64-x86_64-cc"
     elsif smartos?
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
-    elsif solaris2?
+    elsif solaris_10?
       # This should not require a /bin/sh, but without it we get
       # Errno::ENOEXEC: Exec format error
       platform = sparc? ? "solaris-sparcv9-gcc" : "solaris-x86-gcc"
       "/bin/sh ./Configure #{platform}"
+    elsif solaris_11?
+      "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif windows?
       platform = windows_arch_i386? ? "mingw" : "mingw64"
       "perl.exe ./Configure #{platform}"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -29,9 +29,8 @@ default_version "2.1.8"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
-dependency "patch" if solaris2?
+dependency "patch" if solaris_10?
 dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
-
 dependency "zlib"
 dependency "openssl"
 dependency "libffi"
@@ -102,7 +101,7 @@ elsif aix?
   env['SOLIBS'] = "-lm -lc"
   # need to use GNU m4, default m4 doesn't work
   env['M4'] = "/opt/freeware/bin/m4"
-elsif solaris2?
+elsif solaris_10?
   if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
     env['CFLAGS'] << " -std=c99 -O0 -g -pipe -mcpu=v9"
@@ -126,9 +125,9 @@ build do
   patch_env = env.dup
   patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
 
-  if solaris2? && version.satisfies?('>= 2.1')
+  if solaris_10? && version.satisfies?('>= 2.1')
     patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
-  elsif solaris2? && version =~ /^1.9/
+  elsif solaris_10? && version =~ /^1.9/
     patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1, env: patch_env
   end
 
@@ -172,6 +171,7 @@ build do
                        "--disable-install-doc",
                        "--without-gmp",
                        "--without-gdbm",
+                       "--without-tk",
                        "--disable-dtrace"]
   configure_command << "--with-ext=psych" if version.satisfies?('< 2.3')
   configure_command << "--with-bundled-md5" if fips_enabled

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -29,10 +29,8 @@ default_version "2.1.8"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
-unless windows?
-  dependency "patch" if solaris2?
-  dependency "ncurses"
-end
+dependency "patch" if solaris2?
+dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 
 dependency "zlib"
 dependency "openssl"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -29,6 +29,7 @@ default_version "2.1.8"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
+
 dependency "patch" if solaris_10?
 dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 dependency "zlib"

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -40,13 +40,14 @@ build do
   end
 
   bundle "install --without guard", env: env
-  bundle "exec rake build", env: env
-
-  gem "install pkg/test-kitchen-*.gem" \
-      " --no-ri --no-rdoc", env: env
 
   block do
     File.delete(gemfile)
     File.rename(tmp_gemfile, gemfile)
   end
+
+  bundle "exec rake build", env: env
+
+  gem "install pkg/test-kitchen-*.gem" \
+      " --no-ri --no-rdoc", env: env
 end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -66,7 +66,7 @@ build do
     env = with_standard_compiler_flags
     if solaris_10?
       # For some reason zlib needs this flag on solaris (cargocult warning?)
-      env['CFLAGS'] << " -DNO_VIZ" if solaris2?
+      env['CFLAGS'] << " -DNO_VIZ"
     elsif freebsd?
       # FreeBSD 10+ gets cranky if zlib is not compiled in a
       # position-independent way.

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -64,7 +64,7 @@ build do
     # configure script cannot handle.
     # TODO: Do other OSes need this?  Is this strictly a mac thing?
     env = with_standard_compiler_flags
-    if solaris?
+    if solaris_10?
       # For some reason zlib needs this flag on solaris (cargocult warning?)
       env['CFLAGS'] << " -DNO_VIZ" if solaris2?
     elsif freebsd?


### PR DESCRIPTION
### Description

Previously applied Solaris patches and compilation flags are not required by Solaris11, so updated the libraries to enable Solaris 11 support
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

