### PR TITLE
openssl: Apply upstream patch for solaris build

### DIFF
--- a/config/patches/openssl/openssl-1.0.1k-no-bang.patch
+++ b/config/patches/openssl/openssl-1.0.1k-no-bang.patch
@@ -1,0 +1,17 @@
+--- a/util/domd
++++ b/util/domd
+@@ -34,11 +34,11 @@ else
+     ${PERL} $TOP/util/clean-depend.pl < Makefile > Makefile.new
+     RC=$?
+ fi
+-if ! cmp -s Makefile.save Makefile.new; then
+-    mv Makefile.new Makefile
+-else
++if cmp -s Makefile.save Makefile.new; then
+     mv Makefile.save Makefile
+     rm -f Makefile.new
++else
++    mv Makefile.new Makefile
+ fi
+ # unfake the presence of Kerberos
+ rm $TOP/krb5.h

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -114,17 +114,21 @@ build do
       "#{prefix} disable-gost"
     end
 
-  if aix?
+  patch_env = if aix?
+                # This enables omnibus to use 'makedepend'
+                # from fileset 'X11.adt.imake' (AIX install media)
+                env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+                penv = env.dup
+                penv["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
+                penv
+              else
+                env
+              end
 
-    # This enables omnibus to use 'makedepend'
-    # from fileset 'X11.adt.imake' (AIX install media)
-    env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+  patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
 
-    patch_env = env.dup
-    patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
-  else
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
+  if version == "1.0.1k"
+    patch source: "openssl-1.0.1k-no-bang.patch", env: patch_env, plevel: 1
   end
 
   if windows?


### PR DESCRIPTION
See https://github.com/openssl/openssl/issues/2330

This patch was authored by Richard Levitte <levitte@openssl.org> who
is already in OpenSSL's AUTHORS file, so I think our existing
LICENSE/COPYRIGHT tracking code suffices in this case.

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers 