### PR TITLE
jre-from-jdk: skip_transitive_dependency_licensing true

### DIFF
--- a/config/software/jre-from-jdk.rb
+++ b/config/software/jre-from-jdk.rb
@@ -27,6 +27,7 @@ end
 
 license "Oracle-Binary"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 whitelist_file "jre/bin/javaws"
 whitelist_file "jre/bin/policytool"


### PR DESCRIPTION
Forgot to borrow `skip_transitive_dependency_licensing true` from `server-jre.rb` and caching prevented me from noticing this

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>