### PR TITLE
Delivery cli and build curl with our cacert bundle

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -19,6 +19,7 @@ default_version "7.47.1"
 
 dependency "zlib"
 dependency "openssl"
+dependency "cacerts"
 
 license "MIT"
 license_file "COPYING"
@@ -68,6 +69,7 @@ build do
     "--without-librtmp",
     "--with-ssl=#{install_dir}/embedded",
     "--with-zlib=#{install_dir}/embedded",
+    "--with-ca-bundle=#{install_dir}/embedded/ssl/certs"
   ]
 
   command configure_command.join(" "), env: env

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -69,7 +69,7 @@ build do
     "--without-librtmp",
     "--with-ssl=#{install_dir}/embedded",
     "--with-zlib=#{install_dir}/embedded",
-    "--with-ca-bundle=#{install_dir}/embedded/ssl/certs"
+    "--with-ca-bundle=#{install_dir}/embedded/ssl/certs",
   ]
 
   command configure_command.join(" "), env: env

--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "delivery-cli"
+default_version "master"
+
+source git: "https://github.com/chef/delivery-cli.git"
+
+dependency "openssl"
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # The rust core libraries are dynamicaly linked
+  env['LD_LIBRARY_PATH']            = "#{install_dir}/embedded/lib"
+  env['DYLD_FALLBACK_LIBRARY_PATH'] = "#{install_dir}/embedded/lib:" if mac_os_x?
+
+  # Allows us to build with kitchen builders on virtualbox -
+  # due to a bug in virtualbox vboxsf, libgit2 (used by cargo) will
+  # encounter failures when using the default vboxsf-mounted
+  # /home/vagrant/.cargo location
+  env['CARGO_HOME']                 = "#{Omnibus::Config.base_dir}/cargo"
+
+  env['OPENSSL_PREFIX']             = "#{install_dir}/embedded/lib"
+  command "cargo build -j #{workers} --release", env: env
+  mkdir "#{install_dir}/bin"
+  copy "#{project_dir}/target/release/delivery", "#{install_dir}/bin/delivery"
+end

--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -17,6 +17,9 @@
 name "delivery-cli"
 default_version "master"
 
+license "Apache-2.0"
+license_file "LICENSE"
+
 source git: "https://github.com/chef/delivery-cli.git"
 
 dependency "openssl"

--- a/config/software/rust-uninstall.rb
+++ b/config/software/rust-uninstall.rb
@@ -1,0 +1,29 @@
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust-uninstall"
+default_version "0.0.1"
+
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # Until Omnibus has full support for build depedencies (see chef/omnibus#483)
+  # we don't want to ship the Rust and Cargo in our final artifact. Luckily
+  # Rust ships with a nice uninstall script which makes it easy to strip
+  # everything out.
+  command "#{install_dir}/embedded/lib/rustlib/uninstall.sh", env: env
+end

--- a/config/software/rust-uninstall.rb
+++ b/config/software/rust-uninstall.rb
@@ -16,6 +16,8 @@
 name "rust-uninstall"
 default_version "0.0.1"
 
+license :project_license
+
 dependency "rust"
 
 build do

--- a/config/software/rust-uninstall.rb
+++ b/config/software/rust-uninstall.rb
@@ -25,5 +25,5 @@ build do
   # we don't want to ship the Rust and Cargo in our final artifact. Luckily
   # Rust ships with a nice uninstall script which makes it easy to strip
   # everything out.
-  command "#{install_dir}/embedded/lib/rustlib/uninstall.sh", env: env
+  command "sh #{install_dir}/embedded/lib/rustlib/uninstall.sh", env: env
 end

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -1,0 +1,47 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust"
+default_version "2015-10-03"
+
+
+if mac_os_x?
+  host_triple = "apple-darwin"
+  md5sum = "0485cb9902a3b3c563c6c6e20b311419"
+else
+  host_triple = "unknown-linux-gnu"
+  md5sum = "eff35d920b30f191b659075a563197a6"
+end
+
+relative_path "rust-nightly-x86_64-#{host_triple}"
+version "2015-10-03" do
+  source url: "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-#{host_triple}.tar.gz",
+         md5: md5sum
+end
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  # Allows us to build with kitchen builders on  virtuablox -
+  # due to a bug in virtualbox vboxsf, libgit2 (used by cargo) will
+  # encounter failures when using the default vboxsf-mounted
+  # /home/vagrant/.cargo location
+  env['CARGO_HOME']      = "#{Omnibus::Config.base_dir}/cargo"
+
+  command "./install.sh" \
+          " --prefix=#{install_dir}/embedded" \
+          " --components=rustc,cargo" \
+          " --verbose", env: env
+end

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -17,6 +17,9 @@
 name "rust"
 default_version "2015-10-03"
 
+license "Apache-2.0"
+license_file "COPYRIGHT"
+
 # Nightly releases use a slighty different URL and TARBALL naming convention
 if version =~ /\d{4}-\d{2}-\d{2}/
   relative_path_template = "rust-nightly-x86_64-%{host_triple}"

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -17,30 +17,44 @@
 name "rust"
 default_version "2015-10-03"
 
+# Nightly releases use a slighty different URL and TARBALL naming convention
+if version =~ /\d{4}-\d{2}-\d{2}/
+  relative_path_template = "rust-nightly-x86_64-%{host_triple}"
+  url_template = "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-%{host_triple}.tar.gz"
+else
+  relative_path_template = "rust-#{version}-x86_64-${host_triple}"
+  url_template = "https://static.rust-lang.org/dist/rust-#{version}-x86_64-%{host_triple}.tar.gz"
+end
 
-if mac_os_x?
+if windows?
+  host_triple = "pc-windows-gnu"
+
+  version "2015-10-03" do
+    source md5: "25ae6f2624a02fde12d515779a238658",
+           url: url_template % {host_triple: host_triple}
+  end
+elsif mac_os_x?
   host_triple = "apple-darwin"
-  md5sum = "0485cb9902a3b3c563c6c6e20b311419"
+
+  version "2015-10-03" do
+    source md5: "0485cb9902a3b3c563c6c6e20b311419",
+           url: url_template % {host_triple: host_triple}
+  end
 else
   host_triple = "unknown-linux-gnu"
-  md5sum = "eff35d920b30f191b659075a563197a6"
+
+  version "2015-10-03" do
+    source md5: "eff35d920b30f191b659075a563197a6",
+           url: url_template % {host_triple: host_triple}
+  end
 end
 
-relative_path "rust-nightly-x86_64-#{host_triple}"
-version "2015-10-03" do
-  source url: "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-#{host_triple}.tar.gz",
-         md5: md5sum
-end
+relative_path relative_path_template % {host_triple: host_triple}
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  # Allows us to build with kitchen builders on  virtuablox -
-  # due to a bug in virtualbox vboxsf, libgit2 (used by cargo) will
-  # encounter failures when using the default vboxsf-mounted
-  # /home/vagrant/.cargo location
-  env['CARGO_HOME']      = "#{Omnibus::Config.base_dir}/cargo"
 
-  command "./install.sh" \
+  command "sh install.sh" \
           " --prefix=#{install_dir}/embedded" \
           " --components=rustc,cargo" \
           " --verbose", env: env

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -34,25 +34,25 @@ if windows?
 
   version "2015-10-03" do
     source md5: "25ae6f2624a02fde12d515779a238658",
-           url: url_template % {host_triple: host_triple}
+           url: url_template % { host_triple: host_triple }
   end
 elsif mac_os_x?
   host_triple = "apple-darwin"
 
   version "2015-10-03" do
     source md5: "0485cb9902a3b3c563c6c6e20b311419",
-           url: url_template % {host_triple: host_triple}
+           url: url_template % { host_triple: host_triple }
   end
 else
   host_triple = "unknown-linux-gnu"
 
   version "2015-10-03" do
     source md5: "eff35d920b30f191b659075a563197a6",
-           url: url_template % {host_triple: host_triple}
+           url: url_template % { host_triple: host_triple }
   end
 end
 
-relative_path relative_path_template % {host_triple: host_triple}
+relative_path relative_path_template % { host_triple: host_triple }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
### Description

Adding definitions for the Delivery CLI and its dependencies.

Also building curl so that it points to our embedded cacert bundle.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
