### PR TITLE
[BEN-132] - Fix omnibus-toolchain build for RHEL67 s390x platform

### DIFF
--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -41,7 +41,7 @@ build do
     configure_command << " --without-selinux"
   end
 
-  if nexus? || ios_xr?
+  if nexus? || ios_xr? || s390x?
     # ios_xr and nexus don't support posix acls
     configure_command << " --without-posix-acls"
   elsif osx?


### PR DESCRIPTION
Health check failed on s390x RHEL6 platform before this.

Successfully tested the rpm build on RHEL6 & 7 s390x platforms

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
