### PR TITLE
Support armhl server-jre

### DIFF
--- a/config/software/jre-from-jdk.rb
+++ b/config/software/jre-from-jdk.rb
@@ -21,8 +21,8 @@
 name "jre-from-jdk"
 default_version "8u91"
 
-unless armhf?
-  raise "The 'jre-from-jdk' can only be installed on armhf"
+unless _64_bit? || armhf?
+  raise "The 'jre-from-jdk' can only be installed on armhf and x86_64"
 end
 
 license "Oracle-Binary"
@@ -39,8 +39,16 @@ license_cookie = "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-s
 
 version "8u91" do
   # https://www.oracle.com/webfolder/s/digest/8u91checksum.html
-  source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-arm32-vfp-hflt.tar.gz",
-         md5: "1dd3934a493b474dd79b50adbd6df6a2",
+  if armhf?
+    file = "jdk-8u91-linux-arm32-vfp-hflt.tar.gz"
+    md5 = "1dd3934a493b474dd79b50adbd6df6a2"
+  else
+    file = "jdk-8u91-linux-x64.tar.gz"
+    md5 = "3f3d7d0cd70bfe0feab382ed4b0e45c0"
+  end
+
+  source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/#{file}",
+         md5: md5,
          cookie: license_cookie,
          warning: license_warning,
          unsafe: true

--- a/config/software/jre-from-jdk.rb
+++ b/config/software/jre-from-jdk.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2013-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Oracle doesn't distribute JRE builds for ARM, only JDK
+# builds. Since we do no want to ship a larger package with a
+# different layout, we just pick the 'jre' folder inside the jdk.
+# This allows us to get as close as an ARM JRE package as we can.
+name "jre-from-jdk"
+default_version "8u91"
+
+unless armhf?
+  raise "The 'jre-from-jdk' can only be installed on armhf"
+end
+
+license "Oracle-Binary"
+license_file "LICENSE"
+
+whitelist_file "jre/bin/javaws"
+whitelist_file "jre/bin/policytool"
+whitelist_file "jre/lib"
+whitelist_file "jre/plugin"
+whitelist_file "jre/bin/appletviewer"
+
+license_warning = "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+license_cookie = "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie"
+
+version "8u91" do
+  # https://www.oracle.com/webfolder/s/digest/8u91checksum.html
+  source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-arm32-vfp-hflt.tar.gz",
+         md5: "1dd3934a493b474dd79b50adbd6df6a2",
+         cookie: license_cookie,
+         warning: license_warning,
+         unsafe: true
+
+  relative_path "jdk1.8.0_91"
+end
+
+build do
+  mkdir "#{install_dir}/embedded/jre"
+
+  sync  "#{project_dir}/jre", "#{install_dir}/embedded/jre"
+end

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -55,6 +55,10 @@ build do
   # There exists no configure flag to tell Python to not compile readline
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"
 
+  # Ditto for sqlite3
+  delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_sqlite3.*"
+  delete "#{install_dir}/embedded/lib/python2.7/sqlite3/"
+
   # Remove unused extension which is known to make healthchecks fail on CentOS 6
   delete "#{install_dir}/embedded/lib/python2.7/lib-dynload/_bsddb.*"
 

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -15,9 +15,11 @@
 #
 
 name "server-jre"
-default_version "8u74"
+default_version "8u91"
 
-raise "Server-jre can only be installed on x86_64 systems." unless _64_bit?
+unless _64_bit?
+  raise "Server-jre can only be installed on x86_64 systems."
+end
 
 license "Oracle-Binary"
 license_file "LICENSE"
@@ -36,12 +38,26 @@ whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
 
+license_warning = "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+license_cookie = "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie"
+
+version "8u91" do
+  # https://www.oracle.com/webfolder/s/digest/8u91checksum.html
+  source url: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/server-jre-8u91-linux-x64.tar.gz",
+         md5: "3f3d7d0cd70bfe0feab382ed4b0e45c0",
+         cookie: license_cookie,
+         warning: license_warning,
+         unsafe:  true
+
+  relative_path "jdk1.8.0_91"
+end
+
 version "8u74" do
   # https://www.oracle.com/webfolder/s/digest/8u74checksum.html
   source url: "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/server-jre-8u74-linux-x64.tar.gz",
          md5: "2c244c8071b7997219fe664ef1968adf",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         cookie: license_cookie,
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.8.0_74"
 end
@@ -49,8 +65,8 @@ end
 version "8u31" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/8u31-b13/server-jre-8u31-linux-x64.tar.gz",
          md5:     "9d69cdc00c536b8c9f5b26a3128bd2a1",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         cookie:  license_cookie,
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.8.0_31"
 end
@@ -59,8 +75,8 @@ version "7u80" do
   # https://www.oracle.com/webfolder/s/digest/7u80checksum.html
   source url:     "http://download.oracle.com/otn-pub/java/jdk/7u80-b15/server-jre-7u80-linux-x64.tar.gz",
          md5:     "6152f8a7561acf795ca4701daa10a965",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         cookie:  license_cookie,
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.7.0_80"
 end
@@ -68,13 +84,14 @@ end
 version "7u25" do
   source url:     "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
          md5:     "7164bd8619d731a2e8c01d0c60110f80",
-         cookie:  "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie",
-         warning: "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html",
+         cookie:  license_cookie,
+         warning: license_warning,
          unsafe:  true
   relative_path "jdk1.7.0_25"
 end
 
 build do
   mkdir "#{install_dir}/embedded/jre"
+
   sync  "#{project_dir}/", "#{install_dir}/embedded/jre"
 end


### PR DESCRIPTION
### Supporting arm machines

Hey,

I'm trying to make the chef-server run on Scaleway's C1 arm boxes. Those changes add support for ARM in the server-jre omnibus config. This would probably work on any armhl box.

It also fixes a minor bug encountered when building on the last ubuntu: python was linking against the system libsqlite3.

It finally updates the default jre version to the next minor version, for which an arm build is available.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

PS: This is a new PR as I forget the previous one, that was closed by me deleting the branch
