### PR TITLE
Test Kitchen missing deps during chef verify

### DIFF
--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -39,7 +39,7 @@ build do
     end
   end
 
-  bundle "install --without guard", env: env
+  bundle "install --without guard integration", env: env
 
   block do
     File.delete(gemfile)


### PR DESCRIPTION
### Description

We need to start including the guard dependencies, otherwise the chef verify tests which run 'bundle exec rake' on TK fail with missing guard dependencies

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/resolver.rb:354:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'guard-minitest' in any of the gem sources listed in your Gemfile or available on this machine. (Bundler::GemNotFound)
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/resolver.rb:330:in `each'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/resolver.rb:330:in `verify_gemfile_dependencies_are_found!'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/resolver.rb:199:in `start'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/resolver.rb:183:in `resolve'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:198:in `resolve'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:137:in `specs'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:182:in `specs_for'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/definition.rb:171:in `requested_specs'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/environment.rb:18:in `requested_specs'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:13:in `setup'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler.rb:92:in `setup'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/bundler-1.11.2/lib/bundler/setup.rb:18:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```

I don't understand why this _just_ started failing, unless something else was bringing in these missing guard dependencies transitively.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.