### PR TITLE
Add berkshelf-no-depselector software definition

### DIFF
--- a/config/software/berkshelf-no-depselector.rb
+++ b/config/software/berkshelf-no-depselector.rb
@@ -1,0 +1,48 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "berkshelf-no-depselector"
+default_version "master"
+
+license "Apache-2.0"
+license_file "LICENSE"
+
+source git: "https://github.com/berkshelf/berkshelf.git"
+
+relative_path "berkshelf"
+
+dependency "ruby"
+dependency "rubygems"
+
+unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+  dependency "libarchive"
+end
+
+dependency "nokogiri"
+dependency "bundler"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install" \
+         " --jobs #{workers}" \
+         " --without guard changelog development test", env: env
+
+  bundle "exec thor gem:build", env: env
+
+  gem "install pkg/berkshelf-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end


### PR DESCRIPTION
The berkshelf-no-depselector software definition installs berkshelf from
source but

- without a dep-selector-libgecode dependency, and
- excluding many bundler groups

Berks only requires dep-selector-libgecode for cases where the user
desires resolution results *exactly* like the chef-server would
provide. Most of our users of berks is to easily manage very small set
of cookbooks that omnibus packages use for configuration.

This resulting berks install is smaller and faster to install than the
standard berkshelf software definition and eliminates most of the cost
of using berks.

Installing from gems would be best, but will require someone to do the
work to collect all of the transitive licensing information.

We can likely collapse these if someone audits our use of berkshelf
across that packages and verifies that a no-dep-selector install will
work for all of them (we pin to some old versions in a number of
projects).

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
