### PR TITLE
add TODO item to PRs for updating the omnibus cache

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,10 @@
 
 Briefly describe the new feature or fix here
 
+### TODOs
+
+Was a software definition added? Or a new version to an existing definition?
+- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod
+
 --------------------------------------------------
 /cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.


### PR DESCRIPTION
### Description

Adds a TODO item to remind PR submitters or approvers to confirm new software or versions have been added to the cache S3 bucket.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- yo