### PR TITLE
Copy cacerts to embedded/ssl/cert.pem on windows

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -41,6 +41,7 @@ build do
   mkdir "#{install_dir}/embedded/ssl/certs"
 
   copy "#{project_dir}/cacert*.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
+  copy "#{project_dir}/cacert*.pem", "#{install_dir}/embedded/ssl/cert.pem" if windows?
 
   # Windows does not support symlinks
   unless windows?


### PR DESCRIPTION
Need to copy this file into place, on Windows, if one may not symlink
as done on non-windows platforms.

Signed-off-by: Eric G. Wolfe <eric.wolfe@gmail.com>

### Description

I encountered an SSL verify problem using chef_ingredient on a Windows node that used this software definition.  Once I copied cacert.pem to ../cert.pem, the SSL verify problem was resolved.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
