### PR TITLE
Updating default Rust version to 1.8.0 because that is what we want to use for building Delivery CLI

### DIFF
--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -15,7 +15,7 @@
 #
 
 name "rust"
-default_version "2015-10-03"
+default_version "1.8.0"
 
 license "Apache-2.0"
 license_file "COPYRIGHT"


### PR DESCRIPTION
### Description

/cc @tylercloke

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
