### PR TITLE
Now that we are going to build with msys2 (which uses dynamic linking) we need to copy some additional DLLs for our executables

### DIFF
--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -55,6 +55,25 @@ build do
     copy "#{install_dir}/embedded/bin/ssleay32.dll", "#{install_dir}/bin/ssleay32.dll"
     copy "#{install_dir}/embedded/bin/libeay32.dll", "#{install_dir}/bin/libeay32.dll"
     copy "#{install_dir}/embedded/bin/zlib1.dll", "#{install_dir}/bin/zlib1.dll"
+
+    # Needed now that we switched to msys2 and have not figured out how to tell
+    # it how to statically link yet
+    dlls = ["libwinpthread-1"]
+    if windows_arch_i386
+      dlls << "libgcc_s_dw2-1"
+    else
+      dlls << "libgcc_s_seh-1"
+    end
+    dlls.each do |dll|
+      arch_suffix = windows_arch_i386? ? "32" : "64"
+      windows_path = "C:/msys2/mingw#{arch_suffix}/bin/#{dll}.dll"
+      if File.exist?(windows_path)
+        copy windows_path, "#{install_dir}/bin/#{dll}.dll"
+      else
+        raise "Cannot find required DLL needed for dynamic linking: #{windows_path}"
+      end
+    end
+
   else
     copy "#{project_dir}/target/release/delivery", "#{install_dir}/bin/delivery"
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -225,6 +225,24 @@ build do
     # On windows, msys make 3.81 breaks with parallel builds.
     make env: env
     make "install", env: env
+
+    # Needed now that we switched to msys2 and have not figured out how to tell
+    # it how to statically link yet
+    dlls = ["libwinpthread-1"]
+    if windows_arch_i386
+      dlls << "libgcc_s_dw2-1"
+    else
+      dlls << "libgcc_s_seh-1"
+    end
+    dlls.each do |dll|
+      arch_suffix = windows_arch_i386? ? "32" : "64"
+      windows_path = "C:/msys2/mingw#{arch_suffix}/bin/#{dll}.dll"
+      if File.exist?(windows_path)
+        copy windows_path, "#{install_dir}/embedded/bin/#{dll}.dll"
+      else
+        raise "Cannot find required DLL needed for dynamic linking: #{windows_path}"
+      end
+    end
   else
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env


### PR DESCRIPTION
### Description

I decided not to use a software definition for this. It is because the `rust-uninstall` app automatically deletes the `libwinpthread-1.dll` file.  So rather than having a weird software inclusion to save duplicated code, I just have a little bit of duplicated code. They also need to copy the DLLs to different locations.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

/cc @mwrock 