### PR TITLE
[JEX-164] Add licensing data

### DIFF
--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -22,6 +22,9 @@ dependency "ncurses"
 
 version("4.3.30") { source md5: "a27b3ee9be83bd3ba448c0ff52b28447" }
 
+license "GPL-3.0"
+license_file "COPYING"
+
 source url: "https://ftp.gnu.org/gnu/bash/bash-#{version}.tar.gz"
 
 relative_path "bash-#{version}"

--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -17,8 +17,8 @@
 name "make"
 default_version "4.1"
 
-license "libpng"
-license_file "LICENSE"
+license "Zlib"
+license_file "README"
 
 source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
        md5: "654f9117957e6fa6a1c49a8f08270ec9"


### PR DESCRIPTION
### Description

This is to fix the failing build due to missing licensing data for 'bash' and 'make' software which is currently failing angry-omnibus-toolchain and omnibus-toolchain builds.
'make' licensing updated to "Zlib" as "libpng" is now listed as "Zlib" under standard licenses.

/cc @chef/omnibus-maintainers 

