### PR TITLE
Add Openssl 1.0.1t

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,7 +27,7 @@ dependency "makedepend" unless aix? || windows?
 dependency "patch" if solaris_10?
 dependency "openssl-fips" if fips_enabled
 
-default_version "1.0.1s"
+default_version "1.0.1t"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
@@ -36,6 +36,7 @@ source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract:
 # We have not tested version 1.0.2. It's here so we can run experimental builds
 # to verify that it still compiles on all our platforms.
 version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }
+version("1.0.1t") { source md5: "9837746fcf8a6727d46d22ca35953da1" }
 version("1.0.1s") { source md5: "562986f6937aabc7c11a6d376d8a0d26" }
 version("1.0.1r") { source md5: "1abd905e079542ccae948af37e393d28" }
 


### PR DESCRIPTION
Add 1.0.1t to Openssl so omnibus-software has the latest. Make it the default.

md5 was determined just by me pulling down the tarball and running md5 on it. I don't believe any other place needs to be updated, but let me know if so (I'm unsure how fips works with openssl updates, for instance)

/cc @chef/omnibus-maintainers 

