### PR TITLE
Update xorg source URLs

### DIFF
--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -20,7 +20,7 @@ default_version "1.0.5"
 license "MIT"
 license_file "COPYING"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
+source url: "https://www.x.org/releases/individual/util/makedepend-1.0.5.tar.gz",
        md5: "efb2d7c7e22840947863efaedc175747"
 
 relative_path "makedepend-1.0.5"

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -25,7 +25,7 @@ version "1.18.0" do
   source md5: "fd0ba21b3179703c071bbb4c3e5fb0f4"
 end
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz"
+source url: "https://www.x.org/releases/individual/util/util-macros-#{version}.tar.gz"
 
 license "MIT"
 license_file "COPYING"

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -25,7 +25,7 @@ version "7.0.25" do
   source md5: "a47db46cb117805bd6947aa5928a7436"
 end
 
-source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz"
+source url: "https://www.x.org/releases/individual/proto/xproto-#{version}.tar.gz"
 
 license "MIT"
 license_file "COPYING"


### PR DESCRIPTION
### Description

The old xorg.freedesktop.org URLs redirect and cause the following error on older systems like CentOS 5.

```
/opt/languages/ruby/2.1.5/lib/ruby/2.1.0/openssl/ssl.rb:178:in `post_connection_check': hostname "www.x.org" does not match the server certificate (OpenSSL::SSL::SSLError)
```

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

