### PR TITLE
Revert previous fix due to upstream bundler bug

### DIFF
--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -32,8 +32,11 @@ dependency "bundler"
 build do
   env = with_embedded_path()
 
-  # Do not install development dependencies
-  bundle "install --without development development_extras rbx", env: env
+  # We should not be installing development dependencies either, but
+  # this upstream bug causes issues between libyajl2-gem and ffi-yajl
+  # (specifically, "corrupted Gemfile.lock" failures)
+  # https://github.com/bundler/bundler/issues/4467
+  bundle "install --without development_extras", env: env
   bundle "exec rake gem", env: env
 
   delete "pkg/*java*"


### PR DESCRIPTION
### Description

Looks like we're hitting: https://github.com/bundler/bundler/issues/4467

Manifests itself as follows:
```
bundle install --without development development_extras rbx
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
Using libyajl2 1.2.0
Your Gemfile.lock is corrupt. The following gem is missing from the DEPENDENCIES section: 'ffi'
```

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

@chef/engineering-services 