### PR TITLE
[rust] Support installing 32-bit Rust on Windows

### DIFF
--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -22,37 +22,50 @@ license_file "COPYRIGHT"
 
 # Nightly releases use a slighty different URL and TARBALL naming convention
 if version =~ /\d{4}-\d{2}-\d{2}/
-  relative_path_template = "rust-nightly-x86_64-%{host_triple}"
-  url_template = "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-%{host_triple}.tar.gz"
+  relative_path_template = "rust-nightly-%{arch}-%{host_triple}"
+  url_template = "https://static.rust-lang.org/dist/#{version}/rust-nightly-%{arch}-%{host_triple}.tar.gz"
 else
-  relative_path_template = "rust-#{version}-x86_64-${host_triple}"
-  url_template = "https://static.rust-lang.org/dist/rust-#{version}-x86_64-%{host_triple}.tar.gz"
+  relative_path_template = "rust-#{version}-%{arch}-${host_triple}"
+  url_template = "https://static.rust-lang.org/dist/rust-#{version}-%{arch}-%{host_triple}.tar.gz"
 end
+
+# Default architecture is x86_64
+arch = 'x86_64'
 
 if windows?
   host_triple = "pc-windows-gnu"
 
-  version "2015-10-03" do
-    source md5: "25ae6f2624a02fde12d515779a238658",
-           url: url_template % { host_triple: host_triple }
+  if windows_arch_i386?
+    arch = 'i686'
+
+    version "2015-10-03" do
+      source md5: "e56f92d70db368027f01c4d9fe69ec9f",
+             url: url_template % { host_triple: host_triple, arch: arch }
+    end
+  else
+    version "2015-10-03" do
+      source md5: "25ae6f2624a02fde12d515779a238658",
+             url: url_template % { host_triple: host_triple, arch: arch }
+    end
   end
+
 elsif mac_os_x?
   host_triple = "apple-darwin"
 
   version "2015-10-03" do
     source md5: "0485cb9902a3b3c563c6c6e20b311419",
-           url: url_template % { host_triple: host_triple }
+           url: url_template % { host_triple: host_triple, arch: arch }
   end
 else
   host_triple = "unknown-linux-gnu"
 
   version "2015-10-03" do
     source md5: "eff35d920b30f191b659075a563197a6",
-           url: url_template % { host_triple: host_triple }
+           url: url_template % { host_triple: host_triple, arch: arch }
   end
 end
 
-relative_path relative_path_template % { host_triple: host_triple }
+relative_path relative_path_template % { host_triple: host_triple, arch: arch }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
I also ensured the S3 cache has been populated:

```
C:\vagrant\code\chef-dk\omnibus>bundle exec omnibus cache populate
...
                 [NetFetcher: rust] I | Verifying checksum
                          [S3Cache] I | Caching 'C:/omnibus-ruby/cache/rust-nightly-i686-pc-windows-gnu.tar.gz' to 'opscode-omnibus-cache/rust-2015-10-03-e56f92d70db368027f01c4d9fe69ec9f'
```

/cc @tyler-ball @tylercloke @ksubrama @yzl @chef/omnibus-maintainers 
