### PR TITLE
[erlang] patch epmd when >= 18.3

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -35,7 +35,7 @@ version("18.3") { source md5: "7e4ff32f97c36fb3dab736f8d481830b" }
 version("20.0") { source md5: "2faed2c3519353e6bc2501ed4d8e6ae7" }
 
 build do
-  if version.satisfies?(">= 20.0")
+  if version.satisfies?(">= 18.3")
     # Don't listen on 127.0.0.1/::1 implicitly whenever ERL_EPMD_ADDRESS is given
     patch source: "epmd-require-explicitly-adding-loopback-address.patch", plevel: 1
   end


### PR DESCRIPTION
That's the version Chef-Server uses, and that's what finally allows us to remove the check-and-fail kludge. [See PR here](https://github.com/chef/chef-server/pull/1328).

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [X] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod 🆗 _does not apply_
- [X] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out). [✅](http://wilson.ci.chef.co/job/chef-server-12-build/1063/)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
