### PR TITLE
Don't bundle test and integration with inspec

### DIFF
--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -33,7 +33,7 @@ dependency "rb-readline"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --with test integration --without tools maintenance", env: env
+  bundle "install --without test integration tools maintenance", env: env
 
   gem "build inspec.gemspec", env: env
   gem "install inspec-*.gem" \


### PR DESCRIPTION
Update the --with/--without for bundler to match what's done in
https://github.com/chef/inspec/blob/master/omnibus/config/software/inspec.rb.

Signed-off-by: Nathan L Smith <smith@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
