### PR TITLE
Environment value needs to be a string

### DIFF
--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -30,7 +30,7 @@ dependency "rust"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env["RUST_BACKTRACE"] = 1
+  env["RUST_BACKTRACE"] = "1"
 
   # The rust core libraries are dynamicaly linked
   if linux?


### PR DESCRIPTION
### Description

\cc @danielsdeleo @tylercloke @ksubrama @mwrock 

<sigh> This fixes `mixlib-shellout-2.2.6/lib/mixlib/shellout/unix.rb:174:in `[]=': no implicit conversion of Fixnum into String (TypeError)`

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

