### PR TITLE
Update openresty to use regular lua on ppc64

### DIFF
--- a/config/software/ibm-jre.rb
+++ b/config/software/ibm-jre.rb
@@ -44,6 +44,7 @@ whitelist_file "jre/bin/policytool"
 whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
+whitelist_file "jre/bin/unpack200"
 
 build do
   mkdir "#{install_dir}/embedded/jre"

--- a/config/software/lua.rb
+++ b/config/software/lua.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "lua"
+default_version "5.1.5"
+
+version("5.1.5") { source md5: "2e115fe26e435e33b0d5c022e4490567" }
+
+license "MIT"
+license_file "COPYRIGHT"
+
+source url: "https://www.lua.org/ftp/lua-#{version}.tar.gz"
+
+relative_path "lua-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # lua compiles in a slightly interesting way, it has minimal configuration options
+  # and only provides a makefile. We can't use use `-DLUA_USE_LINUX` or the `make linux`
+  # methods because they make the assumption that the readline package has been installed.
+  make "-j #{workers} posix", env: env, cwd: "#{project_dir}/src"
+  make "-j #{workers} install INSTALL_TOP=#{install_dir}/embedded", env: env
+end

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -23,6 +23,7 @@ license_file "README.markdown"
 dependency "pcre"
 dependency "openssl"
 dependency "zlib"
+dependency "lua" if ppc64? || ppc64le?
 
 source_package_name = "openresty"
 
@@ -91,7 +92,7 @@ build do
 
   # Currently LuaJIT doesn't support POWER correctly so use Lua51 there instead
   if ppc64? || ppc64le?
-    configure << "--with-lua51"
+    configure << "--with-lua51=#{install_dir}/embedded/lib"
   else
     configure << "--with-luajit"
   end


### PR DESCRIPTION
### Description

This updates openresty to be able to use an omnibus'd lua, since the built-in lua that comes with openresty fails to compile on power. 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
@chef/engineering-services 
