### PR TITLE
[libarchive] Update config guess so we can build on ppc64le

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -28,8 +28,11 @@ source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
 
 relative_path "libarchive-#{version}"
 
+dependency "config_guess"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  update_config_guess(target: "build/autoconf/")
 
   configure("--prefix=#{install_dir}/embedded",
             "--without-lzma",


### PR DESCRIPTION
### Description

The version of config_guess that libarchive ships doesn't recognize ppc64le. Use the update_config_guess DSL method to fix it up.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

