### PR TITLE
Make installation of `curl` work on Windows

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -49,8 +49,7 @@ build do
     env["LIBPATH"] = "/usr/lib:/lib"
   end
 
-  configure_command = [
-    "./configure",
+  configure_options = [
     "--prefix=#{install_dir}/embedded",
     "--disable-manual",
     "--disable-debug",
@@ -69,7 +68,7 @@ build do
     "--with-ca-bundle=#{install_dir}/embedded/ssl/certs/cacert.pem",
   ]
 
-  command configure_command.join(" "), env: env
+  configure(*configure_options, env: env)
 
   make "-j #{workers}", env: env
   make "install", env: env


### PR DESCRIPTION
### Description

Trying to build this on Windows was failing when trying to run `./configure`. Using the `configure` DSL command instead of the `command` DSL will do the right thing on Windows (and everywhere else).

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
