### PR TITLE
Use raw.githubusercontent.com links

### DIFF
--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -22,7 +22,7 @@ name "berkshelf2"
 default_version "2.0.18"
 
 license "Apache-2.0"
-license_file "https://github.com/berkshelf/berkshelf/blob/2-0-stable/LICENSE"
+license_file "https://raw.githubusercontent.com/berkshelf/berkshelf/2-0-stable/LICENSE"
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,7 @@
 name "cacerts"
 
 license "MPL-2.0"
-license_file "https://github.com/bagder/ca-bundle/blob/master/README.md"
+license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
 default_version "2017-06-07"

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -18,7 +18,7 @@ name "chef-gem"
 default_version "11.12.2"
 
 license "Apache-2.0"
-license_file "https://github.com/chef/chef/blob/master/LICENSE"
+license_file "https://raw.githubusercontent.com/chef/chef/master/LICENSE"
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -18,7 +18,7 @@ name "dep-selector-libgecode"
 default_version "1.3.1"
 
 license "Apache-2.0"
-license_file "https://github.com/chef/dep-selector-libgecode/blob/master/LICENSE.txt"
+license_file "https://raw.githubusercontent.com/chef/dep-selector-libgecode/master/LICENSE.txt"
 # dep-selector-libgecode does not have any dependencies. We only install it from
 # rubygems here.
 skip_transitive_dependency_licensing true

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -18,7 +18,7 @@ name "highline-gem"
 default_version "1.6.21"
 
 license "Ruby"
-license_file "https://github.com/JEG2/highline/blob/master/LICENSE"
+license_file "https://raw.githubusercontent.com/JEG2/highline/master/LICENSE"
 license_file "http://www.ruby-lang.org/en/LICENSE.txt"
 # highline does not have any dependencies. We only install it from
 # rubygems here.

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -18,7 +18,7 @@ name "omnibus-ctl"
 default_version "0.3.6"
 
 license "Apache-2.0"
-license_file "https://github.com/chef/omnibus-ctl/blob/master/LICENSE"
+license_file "https://raw.githubusercontent.com/chef/omnibus-ctl/master/LICENSE"
 # Even though omnibus-ctl is a gem, it does not have any dependencies.
 skip_transitive_dependency_licensing true
 

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -18,8 +18,8 @@ name "pg-gem"
 default_version "0.17.1"
 
 license "BSD-2-Clause"
-license_file "https://github.com/ged/ruby-pg/blob/master/LICENSE"
-license_file "https://github.com/ged/ruby-pg/blob/master/BSDL"
+license_file "https://raw.githubusercontent.com/ged/ruby-pg/master/LICENSE"
+license_file "https://raw.githubusercontent.com/ged/ruby-pg/master/BSDL"
 # pg gem does not have any dependencies. We only install it from
 # rubygems here.
 skip_transitive_dependency_licensing true

--- a/config/software/pry.rb
+++ b/config/software/pry.rb
@@ -17,7 +17,7 @@
 name "pry"
 
 license "MIT"
-license_file "https://github.com/pry/pry/blob/master/LICENSE"
+license_file "https://raw.githubusercontent.com/pry/pry/master/LICENSE"
 
 skip_transitive_dependency_licensing true
 

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -18,7 +18,7 @@ name "redis-gem"
 default_version "3.3.3"
 
 license "MIT"
-license_file "https://github.com/redis/redis-rb/blob/master/LICENSE"
+license_file "https://raw.githubusercontent.com/redis/redis-rb/master/LICENSE"
 # redis gem does not have any dependencies. We only install it from
 # rubygems here.
 skip_transitive_dependency_licensing true

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -18,7 +18,7 @@ name "sequel-gem"
 default_version "4.47.0"
 
 license "MIT"
-license_file "https://github.com/jeremyevans/sequel/blob/master/MIT-LICENSE"
+license_file "https://raw.githubusercontent.com/jeremyevans/sequel/master/MIT-LICENSE"
 # sequel gem does not have any dependencies. We only install it from
 # rubygems here.
 skip_transitive_dependency_licensing true

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -18,7 +18,7 @@ name "sqitch"
 default_version "0.973"
 
 license "MIT"
-license_file "https://github.com/theory/sqitch/blob/master/README.md"
+license_file "https://raw.githubusercontent.com/theory/sqitch/master/README.md"
 
 dependency "perl"
 dependency "cpanminus"


### PR DESCRIPTION
Added raw github links to pull plain-text instead of github HTML
for the following components:

  * berkshelf2
  * chef-gem
  * dep-selector-libgecode
  * highline-gem
  * omnibus-ctl
  * pg-gem
  * pry
  * redis-gem
  * sequel-gem
  * sqitch

Added the plain-text of MPL-2.0 for:

  * cacerts

Signed-off-by: Eric G. Wolfe <eric.wolfe@gmail.com>

### Description

Cleanup raw github plain-text links.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
