### PR TITLE
Fix libsodium download url for version < 1.0.9

### DIFF
--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -37,7 +37,11 @@ version "0.7.1" do
   source md5: "c224fe3923d1dcfe418c65c8a7246316"
 end
 
-source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+if Gem::Version.new("#{version}") > Gem::Version.new("1.0.8")
+  source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+else
+  source url: "https://download.libsodium.org/libsodium/releases/old/libsodium-#{version}.tar.gz"
+end
 
 relative_path "libsodium-#{version}"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -37,7 +37,7 @@ version "0.7.1" do
   source md5: "c224fe3923d1dcfe418c65c8a7246316"
 end
 
-if Gem::Version.new("#{version}") > Gem::Version.new("1.0.8")
+if version.satisfies?(">= 1.0.9")
   source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 else
   source url: "https://download.libsodium.org/libsodium/releases/old/libsodium-#{version}.tar.gz"


### PR DESCRIPTION
### Description

Fix issue #849 

### TODOs

I updated libsodium url if version < 1.0.9

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
