### PR TITLE
Add license_file information for setuptools.

### DIFF
--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -18,6 +18,7 @@ name "setuptools"
 default_version "0.7.7"
 
 license "Python Software Foundation"
+license_file "https://raw.githubusercontent.com/pypa/setuptools/master/LICENSE"
 
 dependency "python"
 


### PR DESCRIPTION
### Description

Adding missing licensing information for `setuptools`.

--------------------------------------------------
/cc @chef/omnibus-maintainers

