### PR TITLE
Update software used by Chef Server ppc for transitive dependency licensing

### DIFF
--- a/config/software/ibm-jre.rb
+++ b/config/software/ibm-jre.rb
@@ -22,6 +22,7 @@ license "IBM-Java-contractual-redistribution"
 # charge and without support or warranty to our mutual customers
 license_file "copyright"
 license_file "license_en.txt"
+skip_transitive_dependency_licensing true
 
 if ppc64?
   source url: "https://s3.amazonaws.com/chef-releng/java/jre/ibm-java-ppc64-80.tar.xz",

--- a/config/software/lua.rb
+++ b/config/software/lua.rb
@@ -21,6 +21,7 @@ version("5.1.5") { source md5: "2e115fe26e435e33b0d5c022e4490567" }
 
 license "MIT"
 license_file "COPYRIGHT"
+skip_transitive_dependency_licensing true
 
 source url: "https://www.lua.org/ftp/lua-#{version}.tar.gz"
 


### PR DESCRIPTION
### Description

These few software definitions are only used on ppc and therefore were not under my radar up to now 😄 

/cc: @danielsdeleo @ryancragun 

--------------------------------------------------
/cc @chef/omnibus-maintainers