### PR TITLE
Install a non-GPL version of libintl-perl

### DIFF
--- a/config/software/libintl-perl.rb
+++ b/config/software/libintl-perl.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ## libintl-perl
+# libintl-perl is a localization library. Normally it would be installed
+# automatically by `cpanm` when you install whatever application you want, and
+# you wouldn't need an explict software definition for it. Unfortunately,
+# libintl-perl changed the license from LGPLv2 to GPLv3 in version 1.24, making
+# it unusable in products that cannot ship GPLv3 code. By pre-installing
+# version 1.23 or earlier, it's possible to workaround the licensing change for
+# now.
+
+name "libintl-perl"
+
+default_version "1.23" # see above before setting this to something newer
+
+# See above. If you set the version to something above 1.23, the license data
+# here will be wrong.
+license "LGPL-2.1"
+
+# This is a (seldom updated) mirror. The primary repo is at
+# git://git.guido-flohr.net/perl/libintl-perl.git
+license_file "https://raw.githubusercontent.com/theory/libintl-perl/a92bda4e01cdecbf7e40f78c1444a8ca22e6fdfc/COPYING.LESSER"
+
+dependency "perl"
+dependency "cpanminus"
+
+source url: "http://search.cpan.org/CPAN/authors/id/G/GU/GUIDO/libintl-perl-1.23.tar.gz",
+       md5: "2e79dc842af1c9efc14fbe6664dc89bf"
+
+relative_path "libintl-perl-#{version}"
+
+# See https://github.com/theory/sqitch for more
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "cpanm -v --notest .", env: env
+end

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -23,6 +23,9 @@ license_file "https://github.com/theory/sqitch/blob/master/README.md"
 dependency "perl"
 dependency "cpanminus"
 
+# install a LGPL-licensed version of libintl-perl:
+dependency "libintl-perl"
+
 version "0.9994" do
   source md5: "7227dfcd141440f23d99f01a2b01e0f2"
 end


### PR DESCRIPTION
### Description

`libintl-perl` is a dependency of sqitch. It changed its license from LGPL-2.1 to GPL-3 in version 1.24: http://cpansearch.perl.org/src/GUIDO/libintl-perl-1.24/NEWS

We do not want to ship the GPL-3 version, so for now we are pinning to 1.23.

Testing locally and via Vagrant-based Chef Server build shows that `cpanm` will not attempt to update this when installing sqitch, so pre-installing is sufficient to "pin" to the older version.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

Signed-off-by: Daniel DeLeo <dan@chef.io>