### PR TITLE
Upgrade lua: add 5.3.3 and 5.2.4; change redis default version

### DIFF
--- a/config/software/lua.rb
+++ b/config/software/lua.rb
@@ -15,12 +15,19 @@
 #
 
 name "lua"
-default_version "5.1.5"
+default_version "5.3.3"
 
-version("5.1.5") { source md5: "2e115fe26e435e33b0d5c022e4490567" }
+version("5.1.5") do
+  source md5: "2e115fe26e435e33b0d5c022e4490567"
+  license_file "COPYRIGHT" # dropped in 5.2.x
+end
+
+version("5.2.4") { source sha256: "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b" }
+
+version("5.3.3") { source sha256: "5113c06884f7de453ce57702abaac1d618307f33f6789fa870e87a59d772aca2" }
 
 license "MIT"
-license_file "COPYRIGHT"
+license_file "https://www.lua.org/license.html"
 skip_transitive_dependency_licensing true
 
 source url: "https://www.lua.org/ftp/lua-#{version}.tar.gz"

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -21,7 +21,7 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 dependency "config_guess"
-default_version "3.0.4"
+default_version "3.0.7"
 
 version "3.0.7" do
   source md5: "84ed3f486e7a6f0ebada6917370f3532"


### PR DESCRIPTION
### Description

Upgrading/adding some things:

- redis: changed default version to 3.0.7 because of _"high urgency"_ of its upgrades (see [release notes](https://raw.githubusercontent.com/antirez/redis/3.0/00-RELEASENOTES))
- added latest lua version of 5.2.x and 5.3.x -- because [_"There will be no futher releases of Lua 5.1."_](https://www.lua.org/versions.html), changed default version to 5.3.3.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

Signed-off-by: Stephan Renatus <srenatus@chef.io>