### PR TITLE
Reverting https://github.com/chef/omnibus-software/pull/640

### DIFF
--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -38,16 +38,6 @@ dependency "dep-selector-libgecode"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gemfile = "#{project_dir}/Gemfile"
-
-  block do
-    require 'fileutils'
-    if File.exist?(gemfile)
-      open(gemfile, 'a') { |f| f.puts "gem 'net-ssh', '= 3.0.2'" }
-    end
-  end
-
-  bundle "lock --update net-ssh", env: env
   bundle "install" \
          " --jobs #{workers}" \
          " --without guard", env: env

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -26,7 +26,6 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --with test integration --without tools maintenance", env: env
 
   gem "build inspec.gemspec", env: env

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -28,7 +28,6 @@ dependency "inspec"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --without development guard test", env: env
 
   gem "build kitchen-inspec.gemspec", env: env

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -27,7 +27,6 @@ dependency "test-kitchen"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "inject net-ssh 3.0.2", env: env
   bundle "install --without development guard test", env: env
 
   gem "build kitchen-vagrant.gemspec", env: env


### PR DESCRIPTION
### Description

https://github.com/mizzy/specinfra/pull/538 was merged and released so we no longer need to take steps to pin net-ssh to 3.0.2.  The omnibus should be using 3.1.1 everywhere

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

because Specinfra was released with an update allowing net-ssh up to 3.1