### PR TITLE
Import the veil-gem software def from chef-server

### DIFF
--- a/config/software/veil-gem.rb
+++ b/config/software/veil-gem.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name "veil-gem"
+default_version "master"
+source git: "https://github.com/chef/chef_secrets.git"
+
+license "Apache-2.0"
+license_file "LICENSE"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  delete "veil-*.gem"
+
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
+  gem "build veil.gemspec", env: env
+  gem "install veil*.gem --no-rdoc --no-ri --without development", env: env
+end


### PR DESCRIPTION
We likely want to use this in a number of add-ons as well so it would
be good to share it.  In the long run, it would be better to not have
this as an omnibus software definition at all. Instead, we should pull
it in via a Gemfile in the appropriate apps.  But, we aren't there yet.

Signed-off-by: Steven Danna <steve@chef.io>

/cc @chef/omnibus-maintainers 