### PR TITLE
Update expat and git software definitions license information.

### DIFF
--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -20,6 +20,9 @@ default_version "2.1.0"
 relative_path "expat-#{version}"
 dependency "config_guess"
 
+license "MIT"
+license_file "COPYING"
+
 source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
        md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
 

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -17,6 +17,9 @@
 name "git"
 default_version "2.7.4"
 
+license "LGPL-2.1"
+license_file "LGPL-2.1"
+
 dependency "curl"
 dependency "zlib"
 dependency "openssl"


### PR DESCRIPTION
### Description

This PR updates expat and git software definitions license information. It is going to fix these warnings from supermarket build logs:

```
[Licensing] W | Software 'expat' does not contain licensing information.
[Licensing] W | Software 'git' does not contain licensing information.
```

--------------------------------------------------
/cc @chef/omnibus-maintainers

