### PR TITLE
 Add s390x platform support for z-systems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ task :list do
   OmnibusSoftware.list
 end
 
+require "json"
 require "chefstyle"
 require "rubocop/rake_task"
 desc " Run ChefStyle"

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -15,10 +15,10 @@
 #
 
 name "erlang"
-default_version "R15B03-1"
+default_version "18.3"
 
-license "Erlang-Public"
-license_file "EPLICENCE"
+license "Apache-2.0"
+license_file "LICENSE.txt"
 
 dependency "zlib"
 dependency "openssl"
@@ -30,55 +30,72 @@ source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 version "R15B03-1" do
   source md5:   "eccd1e6dda6132993555e088005019f2"
   relative_path "otp_src_R15B03"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "R16B03-1" do
   source md5:   "e5ece977375197338c1b93b3d88514f8"
   relative_path "otp_src_#{version}"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "R15B02" do
   source md5:   "ccbe5e032a2afe2390de8913bfe737a1"
   relative_path "otp_src_#{version}"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.0" do
   source md5: "a5f78c1cf0eb7724de3a59babc1a28e5"
   relative_path "otp_src_17.0"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.1" do
   source md5: "9c90706ce70e01651adde34a2b79bf4c"
   relative_path "otp_src_17.1"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.3" do
   source md5: "1d0bb2d54dfe1bb6844756b99902ba20"
   relative_path "otp_src_17.3"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.4" do
   source md5: "3d33c4c6bd7950240dcd7479edd9c7d8"
   relative_path "otp_src_17.4"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.5" do
   source md5: "346dd0136bf1cc28cebc140e505206bb"
   relative_path "otp_src_17.5"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "18.1" do
   source md5: "fa64015fdd133e155b5b19bf90ac8678"
   relative_path "otp_src_18.1"
-  license "Apache-2.0"
-  license_file "LICENSE.txt"
 end
 
 version "18.2" do
   source md5: "b336d2a8ccfbe60266f71d102e99f7ed"
   relative_path "otp_src_18.2"
-  license "Apache-2.0"
-  license_file "LICENSE.txt"
+end
+
+version "18.3" do
+  source md5: "7e4ff32f97c36fb3dab736f8d481830b"
+  relative_path "otp_src_18.3"
 end
 
 build do

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -23,7 +23,7 @@ dependency "config_guess"
 license "MIT"
 license_file "COPYING"
 
-source url: "http://iweb.dl.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
+source url: "http://downloads.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
        md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
 
 build do

--- a/config/software/ibm-jre.rb
+++ b/config/software/ibm-jre.rb
@@ -33,6 +33,11 @@ elsif ppc64le?
          md5: "199e3f1b5e3035bc813094e2973ffafb"
   app_version = "ibm-java-ppc64le-80"
   relative_path "ibm-java-ppc64le-80"
+elsif ohai["kernel"]["machine"].eql? "s390x"
+  source url: "https://s3.amazonaws.com/chef-releng/java/jre/ibm-java-s390x-80.tar.gz",
+         md5: "722bf5ab5436add5fdddbed4b07503c7"
+  app_version = "ibm-java-s390x-80"
+  relative_path "ibm-java-s390x-80"
 else
   puts "The IBM JRE support for this platform was not found, thus it will not be installed"
 end

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -55,7 +55,7 @@ build do
     " --disable-iconv",
   ]
 
-  if ohai["kernel"]["machine"] == "s390x"
+  if s390x?
     configure << "--with-kernel-dir=/usr/src/linux/include/uapi"
   end
 

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -49,9 +49,17 @@ build do
     patch source: "keepalived-1.2.9_opscode_centos_5.patch", env: env
   end
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-iconv", env: env
+  configure = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    " --disable-iconv",
+  ]
+
+  if ohai["kernel"]["machine"] == "s390x"
+    configure << "--with-kernel-dir=/usr/src/linux/include/uapi"
+  end
+
+  command configure.join(" "), env: env
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -28,8 +28,11 @@ source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
 
 relative_path "libarchive-#{version}"
 
+dependency "config_guess"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  update_config_guess(target: "build/autoconf/")
 
   configure("--prefix=#{install_dir}/embedded",
             "--without-lzma",

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -27,23 +27,10 @@ relative_path "xz-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-
-  if windows?
-    # liblzma properly uses CFLAGS for C compilation and CPPFLAGS for common
-    # flags used across tools such as windres.  Don't put anything in it
-    # that can be misinterpreted by windres.
-    env["CPPFLAGS"] = "-I#{install_dir}/embedded/include"
-
-    # We had some issue with ld.exe crashing with various strange error codes
-    # when building .exes that linked against the dlls that it had created
-    # earlier. Turning of LTO (link-time optimizations) seems to help.
-    # If you are using a newer binutils or gcc more recent than 5.4.0, you might
-    # want to experiment with removing this. Just remember to expire the
-    # omnibus cache and try it over and over - the issue seems to be very timing
-    # sensitive and is not easily reproducible.
-    env["CFLAGS"] += " -fno-lto"
-    env["CXXFLAGS"] += " -fno-lto"
-  end
+  # liblzma properly uses CFLAGS for C compilation and CPPFLAGS for common
+  # flags used across tools such as windres.  Don't put anything in it
+  # that can be misinterpreted by windres.
+  env["CPPFLAGS"] = "-I#{install_dir}/embedded/include" if windows?
 
   config_command = [
     "--disable-debug",

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -19,7 +19,7 @@ name "nodejs"
 license "MIT"
 license_file "LICENSE"
 
-if ppc64? || ppc64le?
+if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
   default_version "0.10.38-release-ppc"
 else
   default_version "0.10.35"

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -19,7 +19,7 @@ name "nodejs"
 license "MIT"
 license_file "LICENSE"
 
-if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
+if ppc64? || ppc64le? || s390x?
   default_version "0.10.38-release-ppc"
 else
   default_version "0.10.35"

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -23,7 +23,7 @@ license_file "README.markdown"
 dependency "pcre"
 dependency "openssl"
 dependency "zlib"
-dependency "lua" if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
+dependency "lua" if ppc64? || ppc64le? || s390x?
 
 source_package_name = "openresty"
 
@@ -58,7 +58,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env["PATH"] += "#{env['PATH']}:/usr/sbin:/sbin"
 
-  if version == "1.7.10.1" && (ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x")
+  if version == "1.7.10.1" && (ppc64? || ppc64le? || s390x?)
     patch source: "v1.7.10.1.ppc64le-configure.patch", plevel: 1
   end
 
@@ -91,7 +91,7 @@ build do
   ]
 
   # Currently LuaJIT doesn't support POWER correctly so use Lua51 there instead
-  if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
+  if ppc64? || ppc64le? || s390x?
     configure << "--with-lua51=#{install_dir}/embedded/lib"
   else
     configure << "--with-luajit"

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -23,7 +23,7 @@ license_file "README.markdown"
 dependency "pcre"
 dependency "openssl"
 dependency "zlib"
-dependency "lua" if ppc64? || ppc64le?
+dependency "lua" if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
 
 source_package_name = "openresty"
 
@@ -58,7 +58,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env["PATH"] += "#{env['PATH']}:/usr/sbin:/sbin"
 
-  if version == "1.7.10.1" && (ppc64? || ppc64le?)
+  if version == "1.7.10.1" && (ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x")
     patch source: "v1.7.10.1.ppc64le-configure.patch", plevel: 1
   end
 
@@ -91,7 +91,7 @@ build do
   ]
 
   # Currently LuaJIT doesn't support POWER correctly so use Lua51 there instead
-  if ppc64? || ppc64le?
+  if ppc64? || ppc64le? || ohai["kernel"]["machine"] == "s390x"
     configure << "--with-lua51=#{install_dir}/embedded/lib"
   else
     configure << "--with-luajit"

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -57,7 +57,7 @@ build do
     # compile
     configure_command = ["perl ./Configure linux-ppc64"]
     configure_command << "--prefix=#{install_dir}/embedded"
-  elsif ohai["kernel"]["machine"].eql? "s390x"
+  elsif s390x?
     configure_command = ["perl ./Configure linux64-s390x"]
     configure_command << "--prefix=#{install_dir}/embedded"
     # Unfortunately openssl-fips is not supported on s390x, so we have to tell it to

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -57,6 +57,12 @@ build do
     # compile
     configure_command = ["perl ./Configure linux-ppc64"]
     configure_command << "--prefix=#{install_dir}/embedded"
+  elsif ohai["kernel"]["machine"].eql? "s390x"
+    configure_command = ["perl ./Configure linux64-s390x"]
+    configure_command << "--prefix=#{install_dir}/embedded"
+    # Unfortunately openssl-fips is not supported on s390x, so we have to tell it to
+    # compile solely in C
+    configure_command << "no-asm"
   else
     configure_command = ["./config"]
   end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -103,7 +103,9 @@ build do
         if linux? && ppc64?
           "./Configure linux-ppc64"
         elsif linux? && ohai["kernel"]["machine"] == "s390x"
-          "./Configure linux64-s390x"
+          # With gcc > 4.3 on s390x there is an error building
+          # with inline asm enabled
+          "./Configure linux64-s390x -DOPENSSL_NO_INLINE_ASM"
         else
           "./config"
         end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -102,7 +102,7 @@ build do
       prefix =
         if linux? && ppc64?
           "./Configure linux-ppc64"
-        elsif linux? && ohai["kernel"]["machine"] == "s390x"
+        elsif linux? && s390x?
           # With gcc > 4.3 on s390x there is an error building
           # with inline asm enabled
           "./Configure linux64-s390x -DOPENSSL_NO_INLINE_ASM"

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -32,7 +32,7 @@ version "8.31" do
   source md5: "fab1bb3b91a4c35398263a5c1e0858c1"
 end
 
-source url: "http://iweb.dl.sourceforge.net/project/pcre/pcre/#{version}/pcre-#{version}.tar.gz"
+source url: "http://downloads.sourceforge.net/project/pcre/pcre/#{version}/pcre-#{version}.tar.gz"
 
 relative_path "pcre-#{version}"
 

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -56,4 +56,10 @@ build do
 
   # Remove unused extension which is known to make healthchecks fail on CentOS 6
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_bsddb.*"
+
+  # Remove sqlite3 libraries, if you want to include sqlite, create a new def
+  # in your software project and build it explicitly. This removes the adapter
+  # library from python, which links incorrectly to a system library. Adding
+  # your own sqlite definition will fix this.
+  delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_sqlite3.*"
 end

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -31,7 +31,7 @@ version "0.973" do
   source md5: "0994e9f906a7a4a2e97049c8dbaef584"
 end
 
-source url: "https://github.com/theory/#{name}/archive/#{version}.tar.gz"
+source url: "https://github.com/theory/#{name}/releases/download/v#{version}/app-sqitch-#{version}.tar.gz"
 
 relative_path "App-Sqitch-#{version}"
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -51,7 +51,14 @@ build do
       "CFLAGS=\"#{env['CFLAGS']} -Wall\"",
       "ASFLAGS=\"#{env['CFLAGS']} -Wall\"",
       "LDFLAGS=\"#{env['LDFLAGS']}\"",
-      "-j #{workers}",
+      # The win32 makefile for zlib does not handle parallel make correctly.
+      # In particular, see it's rule for IMPLIB and SHAREDLIB. The ld step in
+      # SHAREDLIB will generate both the dll and the dll.a files. The step to
+      # strip the dll occurs next but since the dll.a file is already present,
+      # make will attempt to link example_d.exe and minigzip_d.exe in parallel
+      # with the strip step - causing gcc to freak out when a source file is
+      # rewritten part way through the linking stage.
+      #"-j #{workers}",
     ]
 
     make(*make_args, env: env)

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -52,7 +52,7 @@ build do
       "ASFLAGS=\"#{env['CFLAGS']} -Wall\"",
       "LDFLAGS=\"#{env['LDFLAGS']}\"",
       # The win32 makefile for zlib does not handle parallel make correctly.
-      # In particular, see it's rule for IMPLIB and SHAREDLIB. The ld step in
+      # In particular, see its rule for IMPLIB and SHAREDLIB. The ld step in
       # SHAREDLIB will generate both the dll and the dll.a files. The step to
       # strip the dll occurs next but since the dll.a file is already present,
       # make will attempt to link example_d.exe and minigzip_d.exe in parallel

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -24,7 +24,7 @@ version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"
 end
 
-source url: "http://iweb.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
+source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
 
 license "Zlib"
 license_file "README"


### PR DESCRIPTION
### Description
Platform adoption updates for IBM Z system

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

* Add nodejs update for z-systems
* Add compile param for keepalived on s390x
* Add fips noasm for s390x
* Add no inline asm for openssl on s390x
* Explicitly delete sqlite3 python adapter
* Fix sqitch download URL
* Update ibm-jre and openresty for z-systems