### PR TITLE
Remove integration group from chef install

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -54,7 +54,7 @@ build do
 
   # compiled ruby on windows 2k8R2 x86 is having issude compiling
   # native extensions for pry-byebug so excluding for now
-  excluded_groups = %w{server docgen maintenance pry travis}
+  excluded_groups = %w{server docgen maintenance pry travis integration}
   excluded_groups << "ruby_prof" if aix?
 
   # install the whole bundle first


### PR DESCRIPTION
Chef 12.10.7 added an integration group to the gemfile that currently
(7 October 2016, chef at 1a0c4c5) includes:

  - chef-provisioning
  - chef-provisioning-aws
  - chef-rewind
  - chef-sugar
  - chefspec
  - halite
  - poise
  - poise-boiler
  - knife-windows
  - foodcritic
  - cucumber
  - oc-chef-pedant

oc-chef-pedant is particularly problematic since it requires a
complete checkout of the chef-server from git, which takes both time
to pull down during the build and takes up roughly 66MB on disk.

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers @chef/client-core 

# Discussion

- *Will this break chefdk or some other client-related release process?*

I have not been able to keep up to speed on the various changes to how we build the client side packages.  Could someone who is familiar with them comment on whether this will break that world?

- *Should chef-server still be using chef-client from master?*

chef-server current uses chef-client from master.  This was done in early 2015 as a way to help find bugs in the big changes that were being pushed into chef-client at the time and to help prevent chef-server's reconfigure cookbooks from getting to far out of date.  The change presented is part of an ongoing side-project I'm doing to try to reduce the size of the chef-server-core packages.  An alternative change to this may be for us to move to the chef-gem software definition rather than continuing to use the latest chef-client.