### PR TITLE
Libzmq is LGPL 3.0 not GPL 3.0

### DIFF
--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -18,7 +18,7 @@
 name "libzmq"
 default_version "2.1.11"
 
-license "GPL-3.0"
+license "LGPL-3.0"
 license_file "COPYING"
 license_file "COPYING.LESSER"
 


### PR DESCRIPTION
### Libzmq is LGPL 3.0 not GPL 3.0

`libzmq` is LGPL 3.0 not GPL 3.0.

--------------------------------------------------
/cc @chef/omnibus-maintainers @josephrdsmith 