### PR TITLE
use ruby 2.2 + 2.3 in travis, since omnibus needs >= 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-rvm: 2.1.2
 sudo: false
+rvm:
+  - 2.2.5
+  - 2.3.0
 branches:
   only:
     - master


### PR DESCRIPTION
### Description

[Omnibus needs something newer than 2.1 now](https://github.com/chef/omnibus/pull/731), so this needs to adapt to have tests pass in Travis.

--------------------------------------------------
/cc @chef/omnibus-maintainers