### PR TITLE
Use suse? instead of s390x? test where appropriate

### DIFF
--- a/config/software/keepalived.rb
+++ b/config/software/keepalived.rb
@@ -56,7 +56,7 @@ build do
     " --disable-iconv",
   ]
 
-  if s390x?
+  if suse?
     configure << "--with-kernel-dir=/usr/src/linux/include/uapi"
   end
 


### PR DESCRIPTION
The keepalived config incorrectly uses s390? instead of suse?, breaking the chef-server build on x86 sles. This fixes that.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
