### PR TITLE
remove libiconv from ruby build

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Chef Software Inc.
+# Copyright 2014 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ dependency "curl"
 dependency "zlib"
 dependency "openssl"
 dependency "pcre"
+dependency "libiconv"
 dependency "expat"
 
 relative_path "git-#{version}"
@@ -88,7 +89,7 @@ build do
   config_hash = {
     # Universal options
     NO_GETTEXT: "YesPlease",
-    NO_ICONV: "YesPlease",
+    NEEDS_LIBICONV: "YesPlease",
     NO_INSTALL_HARDLINKS: "YesPlease",
     NO_PERL: "YesPlease",
     NO_PYTHON: "YesPlease",

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2014-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ dependency "curl"
 dependency "zlib"
 dependency "openssl"
 dependency "pcre"
-dependency "libiconv"
 dependency "expat"
 
 relative_path "git-#{version}"
@@ -89,7 +88,7 @@ build do
   config_hash = {
     # Universal options
     NO_GETTEXT: "YesPlease",
-    NEEDS_LIBICONV: "YesPlease",
+    NO_ICONV: "YesPlease",
     NO_INSTALL_HARDLINKS: "YesPlease",
     NO_PERL: "YesPlease",
     NO_PYTHON: "YesPlease",

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 dependency "zlib"
-dependency "libiconv"
 dependency "liblzma"
 dependency "config_guess"
 
@@ -43,7 +42,7 @@ build do
 
   configure_command = [
     "--with-zlib=#{install_dir}/embedded",
-    "--with-iconv=#{install_dir}/embedded",
+    "--without-iconv",
     "--without-python",
     "--without-icu",
   ]

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -1,5 +1,4 @@
-#
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +26,6 @@ using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.over
 unless using_prebuilt_ruby
   dependency "libxml2"
   dependency "libxslt"
-  dependency "libiconv"
   dependency "liblzma"
   dependency "zlib"
 end
@@ -75,7 +73,7 @@ build do
       "--with-xml2-include=#{install_dir}/embedded/include/libxml2",
       "--with-xslt-lib=#{install_dir}/embedded/lib",
       "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
-      "--with-iconv-dir=#{install_dir}/embedded",
+      "--without-iconv",
       "--with-zlib-dir=#{install_dir}/embedded",
     ]
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -29,11 +29,6 @@ dependency "zlib"
 dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
-# Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
-# they expect to see our libiconv instead of a system version.
-# Ignore on windows - TDM GCC comes with libiconv in the runtime
-# and that's the only one we will ever use.
-dependency "libiconv"
 
 version("2.4.1")      { source sha256: "a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250" }
 version("2.4.0")      { source sha256: "152fd0bd15a90b4a18213448f485d4b53e9f7662e1508190aa5b702446b29e3d" }


### PR DESCRIPTION
removes iconv from the ruby build and from omnibus-chef

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
