### PR TITLE
Use bugs.ruby-lang.org instead of redmine.ruby-lang.org

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -158,7 +158,7 @@ build do
   # Fix reserve stack segmentation fault when building on RHEL5 or below
   # Currently only affects 2.1.7 and 2.2.3. This patch taken from the fix
   # in Ruby trunk and expected to be included in future point releases.
-  # https://redmine.ruby-lang.org/issues/11602
+  # https://bugs.ruby-lang.org/issues/11602
   if rhel? &&
       platform_version.satisfies?("< 6") &&
       (version == "2.1.7" || version == "2.2.3")


### PR DESCRIPTION
### Description

`https://redmine.ruby-lang.org` is invalid now.
Use `https://bugs.ruby-lang.org` instead.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

see https://github.com/ruby/bugs.ruby-lang.org/issues/68