### PR TITLE
Include pthread_time in libxslt

### DIFF
--- a/config/patches/libxslt/libxslt-mingw32.patch
+++ b/config/patches/libxslt/libxslt-mingw32.patch
@@ -1,6 +1,6 @@
 --- a/libxslt/libxslt.h
 +++ b/libxslt/libxslt.h
-@@ -27,4 +27,10 @@
+@@ -27,4 +27,13 @@
  #endif
  #endif
  
@@ -8,6 +8,9 @@
 +#include <io.h>
 +#include <direct.h>
 +#define mkdir(p,m) _mkdir(p)
++
++#include <time.h>
++#include <pthread_time.h>
 +#endif
 +
  #endif /* ! __XSLT_LIBXSLT_H__ */


### PR DESCRIPTION
### Description

Difference between 32 and 64-bit mingw default headers.  The 32-bit version doesn't export clock_gettime by default because of some spectacular dumbassery w.r.t the width of time_t and compat issue with pthread_time.  The 64-bit cross-compiling mingw has enough patches to handle the issue...

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

