### PR TITLE
Fix Chef Server software definitions for license_scout

### DIFF
--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -22,6 +22,7 @@ default_version "1.0.6"
 
 license "BSD-2-Clause"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "openssl"

--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -19,6 +19,7 @@ default_version "1.7004"
 
 license "Artistic-2.0"
 license_file "http://dev.perl.org/licenses/artistic.html"
+skip_transitive_dependency_licensing true
 
 dependency "perl"
 

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -19,6 +19,9 @@ default_version "1.2.0"
 
 license "Apache-2.0"
 license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE.txt"
+# dep-selector-libgecode does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "rubygems"
 

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -19,6 +19,7 @@ default_version "18.3"
 
 license "Apache-2.0"
 license_file "LICENSE.txt"
+skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "openssl"

--- a/config/software/gecode.rb
+++ b/config/software/gecode.rb
@@ -19,6 +19,7 @@ default_version "3.7.3"
 
 license "MIT"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 version "3.7.3" do
   source md5: "7a5cb9945e0bb48f222992f2106130ac"

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -20,6 +20,9 @@ default_version "1.6.21"
 license "Ruby"
 license_file "https://github.com/JEG2/highline/blob/master/LICENSE"
 license_file "http://www.ruby-lang.org/en/LICENSE.txt"
+# highline does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -19,6 +19,7 @@ default_version "1.2.9"
 
 license "GPL-2.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "popt"
 dependency "openssl"

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -22,6 +22,7 @@ default_version "3.1.2"
 
 license "BSD-2-Clause"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
        md5: "efad5a503f66329bb9d2f4308b5de98a"

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -19,6 +19,7 @@ default_version "20120601-3.0"
 
 license "BSD-3-Clause"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "ncurses"
 dependency "config_guess"

--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -19,6 +19,7 @@ default_version "1.6.2"
 
 license "MIT"
 license_file "README"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -19,6 +19,7 @@ default_version "3.8.5"
 
 license "GPL-2.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "popt"
 

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,6 +20,7 @@ default_version "5.9"
 license "MIT"
 license_file "http://invisible-island.net/ncurses/ncurses-license.html"
 license_file "http://invisible-island.net/ncurses/ncurses.faq.html"
+skip_transitive_dependency_licensing true
 
 dependency "libtool" if aix?
 dependency "config_guess"

--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -18,6 +18,7 @@ name "nodejs"
 
 license "MIT"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 if ppc64? || ppc64le? || s390x?
   default_version "0.10.38-release-ppc"

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -18,6 +18,8 @@ name "nokogiri"
 
 license "MIT"
 license_file "https://github.com/sparklemotion/nokogiri/blob/master/LICENSE.txt"
+# We install only nokogiri from rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -19,6 +19,7 @@ default_version "1.9.7.2"
 
 license "BSD-2-Clause"
 license_file "README.markdown"
+skip_transitive_dependency_licensing true
 
 dependency "pcre"
 dependency "openssl"

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -19,6 +19,7 @@ default_version "8.38"
 
 license "BSD-2-Clause"
 license_file "LICENCE"
+skip_transitive_dependency_licensing true
 
 dependency "libedit"
 dependency "ncurses"

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -18,6 +18,7 @@ name "perl"
 
 license "Artistic-2.0"
 license_file "Artistic"
+skip_transitive_dependency_licensing true
 
 default_version "5.18.1"
 

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -20,6 +20,9 @@ default_version "0.17.1"
 license "BSD-2-Clause"
 license_file "https://github.com/ged/ruby-pg/blob/master/LICENSE"
 license_file "https://github.com/ged/ruby-pg/blob/master/BSDL"
+# pg gem does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -19,6 +19,7 @@ default_version "1.16"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -19,6 +19,7 @@ default_version "9.2.10"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
+skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "openssl"

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -19,6 +19,7 @@ default_version "2.7.9"
 
 license "Python-2.0"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "ncurses"
 dependency "zlib"

--- a/config/software/rabbitmq.rb
+++ b/config/software/rabbitmq.rb
@@ -19,6 +19,7 @@ default_version "2.7.1"
 
 license "MPL-2.0"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "erlang"
 

--- a/config/software/rb-readline.rb
+++ b/config/software/rb-readline.rb
@@ -19,6 +19,7 @@ default_version "master"
 
 license "BSD-3-Clause"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -19,6 +19,9 @@ default_version "3.1.0"
 
 license "MIT"
 license_file "https://github.com/redis/redis-rb/blob/master/LICENSE"
+# redis gem does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -18,6 +18,7 @@ name "redis"
 
 license "BSD-3-Clause"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 default_version "3.0.4"

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -19,6 +19,7 @@ default_version "2.1.1"
 
 license "BSD-3-Clause"
 license_file "../package/COPYING"
+skip_transitive_dependency_licensing true
 
 version "2.1.2" do
   source md5: "6c985fbfe3a34608eb3c53dc719172c4"

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -19,6 +19,9 @@ default_version "4.13.0"
 
 license "MIT"
 license_file "https://github.com/jeremyevans/sequel/blob/master/MIT-LICENSE"
+# sequel gem does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -22,6 +22,7 @@ raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
 license "Oracle-Binary"
 license_file "LICENSE"
 license_file "http://java.com/license"
+skip_transitive_dependency_licensing true
 
 whitelist_file "jre/bin/javaws"
 whitelist_file "jre/bin/policytool"


### PR DESCRIPTION
### Description

This PR adds the `skip_transitive_dependency_licensing` flag to the software dependencies of Chef Server that do not need transitive dependency license collection.

--------------------------------------------------
/cc @chef/omnibus-maintainers