### PR TITLE
Correct the version number for the Ruby 2.2.X CVE fix

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -40,7 +40,7 @@ version("2.3.3")      { source sha256: "241408c8c555b258846368830a06146e4849a1d5
 version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }
 version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 
-version("2.2.7")      { source sha256: "8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a" }
+version("2.2.8")      { source sha256: "8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a" }
 version("2.2.6")      { source sha256: "de8e192791cb157d610c48a9a9ff6e7f19d67ce86052feae62b82e3682cc675f" }
 version("2.2.5")      { source md5: "bd8e349d4fb2c75d90817649674f94be" }
 version("2.2.4")      { source md5: "9a5e15f9d5255ba37ace18771b0a8dd2" }


### PR DESCRIPTION
Thanks to @jeremiahsnapp for noticing my mistake here

Signed-off-by: Tim Smith <tsmith@chef.io>