### PR TITLE
Always run with RUST_BACKTRACE=1

### DIFF
--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -30,6 +30,7 @@ dependency "rust"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env["RUST_BACKTRACE"] = 1
 
   # The rust core libraries are dynamicaly linked
   if linux?


### PR DESCRIPTION
### Description

When building delivery CLI, so we get a backtrace in the case of compilation errors

\cc @afiune @danielsdeleo @tylercloke 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.