### PR TITLE
fix_md5_zlib

### DIFF
--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -18,7 +18,7 @@ name "zlib"
 default_version "1.2.8"
 
 version "1.2.8" do
-  source md5: "44d667c142d7cda120332623eab69f40"
+  source md5: "0103b909e19ca9c6497a7ae696c16480"
 end
 version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

12:16:42 ==> debian_wheezy_x64: Verification for zlib failed due to a checksum mismatch:
12:16:42 ==> debian_wheezy_x64: 
12:16:42 ==> debian_wheezy_x64:     expected: 44d667c142d7cda120332623eab69f40
12:16:42 ==> debian_wheezy_x64:     actual:   0103b909e19ca9c6497a7ae696c16480


--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

