### PR TITLE
Add PostgreSQL 9.2.21

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -28,6 +28,10 @@ dependency "ncurses"
 dependency "libossp-uuid"
 dependency "config_guess"
 
+version "9.2.21" do
+  source sha256: "0697e843523ee60c563f987f9c65bc4201294b18525d6e5e4b2c50c6d4058ef9"
+end
+
 version "9.2.14" do
   source md5: "ce2e50565983a14995f5dbcd3c35b627"
 end


### PR DESCRIPTION
This adds PostgreSQL 9.2.21 to the postgresql software definition.

### Description

This adds PostgreSQL 9.2.21.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [x] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod

--------------------------------------------------
/cc @chef/omnibus-maintainers