### PR TITLE
Bump redis-gem and sequel-gem

### DIFF
--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -15,7 +15,7 @@
 #
 
 name "redis-gem"
-default_version "3.1.0"
+default_version "3.3.3"
 
 license "MIT"
 license_file "https://github.com/redis/redis-rb/blob/master/LICENSE"

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -15,7 +15,7 @@
 #
 
 name "sequel-gem"
-default_version "4.13.0"
+default_version "4.47.0"
 
 license "MIT"
 license_file "https://github.com/jeremyevans/sequel/blob/master/MIT-LICENSE"


### PR DESCRIPTION
### Description

Both of these had `default_version`s that make Ruby 2.4.x output
warnings on every require:

```
/opt/opscode/embedded/lib/ruby/gems/2.4.0/gems/sequel-4.13.0/lib/sequel/database/schema_generator.rb:19: warning: constant ::Fixnum is deprecated
/opt/opscode/embedded/lib/ruby/gems/2.4.0/gems/sequel-4.13.0/lib/sequel/database/schema_generator.rb:19: warning: constant ::Bignum is deprecated
/var/opt/opscode/local-mode-cache/cookbooks/packagecloud/resources/repo.rb:10: warning: constant ::Fixnum is deprecated
/opt/opscode/embedded/lib/ruby/gems/2.4.0/gems/redis-3.1.0/lib/redis/client.rb:406: warning: constant ::Fixnum is deprecated
Chef Server Reconfigured!
```

When it come to our projects, sequel-gem is only used by chef-server
and marketplace; redis-gem only by chef-server.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) ~Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod~ doesn't apply, taken from rubygems

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
