### PR TITLE
Support armhl server-jre

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'chef-sugar', github: 'elthariel/chef-sugar', branch: 'support_arm7l'
   gem 'omnibus', github: 'opscode/omnibus'
   gem 'highline'
   gem 'rubocop', '= 0.26.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'chef-sugar', github: 'elthariel/chef-sugar', branch: 'support_arm7l'
   gem 'omnibus', github: 'opscode/omnibus'
   gem 'highline'
   gem 'rubocop', '= 0.26.1'

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -24,7 +24,6 @@ dependency "ncurses"
 dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
-dependency "sqlite3"
 
 version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
 version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -24,6 +24,7 @@ dependency "ncurses"
 dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
+dependency "sqlite3"
 
 version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
 version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }
@@ -53,6 +54,10 @@ build do
 
   # There exists no configure flag to tell Python to not compile readline
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"
+
+  # Ditto for sqlite3
+  delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_sqlite3.*"
+  delete "#{install_dir}/embedded/lib/python2.7/sqlite3/"
 
   # Remove unused extension which is known to make healthchecks fail on CentOS 6
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_bsddb.*"

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -15,7 +15,7 @@
 #
 
 name "server-jre"
-default_version "8u91m"
+default_version "8u91"
 
 unless _64_bit? or armhf?
   raise "Server-jre can only be installed on x86_64 and armhf systems."

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -49,7 +49,7 @@ version "8u91" do
            unsafe: true
   end
 
-  relative_path "jdk1.8.0_74"
+  relative_path "jdk1.8.0_91"
 end
 
 version "8u74" do

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -15,10 +15,10 @@
 #
 
 name "server-jre"
-default_version "8u91"
+default_version "8u91m"
 
-unless _64_bit? or armhl?
-  raise "Server-jre can only be installed on x86_64 and armhl systems."
+unless _64_bit? or armhf?
+  raise "Server-jre can only be installed on x86_64 and armhf systems."
 end
 
 license "Oracle-Binary"

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -15,9 +15,11 @@
 #
 
 name "server-jre"
-default_version "8u74"
+default_version "8u91"
 
-raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
+unless _64_bit? or armhl?
+  raise "Server-jre can only be installed on x86_64 and armhl systems."
+end
 
 license "Oracle-Binary"
 license_file "LICENSE"
@@ -29,12 +31,33 @@ whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
 
+license_warning = "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+
+version "8u91" do
+  # https://www.oracle.com/webfolder/s/digest/8u91checksum.html
+  if _64_bit?
+    source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/server-jre-8u91-linux-x64.tar.gz",
+           md5: "3f3d7d0cd70bfe0feab382ed4b0e45c0",
+           cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
+           warning: license_warning,
+           unsafe:  true
+  elsif armhf?
+    source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/server-jre-8u91-linux-arm32-vfp-hflt.tar.gz",
+           md5: "1dd3934a493b474dd79b50adbd6df6a2",
+           cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
+           warning: license_warning,
+           unsafe: true
+  end
+
+  relative_path "jdk1.8.0_74"
+end
+
 version "8u74" do
   # https://www.oracle.com/webfolder/s/digest/8u74checksum.html
   source url: "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/server-jre-8u74-linux-x64.tar.gz",
          md5: "2c244c8071b7997219fe664ef1968adf",
          cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.8.0_74"
 end
@@ -43,7 +66,7 @@ version "8u31" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/8u31-b13/server-jre-8u31-linux-x64.tar.gz",
          md5:     "9d69cdc00c536b8c9f5b26a3128bd2a1",
          cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.8.0_31"
 end
@@ -53,7 +76,7 @@ version "7u80" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/7u80-b15/server-jre-7u80-linux-x64.tar.gz",
          md5:     "6152f8a7561acf795ca4701daa10a965",
          cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.7.0_80"
 end
@@ -62,7 +85,7 @@ version "7u25" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
          md5:     "7164bd8619d731a2e8c01d0c60110f80",
          cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.7.0_25"
 end


### PR DESCRIPTION
### Description

Hey,

I'm trying to make the chef-server run on Scaleway's C1 arm boxes. Those changes add support for ARM in the server-jre omnibus config.

It also fixes a minor bug encountered when building on the last ubuntu: python was linking against the system libsqlite3.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
