### PR TITLE
Mark rake.bat as writable on windows

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -252,6 +252,11 @@ build do
       %w{ erb gem irb rdoc ri }.each do |cmd|
         copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
       end
+
+      # Ruby 2.4 seems to mark rake.bat as read-only.
+      # Mark it as writable so that we can install other version of rake without
+      # running into permission errors.
+      command "attrib -r #{install_dir}/embedded/bin/rake.bat"
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Kartik Null Cating-Subramanian <ksubramanian@chef.io>

### Description

Ruby 2.4 seems to mark rake.bat as read-only.  Mark it as writable so that we can install other version of rake without running into permission errors.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
