### PR TITLE
[openresty/nginx] add 1.11.2.4, and patch bundled nginx (CVE-2017-7529) in 1.11.2.1; update and bump nginx

### DIFF
--- a/config/patches/openresty/v1.11.2.1_bundled-nginx-cve-2017-7529.patch
+++ b/config/patches/openresty/v1.11.2.1_bundled-nginx-cve-2017-7529.patch
@@ -1,0 +1,73 @@
+diff -ru openresty-1.11.2.1/bundle/nginx-1.11.2/docs/html/index.html openresty-1.11.2.4/bundle/nginx-1.11.2/docs/html/index.html
+--- openresty-1.11.2.1/bundle/nginx-1.11.2/docs/html/index.html	2016-08-25 02:20:57.000000000 +0200
++++ openresty-1.11.2.4/bundle/nginx-1.11.2/docs/html/index.html	2017-07-11 19:36:36.000000000 +0200
+@@ -16,7 +16,7 @@
+ working. Further configuration is required.</p>
+
+ <p>For online documentation and support please refer to
+-<a href="https://openresty.org/">openresty.org</a>.<br/>
++<a href="https://openresty.org/">openresty.org</a>.<br/></p>
+
+ <p><em>Thank you for flying OpenResty.</em></p>
+ </body>
+diff -ru openresty-1.11.2.1/bundle/nginx-1.11.2/src/core/nginx.h openresty-1.11.2.4/bundle/nginx-1.11.2/src/core/nginx.h
+--- openresty-1.11.2.1/bundle/nginx-1.11.2/src/core/nginx.h	2016-08-25 02:20:57.000000000 +0200
++++ openresty-1.11.2.4/bundle/nginx-1.11.2/src/core/nginx.h	2017-07-11 19:36:35.000000000 +0200
+@@ -11,7 +11,7 @@
+
+ #define nginx_version      1011002
+ #define NGINX_VERSION      "1.11.2"
+-#define NGINX_VER          "openresty/" NGINX_VERSION ".1"
++#define NGINX_VER          "openresty/" NGINX_VERSION ".4"
+
+ #ifdef NGX_BUILD
+ #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
+diff -ru openresty-1.11.2.1/bundle/nginx-1.11.2/src/core/ngx_resolver.c openresty-1.11.2.4/bundle/nginx-1.11.2/src/core/ngx_resolver.c
+--- openresty-1.11.2.1/bundle/nginx-1.11.2/src/core/ngx_resolver.c	2016-07-18 04:19:50.000000000 +0200
++++ openresty-1.11.2.4/bundle/nginx-1.11.2/src/core/ngx_resolver.c	2017-07-11 19:36:36.000000000 +0200
+@@ -224,14 +224,22 @@
+             continue;
+         }
+
+-#if (NGX_HAVE_INET6)
+         if (ngx_strncmp(names[i].data, "ipv6=", 5) == 0) {
+
+             if (ngx_strcmp(&names[i].data[5], "on") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 1;
++#else
++                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                   "no ipv6 support but \"%V\" in resolver",
++                                   &names[i]);
++                return NULL;
++#endif
+
+             } else if (ngx_strcmp(&names[i].data[5], "off") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 0;
++#endif
+
+             } else {
+                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+@@ -241,7 +249,6 @@
+
+             continue;
+         }
+-#endif
+
+         ngx_memzero(&u, sizeof(ngx_url_t));
+
+diff -ru openresty-1.11.2.1/bundle/nginx-1.11.2/src/http/modules/ngx_http_range_filter_module.c openresty-1.11.2.4/bundle/nginx-1.11.2/src/http/modules/ngx_http_range_filter_module.c
+--- openresty-1.11.2.1/bundle/nginx-1.11.2/src/http/modules/ngx_http_range_filter_module.c	2016-07-18 04:19:50.000000000 +0200
++++ openresty-1.11.2.4/bundle/nginx-1.11.2/src/http/modules/ngx_http_range_filter_module.c	2017-07-11 19:36:35.000000000 +0200
+@@ -377,6 +377,10 @@
+             range->start = start;
+             range->end = end;
+
++            if (size > NGX_MAX_OFF_T_VALUE - (end - start)) {
++                return NGX_HTTP_RANGE_NOT_SATISFIABLE;
++            }
++
+             size += end - start;
+
+             if (ranges-- == 0) {

--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -15,7 +15,7 @@
 #
 
 name "nginx"
-default_version "1.8.1"
+default_version "1.13.3"
 
 dependency "pcre"
 dependency "openssl"
@@ -25,6 +25,8 @@ license_file "LICENSE"
 
 source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
 
+version("1.13.3") { source sha256: "5b73f98004c302fb8e4a172abf046d9ce77739a82487e4873b39f9b0dcbb0d72" }
+version("1.12.1") { source sha256: "8793bf426485a30f91021b6b945a9fd8a84d87d17b566562c3797aba8fac76fb" }
 version("1.10.2") { source md5: "e8f5f4beed041e63eb97f9f4f55f3085" }
 version("1.9.1") { source md5: "fc054d51effa7c80a2e143bc4e2ae6a7" }
 version("1.8.1") { source md5: "2e91695074dbdfbf1bcec0ada9fda462" }

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -18,7 +18,7 @@ name "openresty"
 license "BSD-2-Clause"
 license_file "README.markdown"
 skip_transitive_dependency_licensing true
-default_version "1.11.2.1"
+default_version "1.11.2.4"
 
 dependency "pcre"
 dependency "openssl"
@@ -27,6 +27,7 @@ dependency "lua" if ppc64? || ppc64le? || s390x?
 
 source_package_name = "openresty"
 
+version("1.11.2.4") { source sha256: "07679171450a6c083f983f6130056de3c4e13cc2d117dea68e1c6990e2e49ac9" }
 version("1.11.2.1") { source md5: "f26d152f40c5263b383a5b7c826a6c7e" }
 version("1.9.7.3") { source md5: "33579b96a8c22bedee97eadfc99d9564" }
 

--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -63,6 +63,10 @@ build do
     patch source: "v1.7.10.1.ppc64le-configure.patch", plevel: 1
   end
 
+  if version == "1.11.2.1"
+    patch source: "v1.11.2.1_bundled-nginx-cve-2017-7529.patch", plevel: 1
+  end
+
   configure = [
     "./configure",
     "--prefix=#{install_dir}/embedded",


### PR DESCRIPTION
There has been [a security fix in nginx](http://mailman.nginx.org/pipermail/nginx-announce/2017/000200.html), which was backported in openrest 1.11.2.4. However, I couldn't get 1.11.2.4 to build on ppc64[le] or s390x, so I've backported the fix to v1.11.2.1 ([That's the fix](https://github.com/openresty/openresty/commit/58f39e963fdfeb342047a4ef33d500ffa0373ee6), however, it's impact on the bundled sources looks a little different, as can be seen from the included patch.)

I've still included the latest version, for those projects we build that that don't depend on said architectures.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [X] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod
- [X] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out). Chef-Server [✅](http://wilson.ci.chef.co/view/Chef%20Server/job/chef-server-build/lastSuccessfulBuild/downstreambuildview/) Automate [✅](http://wilson.ci.chef.co/job/automate-build/600/downstreambuildview/)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
