### PR TITLE
bzip2 Makefile: allow for CC ENV w/gcc as default

### DIFF
--- a/config/patches/bzip2/makefile_take_env_vars.patch
+++ b/config/patches/bzip2/makefile_take_env_vars.patch
@@ -1,15 +1,26 @@
---- bzip2-1.0.6/Makefile-orig	2010-09-10 17:46:02.000000000 -0500
-+++ bzip2-1.0.6/Makefile	2013-11-21 13:55:11.000000000 -0600
+--- bzip2-1.0.6/Makefile-orig   2010-09-10 17:46:02.000000000 -0500
++++ bzip2-1.0.6/Makefile        2013-11-21 13:55:11.000000000 -0600
 @@ -18,10 +18,10 @@
- CC=gcc
+-CC=gcc
++CC?=gcc
  AR=ar
  RANLIB=ranlib
 -LDFLAGS=
 +LDFLAGS+=
- 
+
  BIGFILES=-D_FILE_OFFSET_BITS=64
 -CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
 +CFLAGS+=-Wall -Winline -O2 -g $(BIGFILES)
- 
+
  # Where you want it installed when you do 'make install'
  PREFIX=/usr/local
+--- bzip2-1.0.6/Makefile-libbz2_so-orig   2017-03-21 19:43:16.706849481 +0000
++++ bzip2-1.0.6/Makefile-libbz2_so        2017-03-21 19:43:01.187851955 +0000
+@@ -22,7 +22,7 @@
+
+
+ SHELL=/bin/sh
+-CC=gcc
++CC?=gcc
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+ CFLAGS=-fpic -fPIC -Wall -Winline -O2 -g $(BIGFILES)


### PR DESCRIPTION
obvious fix

Signed-off-by: Isa <ifarnik@llnw.com>

### Description
`bzip2` doesn't include a `./configure` script and hardcodes for `gcc` in the `Makefile`.
This both ensures that on platforms without `gcc` (like FreeBSD) you can supply an alternate `CC` and that the default removes `gcc` (`+=` vs `?=`).

--------------------------------------------------
/cc @chef/omnibus-maintainers

see also: https://github.com/chef/omnibus-software/pull/251