### PR TITLE
openresty: add and default to v1.11.2.1

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -15,11 +15,10 @@
 #
 
 name "openresty"
-default_version "1.9.7.2"
-
 license "BSD-2-Clause"
 license_file "README.markdown"
 skip_transitive_dependency_licensing true
+default_version "1.11.2.1"
 
 dependency "pcre"
 dependency "openssl"
@@ -28,6 +27,7 @@ dependency "lua" if ppc64? || ppc64le? || s390x?
 
 source_package_name = "openresty"
 
+version("1.11.2.1") { source md5: "f26d152f40c5263b383a5b7c826a6c7e" }
 version("1.9.7.3") { source md5: "33579b96a8c22bedee97eadfc99d9564" }
 
 version("1.9.7.2") do


### PR DESCRIPTION
### Description

openresty `1.11.2.1` includes nginx `1.11.2`, and thus remediates the latest [security advisory](https://nginx.org/en/security_advisories.html), [CVE-2016-4450](http://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html).

--------------------------------------------------
/cc @chef/omnibus-maintainers