### PR TITLE
Update ca-certs to latest release.

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,9 +20,11 @@ license "MPL-2.0"
 license_file "https://github.com/bagder/ca-bundle/blob/master/README.md"
 skip_transitive_dependency_licensing true
 
-default_version "2016-04-20"
+default_version "2017-01-18"
 
 source url: "https://curl.haxx.se/ca/cacert-#{version}.pem"
+
+version("2017-01-18") { source sha256: "e62a07e61e5870effa81b430e1900778943c228bd7da1259dd6a955ee2262b47" }
 
 version "2016-04-20" do
   source md5: "782dcde8f5d53b1b9e888fdf113c42b9"


### PR DESCRIPTION
### Description

Update ca-certs to latest release.

We may want to consider forking the upstream certs and removing the StartCom  certs given the trust issues found with them.

https://blog.mozilla.org/security/2016/10/24/distrusting-new-wosign-and-startcom-certificates/
https://security.googleblog.com/2016/10/distrusting-wosign-and-startcom.html

--------------------------------------------------
/cc @chef/omnibus-maintainers