### PR TITLE
Copy libstdc++ into the install as well

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -239,7 +239,7 @@ build do
     # it how to statically link yet
     dlls = [
       "libwinpthread-1",
-      "libstdc++-6"
+      "libstdc++-6",
     ]
     if windows_arch_i386?
       dlls << "libgcc_s_dw2-1"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -237,12 +237,16 @@ build do
   if windows?
     # Needed now that we switched to msys2 and have not figured out how to tell
     # it how to statically link yet
-    dlls = ["libwinpthread-1"]
+    dlls = [
+      "libwinpthread-1",
+      "libstdc++-6"
+    ]
     if windows_arch_i386?
       dlls << "libgcc_s_dw2-1"
     else
       dlls << "libgcc_s_seh-1"
     end
+
     dlls.each do |dll|
       mingw = ENV["MSYSTEM"].downcase
       msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"


### PR DESCRIPTION
Otherwise, some native gem extensions and other things won't work.  We
should probably move *all* of the standard libraries from
omnibus-toolchain into the installation regardless of what software is
built.  But, I'm putting this here for now rather than duplicating
this code.

Signed-off-by: Steven Danna <steve@chef.io>

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
