### PR TITLE
Add openssl 1.0.2j and make it the default

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,14 +27,13 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_enabled
 
-default_version "1.0.1u"
+default_version "1.0.2j"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
-# We have not tested version 1.0.2. It's here so we can run experimental builds
-# to verify that it still compiles on all our platforms.
+version("1.0.2j") { source sha256: "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" }
 version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }
 version("1.0.2h") { source sha256: "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" }
 version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }


### PR DESCRIPTION
Openssl 1.0.1 goes EOL next month. We need to get off this.

Signed-off-by: Tim Smith <tsmith@chef.io>