### PR TITLE
Add unix binutils def, rename windows binutils def

### DIFF
--- a/config/software/binutils-windows.rb
+++ b/config/software/binutils-windows.rb
@@ -19,6 +19,10 @@ default_version "2.25-tdm64-1"
 
 dependency "msys-base"
 
+license "GPL-3.0"
+license_file "COPYING"
+license_file "COPYING.LIB"
+
 source url: "http://iweb.dl.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-#{version}.tar.lzma"
 version("2.25-tdm64-1") { source sha256: "4722bb7b4d46cef714234109e25e5d1cfd29f4e53365b6d615c8a00735f60e40" }
 

--- a/config/software/binutils-windows.rb
+++ b/config/software/binutils-windows.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-name "binutils"
+name "binutils-windows"
 default_version "2.25-tdm64-1"
 
 dependency "msys-base"

--- a/config/software/binutils.rb
+++ b/config/software/binutils.rb
@@ -1,0 +1,44 @@
+#
+# Copyright 2012-2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "binutils"
+default_version "2.26"
+
+version("2.26") { source md5: "9615feddaeedc214d1a1ecd77b6697449c952eab69d79ab2125ea050e944bcc1" }
+
+license "GPL-3.0"
+license_file "COPYING"
+license_file "COPYING.LIB"
+
+source url: "https://ftp.gnu.org/gnu/binutils/binutils-#{version}.tar.gz"
+
+dependency "config_guess"
+
+relative_path "binutils-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  update_config_guess
+
+  configure_command = ["./configure",
+                     "--prefix=#{install_dir}/embedded"]
+
+  command configure_command.join(" "), env: env
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+end


### PR DESCRIPTION
### Description

This is a proposed solution for the binutils def. Ideally we'd build binutils from source on Windows, but I don't know what work is involved with that. This will allow binutils to work as specified on Unix platforms. We have historically called these Windows specific things `-windows`.  Thoughts?

@ksubrama @chef/engineering-services 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

