### PR TITLE
[erlang] Don't build with wx or megaco

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -134,6 +134,8 @@ build do
           " --enable-dynamic-ssl-lib" \
           " --enable-shared-zlib" \
           " --enable-hipe" \
+          " --without-wx" \
+          " --without-megaco" \
           " --without-javac" \
           " --with-ssl=#{install_dir}/embedded" \
           " --disable-debug", env: env


### PR DESCRIPTION
### Description

None of our applications use megaco or wx directly. wx is occasionally
useful in debugging situations, but in these cases it is most likely
that we would use a local erlang installation with wx enabled and
connect it to the remote host.  These apps are the two largest apps in
the erlang installation.

Signed-off-by: Steven Danna <steve@chef.io>

/cc @chef/omnibus-maintainers