### PR TITLE
update license metadata for chefdk builds

### DIFF
--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -17,6 +17,9 @@
 name "chef-provisioning-aws"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-provisioning-aws.git"
 
 dependency "ruby"

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -17,6 +17,9 @@
 name "chef-provisioning-azure"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-provisioning-azure.git"
 
 dependency "ruby"

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -17,6 +17,9 @@
 name "chef-provisioning-fog"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-provisioning-fog.git"
 
 dependency "ruby"

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -17,6 +17,9 @@
 name "chef-provisioning-vagrant"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-provisioning-vagrant.git"
 
 dependency "ruby"

--- a/config/software/chef-provisioning.rb
+++ b/config/software/chef-provisioning.rb
@@ -17,6 +17,9 @@
 name "chef-provisioning"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-provisioning.git"
 
 dependency "ruby"

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -17,6 +17,9 @@
 name "chef-vault"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/chef-vault.git"
 
 relative_path "chef-vault"

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -17,6 +17,9 @@
 name "chefspec"
 default_version "master"
 
+license "MIT"
+license_file "LICENSE"
+
 source git: "https://github.com/sethvargo/chefspec.git"
 
 dependency "ruby"

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -17,6 +17,9 @@
 name "fauxhai"
 default_version "master"
 
+license "MIT"
+license_file "LICENSE"
+
 source git: "https://github.com/customink/fauxhai.git"
 
 dependency "ruby"

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -19,6 +19,9 @@ default_version "v6.0.0"
 
 source git: "https://github.com/acrmp/foodcritic.git"
 
+license "MIT"
+license_file "LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -17,6 +17,9 @@
 name "inspec"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/inspec.git"
 
 dependency "ruby"

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -17,6 +17,9 @@
 name "kitchen-inspec"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/kitchen-inspec.git"
 
 dependency "ruby"

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -17,6 +17,9 @@
 name "kitchen-vagrant"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/test-kitchen/kitchen-vagrant.git"
 
 dependency "ruby"

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -17,6 +17,9 @@
 name "knife-spork"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/jonlives/knife-spork.git"
 
 dependency "ruby"

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -17,6 +17,9 @@
 name "knife-windows"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/knife-windows.git"
 
 dependency "ruby"

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -17,6 +17,9 @@
 name "rubocop"
 default_version "master"
 
+license "MIT"
+license_file "LICENSE.txt"
+
 source git: "https://github.com/bbatsov/rubocop.git"
 
 dependency "ruby"

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -18,6 +18,7 @@ name "rubygems"
 
 license "MIT"
 license_file "LICENSE.txt"
+license_file "MIT.txt"
 
 dependency "ruby"
 

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -18,6 +18,9 @@ name "test-kitchen"
 default_version "master"
 relative_path "test-kitchen"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/test-kitchen/test-kitchen.git"
 
 dependency "ruby"

--- a/config/software/winrm-fs.rb
+++ b/config/software/winrm-fs.rb
@@ -17,6 +17,9 @@
 name "winrm-fs"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/WinRb/winrm-fs.git"
 
 dependency "ruby"


### PR DESCRIPTION
### Description

Add license metadata to satisfy chefdk build warnings for all platforms.

#### ISSUES
1. ~~`rubygems` - Not sure how to handle this warning.  I don't understand why the LICENSE.txt isn't being found.
`License file '/var/cache/omnibus/src/rubygems/LICENSE.txt' does not exist for software 'rubygems'.`~~ [WONT FIX]
2. ~~[knife-spork license file](https://github.com/jonlives/knife-spork/blob/master/LICENSE) is not clear as to which license it's really using.~~ [FIXED]

@chef/engineering-services @sersut 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

