### PR TITLE
Using the correct build/copy command for Stunnel on Windows

### DIFF
--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -54,16 +54,21 @@ build do
     env["WIN32_SSL_DIR_PATCHED"] = "#{install_dir}/embedded"
 
     if windows_arch_i386?
-      make "mingw", env: env, cwd: "#{project_dir}/src"
+      windows_build_type = "mingw"
+      make windows_build_type, env: env, cwd: "#{project_dir}/src"
     else
-      make "mingw64", env: env, cwd: "#{project_dir}/src"
+      windows_build_type = "mingw64"
+      make windows_build_type, env: env, cwd: "#{project_dir}/src"
     end
 
-    mingw = ENV["MSYSTEM"].downcase
     msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
 
     block "copy required windows files" do
-      copy_files = ["#{project_dir}/bin/#{mingw}/stunnel.exe", "#{project_dir}/bin/#{mingw}/tstunnel.exe", "#{msys_path}/#{mingw}/bin/libssp-0.dll"]
+      copy_files = [
+        "#{project_dir}/bin/#{windows_build_type}/stunnel.exe",
+        "#{project_dir}/bin/#{windows_build_type}/tstunnel.exe",
+        "#{msys_path}/#{ENV["MSYSTEM"].downcase}/bin/libssp-0.dll",
+      ]
       copy_files.each do |file|
         if File.exist?(file)
           copy file, "#{install_dir}/embedded/bin/#{File.basename(file)}"

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -53,20 +53,15 @@ build do
     # an env variable to redirect it to the correct location
     env["WIN32_SSL_DIR_PATCHED"] = "#{install_dir}/embedded"
 
-    if windows_arch_i386?
-      windows_build_type = "mingw"
-      make windows_build_type, env: env, cwd: "#{project_dir}/src"
-    else
-      windows_build_type = "mingw64"
-      make windows_build_type, env: env, cwd: "#{project_dir}/src"
-    end
+    target = windows_arch_i386? ? "mingw" : "mingw64"
+    make target, env: env, cwd: "#{project_dir}/src"
 
     msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
 
     block "copy required windows files" do
       copy_files = [
-        "#{project_dir}/bin/#{windows_build_type}/stunnel.exe",
-        "#{project_dir}/bin/#{windows_build_type}/tstunnel.exe",
+        "#{project_dir}/bin/#{target}/stunnel.exe",
+        "#{project_dir}/bin/#{target}/tstunnel.exe",
         "#{msys_path}/#{ENV["MSYSTEM"].downcase}/bin/libssp-0.dll",
       ]
       copy_files.each do |file|


### PR DESCRIPTION
Signed-off-by: tyler-ball <tyleraball@gmail.com>

### Description

1. Sorry I have had so many PRs on the same software definiton
2. The ChefDK Windows builders are _only_ 32 bit, so (if I remember correctly) we left them on the old msys2 build toolchain instead of upgrading them to the TDM toolchain
3. This means that all my local tests were useless, so I only saw failures when sending things through the pipeline
4. I sent these changes through the pipeline and got green builds across all the systems - http://manhattan.ci.chef.co/job/chefdk-build/841/

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
