### PR TITLE
Only support Solaris 10u11 and newer.

### DIFF
--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -25,7 +25,6 @@ license_file "COPYING.LIB"
 skip_transitive_dependency_licensing true
 
 dependency "config_guess"
-dependency "patch" if solaris_10?
 
 source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        md5: "e34509b1623cec449dfeb73d7ce9c6c6"

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -48,9 +48,6 @@ build do
     "--without-icu",
   ]
 
-  # solaris 10 ipv6 support is broken due to no inet_ntop() in -lnsl
-  configure_command << "--enable-ipv6=no" if solaris_10?
-
   update_config_guess
 
   configure(*configure_command, env: env)

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -24,8 +24,6 @@ skip_transitive_dependency_licensing true
 dependency "libxml2"
 dependency "liblzma"
 dependency "config_guess"
-dependency "libtool" if solaris_10?
-dependency "patch" if solaris_10?
 
 version "1.1.29" do
   source md5: "a129d3c44c022de3b9dcf6d6f288d72e"

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -33,10 +33,6 @@ dependency "pkg-config-lite"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if solaris_10?
-    env["PKG_CONFIG"] = "#{install_dir}/embedded/bin/pkg-config"
-  end
-
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -25,7 +25,6 @@ fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) 
 dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
-dependency "patch" if solaris_10?
 dependency "openssl-fips" if fips_enabled
 
 default_version "1.0.1t"
@@ -94,7 +93,7 @@ build do
       # This should not require a /bin/sh, but without it we get
       # Errno::ENOEXEC: Exec format error
       platform = sparc? ? "solaris-sparcv9-gcc" : "solaris-x86-gcc"
-      "/bin/sh ./Configure #{platform}"
+      "/bin/sh ./Configure #{platform} -static-libgcc"
     elsif solaris_11?
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif windows?

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -35,8 +35,13 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   solaris_mapfile_path = File.expand_path(Omnibus::Config.solaris_linker_mapfile, Omnibus::Config.project_root)
-  if solaris2? && File.exist?(solaris_mapfile_path)
-    cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}"
+  if solaris_10?
+    cc_command = "-Dcc='gcc -static-libgcc'"
+    if File.exist?(solaris_mapfile_path)
+      cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}'"
+    end
+  elsif solaris_11?
+    cc_command = "-Dcc='gcc -m64 -static-libgcc'"
   elsif aix?
     cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"
   elsif freebsd? && ohai["os_version"].to_i >= 1000024

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -30,7 +30,6 @@ default_version "2.1.8"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
-dependency "patch" if solaris_10?
 dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 dependency "zlib"
 dependency "openssl"
@@ -105,7 +104,7 @@ elsif aix?
 elsif solaris_10?
   if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env["CFLAGS"] << " -std=c99 -O0 -g -pipe -mcpu=v9"
+    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9"
     env["LDFLAGS"] << " -mcpu=v9"
   else
     env["CFLAGS"] << " -std=c99 -O3 -g -pipe"
@@ -128,8 +127,6 @@ build do
 
   if solaris_10? && version.satisfies?(">= 2.1")
     patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
-  elsif solaris_10? && version =~ /^1.9/
-    patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1, env: patch_env
   elsif solaris_11? && version =~ /^2.1/
     patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1, env: patch_env
   end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -78,6 +78,6 @@ build do
   else
     # Installing direct from rubygems:
     # If there is no version, this will get latest.
-    gem "update --system #{version}", env: env
+    gem "update --no-document --system #{version}", env: env
   end
 end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -70,10 +70,7 @@ build do
     # configure script cannot handle.
     # TODO: Do other OSes need this?  Is this strictly a mac thing?
     env = with_standard_compiler_flags
-    if solaris_10?
-      # For some reason zlib needs this flag on solaris (cargocult warning?)
-      env["CFLAGS"] << " -DNO_VIZ"
-    elsif freebsd?
+    if freebsd?
       # FreeBSD 10+ gets cranky if zlib is not compiled in a
       # position-independent way.
       env["CFLAGS"] << " -fPIC"


### PR DESCRIPTION
### Description

Only support Solaris 10u11 and newer. This is largely based on the work originally done by @scotthain 

--------------------------------------------------
/cc @chef/omnibus-maintainers 

This removes the Solaris patches and removes dead code no longer needed
for newer versions of Solaris.