### PR TITLE
Currently license_scout does not support python projects. Until we do…

### DIFF
--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -19,6 +19,7 @@ default_version "0.7.7"
 
 license "Python Software Foundation"
 license_file "https://raw.githubusercontent.com/pypa/setuptools/master/LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "python"
 


### PR DESCRIPTION
### Description

Disable the transitive dependency checking on setuptools until we support python. 

--------------------------------------------------
/cc @chef/omnibus-maintainers