### PR TITLE
add curl 7.51.0, make it default

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.47.1"
+default_version "7.51.0"
 
 dependency "zlib"
 dependency "openssl"
@@ -25,13 +25,9 @@ license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version "7.47.1" do
-  source md5: "3f9d1be7bf33ca4b8c8602820525302b"
-end
-
-version "7.36.0" do
-  source md5: "643a7030b27449e76413d501d4b8eb57"
-end
+version("7.51.0") { source sha256: "65b5216a6fbfa72f547eb7706ca5902d7400db9868269017a8888aa91d87977c" }
+version("7.47.1") { source md5: "3f9d1be7bf33ca4b8c8602820525302b" }
+version("7.36.0") { source md5: "643a7030b27449e76413d501d4b8eb57" }
 
 source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz"
 


### PR DESCRIPTION
### Description

[This mailing list annoucement](https://curl.haxx.se/mail/lib-2016-11/0019.html) sounds like bumping this is the right thing to do now.

This addresses the following CVEs:

 - CVE-2016-8615: cookie injection for other servers
 - CVE-2016-8616: case insensitive password comparison
 - CVE-2016-8617: OOB write via unchecked multiplication
 - CVE-2016-8618: double-free in curl_maprintf
 - CVE-2016-8619: double-free in krb5 code
 - CVE-2016-8620: glob parser write/read out of bounds
 - CVE-2016-8621: curl_getdate read out of bounds
 - CVE-2016-8622: URL unescape heap overflow via integer truncation
 - CVE-2016-8623: Use-after-free via shared cookies
 - CVE-2016-8624: invalid URL parsing with '#'
 - CVE-2016-8625: IDNA 2003 makes curl use wrong host

--------------------------------------------------
/cc @chef/omnibus-maintainers