### PR TITLE
Patch ruby to work with windows nano

### DIFF
--- a/config/patches/ruby/ruby_nano.patch
+++ b/config/patches/ruby/ruby_nano.patch
@@ -1,0 +1,68 @@
+--- a/ext/win32ole/win32ole.c
++++ b/ext/win32ole/win32ole.c
+@@ -50,6 +50,7 @@ static volatile DWORD g_ole_initialized_key = TLS_OUT_OF_INDEXES;
+ static BOOL g_uninitialize_hooked = FALSE;
+ static BOOL g_cp_installed = FALSE;
+ static BOOL g_lcid_installed = FALSE;
++static BOOL g_running_nano = FALSE;
+ static HINSTANCE ghhctrl = NULL;
+ static HINSTANCE gole32 = NULL;
+ static FNCOCREATEINSTANCEEX *gCoCreateInstanceEx = NULL;
+@@ -817,16 +818,22 @@ ole_initialize(void)
+     }
+ 
+     if(g_ole_initialized == FALSE) {
+-        hr = OleInitialize(NULL);
++        if(g_running_nano == TRUE) {
++            hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
++        } else {
++            hr = OleInitialize(NULL);
++        }
+         if(FAILED(hr)) {
+             ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
+         }
+         g_ole_initialized_set(TRUE);
+ 
+-        hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
+-        if(FAILED(hr)) {
+-            previous_filter = NULL;
+-            ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
++        if(g_running_nano == FALSE) {
++            hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
++            if(FAILED(hr)) {
++                previous_filter = NULL;
++                ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
++            }
+         }
+     }
+ }
+@@ -3890,10 +3897,29 @@ com_hash_size(const void *ptr)
+ }
+ 
+ void
++check_nano_server(void)
++{
++    HKEY hsubkey;
++    LONG err;
++    const char * subkey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Server\\ServerLevels";
++    const char * regval = "NanoServer";
++
++    err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &hsubkey);
++    if (err == ERROR_SUCCESS) {
++        err = RegQueryValueEx(hsubkey, regval, NULL, NULL, NULL, NULL);
++        if (err == ERROR_SUCCESS) {
++            g_running_nano = TRUE;
++        }
++        RegCloseKey(hsubkey);
++    }
++}
++
++void
+ Init_win32ole(void)
+ {
+     cWIN32OLE_lcid = LOCALE_SYSTEM_DEFAULT;
+     g_ole_initialized_init();
++    check_nano_server();
+ 
+     com_vtbl.QueryInterface = QueryInterface;
+     com_vtbl.AddRef = AddRef;

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -212,6 +212,12 @@ build do
     configure_command << "ac_cv_func_dl_iterate_phdr=no"
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   elsif windows?
+    if version.satisfies?(">= 2.3")
+      # Windows Nano Server COM libraries do not support Apartment threading
+      # instead COINIT_MULTITHREADED must be used
+      patch source: "ruby_nano.patch", plevel: 1, env: patch_env
+    end
+
     configure_command << " debugflags=-g"
   else
     configure_command << "--with-opt-dir=#{install_dir}/embedded"


### PR DESCRIPTION
Windows Nano does not support apartment theaded concurrency in its COM libraries. However, multi threaded concurrency is supported. The technical preview of nano available at the time of this submission (TP5), contains a hack in its win32ole.dll forwarder that causes calls to `OleInitialize` which normally call `CoInitializeEx` with `STA` to use `MTA` instead. This hack will be removed from the final RTM Windows nano and cause all calls to `reuire 'win32ole'` to fail. Chef uses this extensively in ohai plugins and elsewhere.

@alexpilotti, on behalf of microsoft,  suggested we change https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/ext/win32ole/win32ole.c#L820-L830 to:
```
       hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
        if(FAILED(hr)) {
            ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
        }
        g_ole_initialized_set(TRUE);
```

I have confirmed that this does work with preview bits we have been given in participaion with the MS partner program.

Because we want to use the same ruby binary on all versions of windows, I have added a check to determine if ruby is running on nano so that the above code will only be used on nano. I anticipate the vast majority of usages of win32ole would be fine with this implementation and only certain multithreaded scenarios might experience unexpected results. However it seems best to preserve the current behavior for all non nano environments.

Note that I am not a c++ developer but I have done my best to comply with the conventions of the win32ole.c code. I have added static flags to prevent registry lookups on every call. If anyone can think of a cleaner approach or a better way to test for nano, I'd be interested but I have tested this against current versions of windows and a preview win32ole.dll with the above mentioned hack removed and things work.