### PR TITLE
Fix license information of openssl-customization software definition.

### DIFF
--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -20,8 +20,7 @@
 # tools can be used with https URLs out of the box.
 name "openssl-customization"
 
-license "OpenSSL"
-license_file "https://www.openssl.org/source/license.html"
+license :project_license
 
 source path: "#{project.files_path}/#{name}"
 


### PR DESCRIPTION
### Description

`openssl-customization` software definition just puts a workaround to OpenSSL. It is not licensed with full `OpenSSL` license.

--------------------------------------------------
/cc @chef/omnibus-maintainers

