### PR TITLE
Restore pip (python package manager)

### DIFF
--- a/config/software/pip.rb
+++ b/config/software/pip.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2013-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "pip"
+default_version "9.0.1"
+
+dependency "setuptools"
+
+source url: "https://files.pythonhosted.org/packages/source/p/pip/pip-#{version}.tar.gz",
+       md5: "918559b784e2aca9559d498050bb86e7"
+
+relative_path "pip-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "#{install_dir}/embedded/bin/python setup.py install" \
+          " --prefix=#{install_dir}/embedded", env: env
+end


### PR DESCRIPTION
### Description

I believe removing `pip` in https://github.com/chef/omnibus-software/commit/6fc18506e5c4e24cd3fce9201610203b8154ef6d was a mistake. It's the standard package manager for Python

Modern Python versions now bundle pip, but many projects still rely on Python 2.7, which may have no pip, or a very outdated pip.

I have also updated the default pip version to `9.0.1`

### TODOs

Was a software definition added? Or a new version to an existing definition?

pip (python package manager) was reintroduced.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
