### PR TITLE
beat c99 into solaris 11 compiles

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -110,6 +110,9 @@ elsif solaris_10?
   else
     env["CFLAGS"] << " -std=c99 -O3 -g -pipe"
   end
+elsif solaris_11?
+  env["CFLAGS"] << " -std=c99"
+  env["CPPFLAGS"] << " -D_XOPEN_SOURCE=600 -D_XPG6"
 elsif windows?
   env["CPPFLAGS"] << " -DFD_SETSIZE=2048"
 else # including linux


### PR DESCRIPTION
fixes build breakages on chef-13 / rubby-2.4 of this form:

```
/usr/include/sys/feature_tests.h:332:2: #error "Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications"
```

its unclear to me why rubby 2.4 seems to now need this, but if you're going to define c99 then the solaris 11 header files explode helpfully for you if you're using _XOPEN_SOURCE < 600

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
