### PR TITLE
add license metadata to satisfy chef-client builds

### DIFF
--- a/config/software/clean-static-libs.rb
+++ b/config/software/clean-static-libs.rb
@@ -18,6 +18,8 @@ name "clean-static-libs"
 description "cleanup un-needed static libraries from the build"
 default_version '1.0.0'
 
+license :project_license
+
 build do
   # Remove static object files for all platforms
   # except AIX which uses them at runtime.

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -20,6 +20,9 @@
 # tools can be used with https URLs out of the box.
 name "openssl-customization"
 
+license "OpenSSL"
+license_file "https://www.openssl.org/source/license.html"
+
 source path: "#{project.files_path}/#{name}"
 
 dependency "ruby"

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -17,6 +17,9 @@
 name "openssl-fips"
 default_version "2.0.10"
 
+license "OpenSSL"
+license_file "https://www.openssl.org/source/license.html"
+
 version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
 version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
 version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }

--- a/config/software/pry.rb
+++ b/config/software/pry.rb
@@ -16,6 +16,9 @@
 
 name "pry"
 
+license "MIT"
+license_file "LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/rb-readline.rb
+++ b/config/software/rb-readline.rb
@@ -17,6 +17,9 @@
 name "rb-readline"
 default_version "master"
 
+license "BSD-3-Clause"
+license_file "LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -18,6 +18,9 @@
 name "ruby-windows-devkit-bash"
 default_version "3.1.23-4-msys-1.0.18"
 
+license "GPL-3.0"
+license_file "http://www.gnu.org/licenses/gpl-3.0.txt"
+
 dependency "ruby-windows-devkit"
 source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
        md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -17,6 +17,9 @@
 name "ruby-windows-devkit"
 default_version "4.7.2-20130224"
 
+license "BSD-3-Clause"
+license_file "LICENSE.txt"
+
 if windows_arch_i386?
   version "4.5.2-20111229-1559" do
     source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",

--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -23,6 +23,8 @@ name "shebang-cleanup"
 
 default_version "0.0.2"
 
+license :project_license
+
 build do
   if windows?
     block "Update batch files to point at embedded ruby" do


### PR DESCRIPTION
### Description

Add license metadata to software defs that raise licensing warnings during chef-client builds.

cross-checked the ubuntu and windows builds warnings.

@sersut  @chef/engineering-services 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

