### PR TITLE
[curl] `--with-ca-bundle` option expects a `*.pem` file

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -69,7 +69,7 @@ build do
     "--without-librtmp",
     "--with-ssl=#{install_dir}/embedded",
     "--with-zlib=#{install_dir}/embedded",
-    "--with-ca-bundle=#{install_dir}/embedded/ssl/certs",
+    "--with-ca-bundle=#{install_dir}/embedded/ssl/certs/cacert.pem",
   ]
 
   command configure_command.join(" "), env: env


### PR DESCRIPTION
More details at: https://curl.haxx.se/docs/sslcerts.html

This should fix some strange build failures we are currently seeing in the Delivery project's build pipeline.

/cc @chef/omnibus-maintainers @tyler-ball @oferrigni 
