### PR TITLE
Add PostgreSQL 9.3.14 to available versions.

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -72,6 +72,10 @@ version "9.4.0" do
   source md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b"
 end
 
+version "9.3.14" do
+  source sha256: "5c4322f1c42ba1ff4b28383069c56663b46160bb08e85d41fa2ab9a5009d039d"
+end
+
 version "9.3.10" do
   source md5: "ec2365548d08f69c8023eddd4f2d1a28"
 end


### PR DESCRIPTION
### Description

CVEs addressed between 9.3.10 and 9.3.14:

### [9.3.11](https://www.postgresql.org/docs/current/static/release-9-3-11.html):

* CVE-2016-0773: Very large character ranges in bracket expressions
  could cause infinite loops in some cases, and memory overwrites in
  other cases.
* CVE-2007-4772: A more complete fix for an old fix to regex compiler
  handling loops.
* CVE-2016-0766: Mitigate a PL/Java bug.

### [9.3.14](https://www.postgresql.org/docs/current/static/release-9-3-14.html)

* CVE-2016-5423: possible mis-evaluation of nested CASE-WHEN expressions
* CVE-2016-5424: Fix client programs' handling of special characters in
  database and role names. ... considered security fixes because crafted
  object names containing special characters could have been used to
  execute commands with superuser privileges the next time a superuser
  executes pg_dumpall or other routine maintenance operations.

### [SHAAAAAAAA-A-A-A](https://ftp.postgresql.org/pub/source/v9.3.14/postgresql-9.3.14.tar.bz2.sha256)

```
5c4322f1c42ba1ff4b28383069c56663b46160bb08e85d41fa2ab9a5009d039d  postgresql-9.3.14.tar.bz2
```

--------------------------------------------------
/cc @chef/omnibus-maintainers