### PR TITLE
Enable building the HTTP2 module in openresty when it's available

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -91,6 +91,11 @@ build do
     #'--with-libatomic'
   ]
 
+  # HTTP/2 was introduced with nginx 1.9.5
+  if version.satisfies?(">= 1.9.5")
+    configure << "--with-http_v2_module"
+  end
+
   # Currently LuaJIT doesn't support POWER correctly so use Lua51 there instead
   if ppc64? || ppc64le? || s390x?
     configure << "--with-lua51=#{install_dir}/embedded/lib"


### PR DESCRIPTION
### Description

It became available with nginx 1.9.5, so it's available in any version of openresty >= 1.9.5.x.

This just enabled building the module, _using it_ requires adding `http2 default_server` to the server's `listen` directive.

(Just remembered I had this branch sitting here when I read #771.)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
