### PR TITLE
add OpenSSL versions 1.0.1u & 1.0.2i

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,7 +27,7 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_enabled
 
-default_version "1.0.1t"
+default_version "1.0.1u"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
@@ -35,8 +35,10 @@ source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract:
 
 # We have not tested version 1.0.2. It's here so we can run experimental builds
 # to verify that it still compiles on all our platforms.
+version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }
 version("1.0.2h") { source sha256: "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" }
 version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }
+version("1.0.1u") { source sha256: "4312b4ca1215b6f2c97007503d80db80d5157f76f8f7d3febbe6b4c56ff26739" }
 version("1.0.1t") { source md5: "9837746fcf8a6727d46d22ca35953da1" }
 version("1.0.1s") { source md5: "562986f6937aabc7c11a6d376d8a0d26" }
 version("1.0.1r") { source md5: "1abd905e079542ccae948af37e393d28" }


### PR DESCRIPTION
# So, OpenSSL, we meet again.

## Severity: High

* OCSP Status Request extension unbounded memory growth (CVE-2016-6304)

## Severity: Medium

* SSL_peek() hang on empty record (CVE-2016-6305)

## Severity: Low

* SWEET32 Mitigation (CVE-2016-2183)
* OOB write in MDC2_Update() (CVE-2016-6303)
* Malformed SHA512 ticket DoS (CVE-2016-6302)
* OOB write in BN_bn2dec() (CVE-2016-2182)
* OOB read in TS_OBJ_print_bio() (CVE-2016-2180)
* Pointer arithmetic undefined behaviour (CVE-2016-2177)
* Constant time flag not preserved in DSA signing (CVE-2016-2178)
* DTLS buffered message DoS (CVE-2016-2179)
* DTLS replay protection DoS (CVE-2016-2181)
* Certificate message OOB reads (CVE-2016-6306)
* Excessive allocation of memory in tls_get_message_header() (CVE-2016-6307)
* Excessive allocation of memory in dtls1_preprocess_fragment() (CVE-2016-6308)

https://www.openssl.org/news/secadv/20160922.txt

# Needs doing outside the PR:

* [x] 1.0.1u added to omnibus cache
* [x] 1.0.2i added to omnibus cache

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.