### PR TITLE
Fix libtool bug for Solaris11

### DIFF
--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -40,8 +40,8 @@ build do
 
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
-  elsif sparc? && solaris_11?
-    # We hit this bug on sparc platforms bug#14291: libtool 2.4.2 fails to build due to macro_revision	reversion
+  elsif solaris_11?
+    # We hit this bug on Solaris11 platforms bug#14291: libtool 2.4.2 fails to build due to macro_revision	reversion
     # The problem occurs with LANG=en_US.UTF-8 but not with LANG=C
     env["LANG"] = "C"
   end


### PR DESCRIPTION
Fix Solaris11 libtool bug#14291: libtool 2.4.2 fails to build due to macro_revision
The problem occurs with LANG=en_US.UTF-8 but not with LANG=C

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

@chef/engineering-services 

### Description

Briefly describe the new feature or fix here

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
