### PR TITLE
Remove Test-MockModule from the package after installing sqitch.

### DIFF
--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -46,4 +46,34 @@ build do
   command "./Build installdeps --cpan_client 'cpanm -v --notest'", env: env
   command "./Build", env: env
   command "./Build install", env: env
+
+  # Here is another licensing fun. Some of the dependencies of sqitch
+  # unfortunately have GPL3 and LGPL3 licenses which are requiring us to remove
+  # them from our packages after installing sqitch. Here we are uninstalling
+  # them without breaking the licensing information collection.
+  %w{Test-MockModule}.each do |package_name|
+    module_name = package_name.gsub("-", "::")
+
+    # Here we run cpanm --uninstall with a different PERL_CPANM_HOME. The reason
+    # for this is to keep the licensing information for sqitch intact. The way
+    # license_scout works is to look into PERL_CPANM_HOME/latest-build (by
+    # default ~/.cpanm/latest-build) which contains the modules installed during
+    # the last install. This directory is a symlink that points to the directory
+    # contains the information about the latest build. Without changing
+    # PERL_CPANM_HOME we would overwrite the link and will not be able to
+    # collect the dependencies installed to our package while doing the actual
+    # sqitch install.
+    Dir.mktmpdir do |tmpdir|
+      command "cpanm --force --uninstall #{module_name}", env: env.merge({
+        "PERL_CPANM_HOME" => tmpdir,
+      })
+    end
+
+    # Here we are removing the problematic package from the original
+    # PERL_CPANM_HOME cache directory. This ensures that we do not add
+    # licensing information about these components to our package.
+    cpanm_root = File.expand_path("~/.cpanm/latest-build")
+    delete "#{cpanm_root}/#{package_name}*"
+  end
+
 end


### PR DESCRIPTION
### Description

Test-MockModule is a GPL3 licensed component and we need to remove it from our packages.

Jenkins Build: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/280/downstreambuildview/

After installation only the metadata file of the module is left over by cpanm.

```
vagrant@default-ubuntu-1204:~$ cat /opt/opscode/LICENSE | grep Test-MockModule
vagrant@default-ubuntu-1204:~$ find /opt/opscode -name "*Test-MockModule*"
/opt/opscode/embedded/lib/perl5/site_perl/5.18.1/x86_64-linux-thread-multi/.meta/Test-MockModule-0.11
```

--------------------------------------------------
/cc @chef/omnibus-maintainers

