### PR TITLE
Skip transitive license deps in setuptools

### DIFF
--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -19,6 +19,7 @@ default_version "0.7.7"
 
 license "Python Software Foundation"
 license_file "https://raw.githubusercontent.com/pypa/setuptools/master/LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "python"
 


### PR DESCRIPTION
### Description

If I am reading setuptools setup.py correctly, I don't think it has transitive deps.
Since license_scout doesn't support searching transitive python deps I'm opting to skip deps for now.
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
