### PR TITLE
Add s390x platform support for z-systems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ task :list do
   OmnibusSoftware.list
 end
 
+require "json"
 require "chefstyle"
 require "rubocop/rake_task"
 desc " Run ChefStyle"

--- a/config/software/ibm-jre.rb
+++ b/config/software/ibm-jre.rb
@@ -33,6 +33,11 @@ elsif ppc64le?
          md5: "199e3f1b5e3035bc813094e2973ffafb"
   app_version = "ibm-java-ppc64le-80"
   relative_path "ibm-java-ppc64le-80"
+elsif s390x?
+  source url: "https://s3.amazonaws.com/chef-releng/java/jre/ibm-java-s390x-80.tar.gz",
+         md5: "722bf5ab5436add5fdddbed4b07503c7"
+  app_version = "ibm-java-s390x-80"
+  relative_path "ibm-java-s390x-80"
 else
   puts "The IBM JRE support for this platform was not found, thus it will not be installed"
 end

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -49,9 +49,17 @@ build do
     patch source: "keepalived-1.2.9_opscode_centos_5.patch", env: env
   end
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-iconv", env: env
+  configure = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    " --disable-iconv",
+  ]
+
+  if s390x?
+    configure << "--with-kernel-dir=/usr/src/linux/include/uapi"
+  end
+
+  command configure.join(" "), env: env
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -34,19 +34,28 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   update_config_guess(target: "build/autoconf/")
 
-  configure("--prefix=#{install_dir}/embedded",
-            "--without-lzma",
-            "--without-lzo2",
-            "--without-nettle",
-            "--without-xml2",
-            "--without-expat",
-            "--without-bz2lib",
-            "--without-iconv",
-            "--without-zlib",
-            "--disable-bsdtar",
-            "--disable-bsdcpio",
-            "--without-lzmadec",
-            "--without-openssl", env: env)
+  configure = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    "--without-lzma",
+    "--without-lzo2",
+    "--without-nettle",
+    "--without-xml2",
+    "--without-expat",
+    "--without-bz2lib",
+    "--without-iconv",
+    "--without-zlib",
+    "--disable-bsdtar",
+    "--disable-bsdcpio",
+    "--without-lzmadec",
+    "--without-openssl",
+  ]
+
+  if s390x?
+    configure << "--disable-xattr --disable-acl"
+  end
+
+  command configure.join(" "), env: env
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -19,7 +19,7 @@ name "nodejs"
 license "MIT"
 license_file "LICENSE"
 
-if ppc64? || ppc64le?
+if ppc64? || ppc64le? || s390x?
   default_version "0.10.38-release-ppc"
 else
   default_version "0.10.35"

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -23,7 +23,7 @@ license_file "README.markdown"
 dependency "pcre"
 dependency "openssl"
 dependency "zlib"
-dependency "lua" if ppc64? || ppc64le?
+dependency "lua" if ppc64? || ppc64le? || s390x?
 
 source_package_name = "openresty"
 
@@ -58,7 +58,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env["PATH"] += "#{env['PATH']}:/usr/sbin:/sbin"
 
-  if version == "1.7.10.1" && (ppc64? || ppc64le?)
+  if version == "1.7.10.1" && (ppc64? || ppc64le? || s390x?)
     patch source: "v1.7.10.1.ppc64le-configure.patch", plevel: 1
   end
 
@@ -91,7 +91,7 @@ build do
   ]
 
   # Currently LuaJIT doesn't support POWER correctly so use Lua51 there instead
-  if ppc64? || ppc64le?
+  if ppc64? || ppc64le? || s390x?
     configure << "--with-lua51=#{install_dir}/embedded/lib"
   else
     configure << "--with-luajit"

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -57,6 +57,12 @@ build do
     # compile
     configure_command = ["perl ./Configure linux-ppc64"]
     configure_command << "--prefix=#{install_dir}/embedded"
+  elsif s390x?
+    configure_command = ["perl ./Configure linux64-s390x"]
+    configure_command << "--prefix=#{install_dir}/embedded"
+    # Unfortunately openssl-fips is not supported on s390x, so we have to tell it to
+    # compile solely in C
+    configure_command << "no-asm"
   else
     configure_command = ["./config"]
   end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -102,8 +102,10 @@ build do
       prefix =
         if linux? && ppc64?
           "./Configure linux-ppc64"
-        elsif linux? && ohai["kernel"]["machine"] == "s390x"
-          "./Configure linux64-s390x"
+        elsif linux? && s390x?
+          # With gcc > 4.3 on s390x there is an error building
+          # with inline asm enabled
+          "./Configure linux64-s390x -DOPENSSL_NO_INLINE_ASM"
         else
           "./config"
         end

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -56,4 +56,10 @@ build do
 
   # Remove unused extension which is known to make healthchecks fail on CentOS 6
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_bsddb.*"
+
+  # Remove sqlite3 libraries, if you want to include sqlite, create a new def
+  # in your software project and build it explicitly. This removes the adapter
+  # library from python, which links incorrectly to a system library. Adding
+  # your own sqlite definition will fix this.
+  delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_sqlite3.*"
 end

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -31,7 +31,7 @@ version "0.973" do
   source md5: "0994e9f906a7a4a2e97049c8dbaef584"
 end
 
-source url: "https://github.com/theory/#{name}/archive/#{version}.tar.gz"
+source url: "https://github.com/theory/#{name}/releases/download/v#{version}/app-sqitch-#{version}.tar.gz"
 
 relative_path "App-Sqitch-#{version}"
 

--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
   s.add_dependency "omnibus", ">= 5.2.0"
+  s.add_dependency "chef-sugar", ">= 3.4.0"
 
   s.add_development_dependency "chefstyle", "~> 0.3"
 


### PR DESCRIPTION
### Description

Add s390x platform support for z-systems

@chef/engineering-services 
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

Add s390x platform support for z-systems

Add nodejs update for z-systems

Add compile param for keepalived on s390x

Add fips noasm for s390x

Add no inline asm for openssl on s390x

Explicitly delete sqlite3 python adapter

Fix sqitch download URL

Update ibm-jre and openresty for z-systems

Update keepalived.rb

Update openresty.rb

Update sqitch url to not use archive

Apply chefstyle

Add s390x plaform identification from chef-sugar

Use chef-sugar method released in v3.4 for s390x platform