### PR TITLE
Pinning net-ssh 3.0 temporarily while we try and get the ChefDK test matrix green

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -38,6 +38,16 @@ dependency "dep-selector-libgecode"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  gemfile = "#{project_dir}/Gemfile"
+
+  block do
+    require 'fileutils'
+    if File.exist?(gemfile)
+      open(gemfile, 'a') { |f| f.puts "gem 'net-ssh', '= 3.0.2'" }
+    end
+  end
+
+  bundle "lock --update net-ssh", env: env
   bundle "install" \
          " --jobs #{workers}" \
          " --without guard", env: env

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -26,6 +26,7 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --with test integration --without tools maintenance", env: env
 
   gem "build inspec.gemspec", env: env

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -28,6 +28,7 @@ dependency "inspec"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --without development guard test", env: env
 
   gem "build kitchen-inspec.gemspec", env: env

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -27,6 +27,7 @@ dependency "test-kitchen"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --without development guard test", env: env
 
   gem "build kitchen-vagrant.gemspec", env: env


### PR DESCRIPTION
### Description

ChefDK tests are currently failing because Specinfra is pinned to a different version of net-ssh than all our other dependencies.  This causes an error trying to run `rspec` on a newly generated cookbook:

```
/opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2275:in `check_version_conflict': can't activate net-ssh-3.1.1, already activated net-ssh-3.0.2 (Gem::LoadError)
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:1404:in `activate'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems.rb:214:in `block in finish_resolve'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems.rb:213:in `each'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems.rb:213:in `finish_resolve'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/rdoc.rb:15:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/uninstaller.rb:11:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.7/lib/chef/provider/package/rubygems.rb:37:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.7/lib/chef/providers.rb:76:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chefspec-4.6.0/lib/chefspec/extensions/chef/client.rb:7:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chefspec-4.6.0/lib/chefspec.rb:46:in `require_relative'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chefspec-4.6.0/lib/chefspec.rb:46:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:127:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /private/tmp/d20160330-95013-ztyymc/spec/spec_helper.rb:1:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /private/tmp/d20160330-95013-ztyymc/spec/foo_spec.rb:1:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `load'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `block in load_spec_files'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `each'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `load_spec_files'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:106:in `setup'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:92:in `run'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
	from /opt/chefdk/embedded/bin/rspec:22:in `load'
	from /opt/chefdk/embedded/bin/rspec:22:in `<main>'
```

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.