### PR TITLE
Skip licensing info collection for transitive deps of Chef Client's when not needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "omnibus", github: "opscode/omnibus"
+  gem "omnibus", github: "chef/omnibus"
   gem "highline"
   gem "rake"
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -18,6 +18,7 @@ name "bundler"
 
 license "MIT"
 license_file "https://raw.githubusercontent.com/bundler/bundler/master/LICENSE.md"
+skip_transitive_dependency_licensing true
 
 dependency "rubygems"
 

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -18,6 +18,7 @@ name "cacerts"
 
 license "MPL-2.0"
 license_file "https://github.com/bagder/ca-bundle/blob/master/README.md"
+skip_transitive_dependency_licensing true
 
 default_version "2016-04-20"
 

--- a/config/software/clean-static-libs.rb
+++ b/config/software/clean-static-libs.rb
@@ -19,6 +19,7 @@ description "cleanup un-needed static libraries from the build"
 default_version "1.0.0"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   # Remove static object files for all platforms

--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -24,6 +24,7 @@ source git: "git://git.sv.gnu.org/config.git"
 license "GPL-3.0 (with exception)"
 license_file "config.guess"
 license_file "config.sub"
+skip_transitive_dependency_licensing true
 
 relative_path "config_guess-#{version}"
 

--- a/config/software/gem-permissions.rb
+++ b/config/software/gem-permissions.rb
@@ -23,6 +23,7 @@ name "gem-permissions"
 default_version "0.0.1"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   unless windows?

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -20,6 +20,7 @@ default_version "3.2.1"
 
 license "MIT"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -22,6 +22,7 @@ default_version "1.14"
 
 license "LGPL-2.1"
 license_file "COPYING.LIB"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 dependency "patch" if solaris_10?

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -19,6 +19,7 @@ default_version "5.2.2"
 
 license "Public-Domain"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
        md5: "7cf6a8544a7dae8e8106fdf7addfa28c"

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -19,6 +19,7 @@ default_version "2.4"
 
 license "GPL-2.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -19,6 +19,7 @@ default_version "2.9.4"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "libiconv"

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -19,6 +19,7 @@ default_version "1.1.29"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "libxml2"
 dependency "liblzma"

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -19,6 +19,7 @@ default_version "0.1.6"
 
 license "MIT"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -19,6 +19,7 @@ default_version "1.0.5"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 source url: "https://www.x.org/releases/individual/util/makedepend-1.0.5.tar.gz",
        md5: "efb2d7c7e22840947863efaedc175747"

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -19,6 +19,8 @@ default_version "0.3.6"
 
 license "Apache-2.0"
 license_file "https://github.com/chef/omnibus-ctl/blob/master/LICENSE"
+# Even though omnibus-ctl is a gem, it does not have any dependencies.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -21,6 +21,7 @@
 name "openssl-customization"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 source path: "#{project.files_path}/#{name}"
 

--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -19,6 +19,7 @@ default_version "2.0.10"
 
 license "OpenSSL"
 license_file "https://www.openssl.org/source/license.html"
+skip_transitive_dependency_licensing true
 
 version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
 version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -18,6 +18,7 @@ name "openssl"
 
 license "OpenSSL"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 

--- a/config/software/patch.rb
+++ b/config/software/patch.rb
@@ -20,6 +20,7 @@ dependency "config_guess"
 
 license "GPL-3.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 default_version "2.7"
 

--- a/config/software/pkg-config-lite.rb
+++ b/config/software/pkg-config-lite.rb
@@ -19,6 +19,7 @@ default_version "0.28-1"
 
 license "GPL-2.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 

--- a/config/software/preparation.rb
+++ b/config/software/preparation.rb
@@ -19,6 +19,7 @@ description "the steps required to preprare the build"
 default_version "1.0.0"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   block do

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -20,6 +20,7 @@ default_version "3.1.23-4-msys-1.0.18"
 
 license "GPL-3.0"
 license_file "http://www.gnu.org/licenses/gpl-3.0.txt"
+skip_transitive_dependency_licensing true
 
 dependency "ruby-windows-devkit"
 source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -19,6 +19,7 @@ default_version "4.7.2-20130224"
 
 license "BSD-3-Clause"
 license_file "https://raw.githubusercontent.com/oneclick/rubyinstaller/master/LICENSE.txt"
+skip_transitive_dependency_licensing true
 
 if windows_arch_i386?
   version "4.5.2-20111229-1559" do

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -20,6 +20,7 @@ license "BSD-2-Clause"
 license_file "BSDL"
 license_file "COPYING"
 license_file "LEGAL"
+skip_transitive_dependency_licensing true
 
 # - chef-client cannot use 2.2.x yet due to a bug in IRB that affects chef-shell on linux:
 #   https://bugs.ruby-lang.org/issues/11869

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -18,6 +18,7 @@ name "rubygems"
 
 license "MIT"
 license_file "https://raw.githubusercontent.com/rubygems/rubygems/master/LICENSE.txt"
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 

--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -24,6 +24,7 @@ name "shebang-cleanup"
 default_version "0.0.2"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   if windows?

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -29,6 +29,7 @@ source url: "https://www.x.org/releases/individual/util/util-macros-#{version}.t
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 relative_path "util-macros-#{version}"
 

--- a/config/software/version-manifest.rb
+++ b/config/software/version-manifest.rb
@@ -19,6 +19,7 @@ description "generates a version manifest file"
 default_version "0.0.1"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   block do

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -29,6 +29,7 @@ source url: "https://www.x.org/releases/individual/proto/xproto-#{version}.tar.g
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 relative_path "xproto-#{version}"
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -28,6 +28,7 @@ source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zli
 
 license "Zlib"
 license_file "README"
+skip_transitive_dependency_licensing true
 
 relative_path "zlib-#{version}"
 

--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
-  s.add_dependency "omnibus", ">= 5.2.0"
+  s.add_dependency "omnibus", ">= 5.5.0"
   s.add_dependency "chef-sugar", ">= 3.4.0"
 
   s.add_development_dependency "chefstyle", "~> 0.3"


### PR DESCRIPTION
### Description

https://github.com/chef/omnibus/pull/705 adds the licensing information collection for the transitive dependencies to omnibus. As explained in that PR, in order not to leak any software without license information, we are enforcing software definitions that do not have any transitive dependencies to set `skip_transitive_dependency_licensing`. 

This PR adds all the required flags to the dependencies of Chef Client omnibus project. It is tested at http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/157/downstreambuildview/

Note that there are some `Gemfile` and `gemspec` fixes required for this PR before merge.

--------------------------------------------------
/cc @chef/omnibus-maintainers