### PR TITLE
Relocating Windows OpenSSL DLLs

### DIFF
--- a/config/patches/openssl/openssl-1.0.1j-windows-relocate-dll.patch
+++ b/config/patches/openssl/openssl-1.0.1j-windows-relocate-dll.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile.shared b/Makefile.shared
+index e8d222a..02ec85b 100644
+--- a/Makefile.shared
++++ b/Makefile.shared
+@@ -283,13 +283,12 @@ link_a.cygwin:
+ 	base=-Wl,--enable-auto-image-base; \
+ 	if expr $(PLATFORM) : 'mingw' > /dev/null; then \
+ 		case $(LIBNAME) in \
+-			crypto) SHLIB=libeay;; \
+-			ssl) SHLIB=ssleay;; \
++			crypto) SHLIB=libeay; base=-Wl,--image-base,0x64000000;; \
++			ssl) SHLIB=ssleay; base=-Wl,--image-base,0x65000000;; \
+ 		esac; \
+ 		SHLIB_SOVER=32; \
+ 		extras="$(LIBNAME).def"; \
+ 		$(PERL) util/mkdef.pl 32 $$SHLIB > $$extras; \
+-		base=; [ $(LIBNAME) = "crypto" -a -n "$(FIPSCANLIB)" ] && base=-Wl,--image-base,0x63000000; \
+ 	fi; \
+ 	dll_name=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX; \
+ 	$(PERL) util/mkrc.pl $$dll_name | \

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -143,6 +143,11 @@ build do
   configure_command = configure_args.unshift(configure_cmd).join(" ")
 
   command configure_command, env: env, in_msys_bash: true
+
+  if windows?
+    patch source: "openssl-1.0.1j-windows-relocate-dll.patch", env: env
+  end
+
   make "depend", env: env
   # make -j N on openssl is not reliable
   make env: env


### PR DESCRIPTION
### Description

When OpenSSL starts in FIPS mode it does a self-check. Part of this
self-check is looking at the openssl code loaded into memory and
ensuring it matches a known checksum. If Windows relocates the OpenSSL
DLLs because of an already-loaded image-base conflict then this
self-check will fail. So we hard code the image base for these items on
Windows to prevent them getting relocated

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
/cc @ksubrama 
