### PR TITLE
Point rubygems license to internet

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -17,7 +17,7 @@
 name "rubygems"
 
 license "MIT"
-license_file "LICENSE.txt"
+license_file "https://raw.githubusercontent.com/rubygems/rubygems/master/LICENSE.txt"
 
 dependency "ruby"
 


### PR DESCRIPTION
### Description

We have more than a few ways of getting rubygems into an omnibus build: 

https://github.com/chef/omnibus-software/blob/master/config/software/rubygems.rb#L24-L64

Some of these creates issues when we specify a relative path to the license file. Here is an example:

http://wilson.ci.chef.co/view/Chef%20Compliance/job/chef-compliance-build/architecture=x86_64,platform=el-6,project=chef-compliance,role=builder/435/console

```
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    License file '/var/cache/omnibus/src/rubygems/LICENSE.txt' does not exist for software '
```

Pointing to internet is going to fix this across the board.
--------------------------------------------------
/cc @chef/omnibus-maintainers
