### PR TITLE
move gemfile revert before the gem build

### DIFF
--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -40,13 +40,14 @@ build do
   end
 
   bundle "install --without guard", env: env
-  bundle "exec rake build", env: env
-
-  gem "install pkg/test-kitchen-*.gem" \
-      " --no-ri --no-rdoc", env: env
 
   block do
     File.delete(gemfile)
     File.rename(tmp_gemfile, gemfile)
   end
+
+  bundle "exec rake build", env: env
+
+  gem "install pkg/test-kitchen-*.gem" \
+      " --no-ri --no-rdoc", env: env
 end


### PR DESCRIPTION
I had tested this on windows before which turns out to be the only tester is passes. Looked on a linux builder that failed an ad hoc build and saw that the added gem reference was still in the Gemfile. The reason is that I was deleting it after the gem had been built. This moves the deletion to just before the build.

I have another ad-hoc build running this to validate.