### PR TITLE
Update logrotate default from 3.8.5 to 3.9.2

### DIFF
--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -15,7 +15,7 @@
 #
 
 name "logrotate"
-default_version "3.8.5"
+default_version "3.9.2"
 
 license "GPL-2.0"
 license_file "COPYING"
@@ -24,13 +24,8 @@ dependency "popt"
 
 source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
-version "3.9.2" do
-  source md5: "584bca013dcceeb23b06b27d6d0342fb"
-end
-version "3.8.5" do
-  source md5: "d3c13e2a963a55c584cfaa83e96b173d",
-         url: "https://fedorahosted.org/releases/l/o/logrotate/logrotate-#{version}.tar.gz"
-end
+version("3.9.2") { source md5: "584bca013dcceeb23b06b27d6d0342fb" }
+version("3.8.9") { source md5: "e6da1f1b91d1f202d26caaf864aa0d71" }
 
 relative_path "logrotate-#{version}"
 


### PR DESCRIPTION
### Description

There is a [bug](https://fedorahosted.org/logrotate/ticket/32) in logrotate 3.8.5 that can prevent pre/post rotate scripts from executing. This is [currently impacting](https://github.com/chef/chef-server/issues/843) chef-server customers. As a result, we're removing it and replacing it with the latest 3.8 release (3.8.9). In addition, we're making 3.9.2 the default version.

--------------------------------------------------
/cc @chef/omnibus-maintainers
