### PR TITLE
Add gems for ECC algorithm support.

### DIFF
--- a/config/software/bcrypt_pbkdf-ruby.rb
+++ b/config/software/bcrypt_pbkdf-ruby.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2012-2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "bcrypt_pbkdf-ruby"
+default_version "master"
+relative_path "bcrypt_pbkdf"
+
+source git: "https://github.com/mfazekas/bcrypt_pbkdf-ruby.git"
+
+license "MIT"
+license_file "COPYING"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_embedded_path()
+
+  bundle "install --without development", env: env
+  bundle "exec rake gem", env: env
+
+  delete "pkg/*java*"
+
+  gem "install pkg/bcrypt_pbkdf-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/config/software/rbnacl-libsodium.rb
+++ b/config/software/rbnacl-libsodium.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2012-2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rbnacl-libsodium"
+default_version "1.0.11"
+relative_path "rbnacl-libsodium"
+
+source git: "https://github.com/cryptosphere/rbnacl-libsodium.git"
+
+license "MIT"
+license_file "LICENSE"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_embedded_path()
+
+  bundle "install --without development_extras", env: env
+  bundle "exec rake gem", env: env
+
+  delete "pkg/*java*"
+
+  gem "install pkg/rbnacl-libsodium-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end


### PR DESCRIPTION
### Description

These definitions have been added to resolve build issues with ECC algorithm support.

The bcyrpt_pbkdf gem currently link against shared libs which are not installed on Cisco IOS-XR.

The rbnacl-libsodium gem currently fails to compile on Solaris for both x86-64 and SPARC architectures.

Adding these definitions will allow us to selectively define the supported platforms as well as provide a simple means to iterate on patches as needed.

--------------------------------------------------
/cc @chef/omnibus-maintainers