### PR TITLE
Use omnibus-toolchain path when copying ruby DLLs

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -241,8 +241,9 @@ build do
       dlls << "libgcc_s_seh-1"
     end
     dlls.each do |dll|
-      arch_suffix = windows_arch_i386? ? "32" : "64"
-      windows_path = "C:/msys2/mingw#{arch_suffix}/bin/#{dll}.dll"
+      mingw = ENV["MSYSTEM"].downcase
+      msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+      windows_path = "#{msys_path}/#{mingw}/bin/#{dll}.dll"
       if File.exist?(windows_path)
         copy windows_path, "#{install_dir}/embedded/bin/#{dll}.dll"
       else


### PR DESCRIPTION
### Description

Load mingw DLLs from the correct directory. This is done to support the new omnibus-toolchain.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

Signed-off-by: Tom Duffield <tom@chef.io>