### PR TITLE
Change the default gem perms to 644 on *nix platforms

### DIFF
--- a/config/software/gem-permissions.rb
+++ b/config/software/gem-permissions.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Use this software definition to fix the gem-permissions on * nix builds.
+#
+
+name "gem-permissions"
+
+default_version "0.0.1"
+
+license :project_license
+
+build do
+  unless windows?
+    block "Fix gem permissions" do
+      FileUtils.chmod_R "a+rX", "#{install_dir}/embedded/lib/ruby/gems/"
+    end
+  end
+end


### PR DESCRIPTION
```
[vagrant@chef-centos-72 omnibus]$ ls -l /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/descendants_tracker-0.0.4/
total 36
drwxrwxr-x. 2 root root 4096 May  4 15:22 config
-rw-rw-r--. 1 root root 1033 May  4 15:21 CONTRIBUTING.md
-rw-rw-r--. 1 root root  928 May  4 15:21 descendants_tracker.gemspec
-rw-rw-r--. 1 root root  189 May  4 15:21 Gemfile
-rw-rw-r--. 1 root root 1642 May  4 15:21 Gemfile.devtools
-rw-rw-r--. 1 root root  633 May  4 15:21 Guardfile
drwxrwxr-x. 3 root root   61 May  4 15:22 lib
-rw-rw-r--. 1 root root 1169 May  4 15:21 LICENSE
-rw-rw-r--. 1 root root   64 May  4 15:21 Rakefile
-rw-rw-r--. 1 root root 1395 May  4 15:21 README.md
drwxrwxr-x. 4 root root   84 May  4 15:22 spec
-rw-rw-r--. 1 root root    0 May  4 15:21 TODO

[vagrant@chef-centos-72 omnibus]$ rpm -V chef                                                                           
```

--------------------------------------------------
/cc @chef/omnibus-maintainers
