### PR TITLE
Revert runit back to 2.1.1

### DIFF
--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -15,7 +15,7 @@
 #
 
 name "runit"
-default_version "2.1.2"
+default_version "2.1.1"
 
 license "BSD-3-Clause"
 license_file "../package/COPYING"


### PR DESCRIPTION
Despite my initial review of these changes, it appears 2.1.2 does
include a change that breaks some of our tooling.  Namely, the following
change in sv.c:

```
@@ -153,20 +155,22 @@
   int rc;

   rc =svstatus_get();
-  switch(r) { case -1: if (lsb) done(4); case 0: return(0); }
+  switch(rc) { case -1: if (lsb) done(4); case 0: return(0); }
   rc =svstatus_print(*service);
+  islog =1;
   if (chdir("log") == -1) {
     if (errno != error_noent) {
-      outs("; log: "); outs(WARN);
-      outs("unable to change to log service directory: ");
-      outs(error_str(errno));
+      outs("; ");
+      warn("unable to change directory");
     }
+    else outs("\n");
   }
-  else
-    if (svstatus_get()) {
-      outs("; "); svstatus_print("log");
-    }
-  flush("\n");
+  else {
+    outs("; ");
+    if (svstatus_get()) { rc =svstatus_print("log"); outs("\n"); }
+  }
+  islog =0;
+  flush("");
   if (lsb) switch(rc) { case 1: done(0); case 2: done(3); case 0: done(4); }
   return(rc);
 }
```

will result in that status output for a service returning 0 when the
service is down provided that the log service is still up.

In our opinion, this is a bug in runit, so we are going to revert and
try to work with upstream to fix it.

Signed-off-by: Steven Danna <steve@chef.io>

---
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
