### PR TITLE
Correct md5 for different liblzma versions

### DIFF
--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -21,8 +21,10 @@ license "Public-Domain"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
-       md5: "ef68674fb47a8b8e741b34e429d86e9d"
+version("5.2.2") { source md5: "7cf6a8544a7dae8e8106fdf7addfa28c" }
+version("5.2.3") { source md5: "ef68674fb47a8b8e741b34e429d86e9d" }
+
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz"
 
 relative_path "xz-#{version}"
 


### PR DESCRIPTION
### Description

Pull #785 broke liblzma md5 for older versions.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
