### PR TITLE
[erlang] Add 18.3 and make it the default

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -15,10 +15,10 @@
 #
 
 name "erlang"
-default_version "R15B03-1"
+default_version "18.3"
 
-license "Erlang-Public"
-license_file "EPLICENCE"
+license "Apache-2.0"
+license_file "LICENSE.txt"
 
 dependency "zlib"
 dependency "openssl"
@@ -30,55 +30,72 @@ source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 version "R15B03-1" do
   source md5:   "eccd1e6dda6132993555e088005019f2"
   relative_path "otp_src_R15B03"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "R16B03-1" do
   source md5:   "e5ece977375197338c1b93b3d88514f8"
   relative_path "otp_src_#{version}"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "R15B02" do
   source md5:   "ccbe5e032a2afe2390de8913bfe737a1"
   relative_path "otp_src_#{version}"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.0" do
   source md5: "a5f78c1cf0eb7724de3a59babc1a28e5"
   relative_path "otp_src_17.0"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.1" do
   source md5: "9c90706ce70e01651adde34a2b79bf4c"
   relative_path "otp_src_17.1"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.3" do
   source md5: "1d0bb2d54dfe1bb6844756b99902ba20"
   relative_path "otp_src_17.3"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.4" do
   source md5: "3d33c4c6bd7950240dcd7479edd9c7d8"
   relative_path "otp_src_17.4"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "17.5" do
   source md5: "346dd0136bf1cc28cebc140e505206bb"
   relative_path "otp_src_17.5"
+  license "Erlang-Public"
+  license_file "EPLICENCE"
 end
 
 version "18.1" do
   source md5: "fa64015fdd133e155b5b19bf90ac8678"
   relative_path "otp_src_18.1"
-  license "Apache-2.0"
-  license_file "LICENSE.txt"
 end
 
 version "18.2" do
   source md5: "b336d2a8ccfbe60266f71d102e99f7ed"
   relative_path "otp_src_18.2"
-  license "Apache-2.0"
-  license_file "LICENSE.txt"
+end
+
+version "18.3" do
+  source md5: "7e4ff32f97c36fb3dab736f8d481830b"
+  relative_path "otp_src_18.3"
 end
 
 build do


### PR DESCRIPTION
### Bump erlang to 18.3

Any of our projects that are on R15 and don't have it pinned will break.  That is a good thing. They should break and get on a reasonable version of the runtime.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

