### PR TITLE
Skip transitive dependency licensing for curl, expat and git.

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -23,6 +23,7 @@ dependency "cacerts"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 version "7.47.1" do
   source md5: "3f9d1be7bf33ca4b8c8602820525302b"

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -22,6 +22,7 @@ dependency "config_guess"
 
 license "MIT"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 source url: "http://downloads.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz",
        md5: "dd7dab7a5fea97d2a6a43f511449b7cd"

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -19,6 +19,7 @@ default_version "2.8.2"
 
 license "LGPL-2.1"
 license_file "LGPL-2.1"
+skip_transitive_dependency_licensing true
 
 dependency "curl"
 dependency "zlib"


### PR DESCRIPTION
### Description

These are the projects used in Chef Automate that we need to skip transitive dependency license collection. 

/cc: @danielsdeleo @ryancragun 
--------------------------------------------------
/cc @chef/omnibus-maintainers