### PR TITLE
[redis] Patch to read password from the environment

### DIFF
--- a/config/patches/redis/password-from-environment.patch
+++ b/config/patches/redis/password-from-environment.patch
@@ -1,0 +1,20 @@
+diff --git a/src/redis.c b/src/redis.c
+index 8e792c17..e31e0a28 100644
+--- a/src/redis.c
++++ b/src/redis.c
+@@ -3667,6 +3667,15 @@ int main(int argc, char **argv) {
+     } else {
+         redisLog(REDIS_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/%s.conf", argv[0], server.sentinel_mode ? "sentinel" : "redis");
+     }
++
++    if (!server.requirepass) {
++      const char* password = getenv("REDIS_PASSWORD");
++      if (password != NULL) {
++        server.requirepass = zstrdup(password);
++      }
++      unsetenv("REDIS_PASSWORD");
++    }
++
+     if (server.daemonize) daemonize();
+     initServer();
+     if (server.daemonize) createPidFile();

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -54,6 +54,12 @@ build do
 
   update_config_guess
 
+  # This patch was written against 3.0.7.  A slightly different patch
+  # will be needed if we upgrade to 3.2 or unstable.
+  if version.satisfies?(">= 3.0.7", "< 3.1")
+    patch source: "password-from-environment.patch", plevel: 1, env: env
+  end
+
   make "-j #{workers}", env: env
   make "install", env: env
 end


### PR DESCRIPTION
We are trying to reduce the number places where we have to render
passwords into configuration files. This patches redis to read the
REDIS_PASSWORD environment variable if the password isn't otherwise
configured.

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers