### PR TITLE
pcre: 8.35

### DIFF
--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -29,6 +29,10 @@ version "8.38" do
   source md5: "8a353fe1450216b6655dfcf3561716d9"
 end
 
+version "8.35" do
+  source md5: "ed58bcbe54d3b1d59e9f5415ef45ce1c"
+end
+
 version "8.31" do
   source md5: "fab1bb3b91a4c35398263a5c1e0858c1"
 end


### PR DESCRIPTION
### Description

`pcre: 8.35`

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).
- [ ] (Chef employee) Add software tarball/gz/zip/whatevs to the opscode-omnibus-cache S3 bucket in preprod

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
