### PR TITLE
Use a github mirror of GNU config

### DIFF
--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -17,8 +17,8 @@
 name "config_guess"
 default_version "master"
 
-# occasionally http protocol downloads get 500s, so we use git://
-source git: "git://git.sv.gnu.org/config.git"
+# Use our github mirror of the savannah repository
+source git: "https://github.com/chef/config-mirror.git"
 
 # http://savannah.gnu.org/projects/config
 license "GPL-3.0 (with exception)"


### PR DESCRIPTION
Savannah has been unavailable multiple times this year. We don't
typically need frequent updates to the repository.  I've pushed a copy
of it to github, a service which tends to be more reliable for us.

If we want to use this long term, we should find a way to update our
mirror periodically.

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers 