### PR TITLE
Remove tcltk from git def

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -80,6 +80,7 @@ build do
     NO_INSTALL_HARDLINKS: "YesPlease",
     NO_PERL: "YesPlease",
     NO_PYTHON: "YesPlease",
+    NO_TCLTK: "YesPlease",
   }
 
   if freebsd?


### PR DESCRIPTION
### Description

Removes tcltk build components that aren't needed. Verifying on build: http://manhattan.ci.chef.co/job/angry-omnibus-toolchain-build/58/

@chef/engineering-services 
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
