### PR TITLE
Update nokogiri license location

### DIFF
--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -17,7 +17,7 @@
 name "nokogiri"
 
 license "MIT"
-license_file "https://github.com/sparklemotion/nokogiri/blob/master/LICENSE.txt"
+license_file "https://raw.githubusercontent.com/sparklemotion/nokogiri/master/LICENSE.md"
 # We install only nokogiri from rubygems here.
 skip_transitive_dependency_licensing true
 


### PR DESCRIPTION
### Description

Nokogiri changed it's license file location causing builds to fail. This change updates the license file location with the new license file.

```
  [Builder: nokogiri] I | 2017-02-13T09:03:23+00:00 | Finished build
              [Licensing] I | 2017-02-13T09:03:23+00:00 | Retrying failed download due to 404 Not Found (5 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (4 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (3 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (2 retries left)...
              [Licensing] I | 2017-02-13T09:03:25+00:00 | Retrying failed download due to 404 Not Found (1 retries left)...
              [Licensing] E | 2017-02-13T09:03:25+00:00 | Download failed - OpenURI::HTTPError!
              [Licensing] W | 2017-02-13T09:03:25+00:00 | Can not download license file 'https://github.com/sparklemotion/nokogiri/blob/master/LICENSE.txt' for software 'nokogiri'.
```

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
