### PR TITLE
add OpenSSL version 1.0.2j

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -35,6 +35,7 @@ source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract:
 
 # We have not tested version 1.0.2. It's here so we can run experimental builds
 # to verify that it still compiles on all our platforms.
+version("1.0.2j") { source sha256: "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" }
 version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }
 version("1.0.2h") { source sha256: "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" }
 version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }


### PR DESCRIPTION
# Update the update to OpenSSL

> Don't get too proud of this technological terror you've constructed.

### [Severity: Moderate](https://www.openssl.org/news/secadv/20160926.txt)

* Missing CRL sanity check (CVE-2016-7052)

### [SHAAAAAAAA-A-A-A](https://www.openssl.org/source/openssl-1.0.2j.tar.gz.sha256)

```
e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431  openssl-1.0.2j.tar.gz
```

## Needs doing outside the PR:

* [x] 1.0.2j added to omnibus cache

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.