### PR TITLE
Remove version pin on chefstyle

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "omnibus-software"
   s.version     = OmnibusSoftware::VERSION
   s.authors     = ["Chef Software, Inc."]
-  s.email       = ["legal@getchef.com"]
-  s.homepage    = "http://github.com/opscode/omnibus-software"
+  s.email       = ["legal@chef.io"]
+  s.homepage    = "https://github.com/chef/omnibus-software"
   s.summary     = %q{Open Source software for use with Omnibus}
   s.description = %q{Open Source software build descriptions for use with Omnibus}
 
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "omnibus", ">= 5.5.0"
   s.add_dependency "chef-sugar", ">= 3.4.0"
 
-  s.add_development_dependency "chefstyle", "~> 0.3"
+  s.add_development_dependency "chefstyle"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
We've moved away from pinning chefstyle in chef projects and instead
realized that we should cleanup things as we break them.

Update URLs while I'm in here.

Signed-off-by: Tim Smith <tsmith@chef.io>