### PR TITLE
Bump dep-selector-libgecode to 1.3.1

### DIFF
--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -15,7 +15,7 @@
 #
 
 name "dep-selector-libgecode"
-default_version "1.2.0"
+default_version "1.3.1"
 
 license "Apache-2.0"
 license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE.txt"


### PR DESCRIPTION
### Description

Currently, the berkshelf software definition depends on this software
definition. However, the berkshelf software definition also runs bundle
install which installs dep-selector-libgecode 1.3.1. The result is that
anyone depending on berkshelf gets 2 versions of depselector installed.

A careful observer might ask, "If berkshelf does a bundle install why do
we need this software definition at all?" We have two separate
definitions is so that they can be cached separately. berks is more
likely to change than dep-selector.

Signed-off-by: Steven Danna <steve@chef.io>