### PR TITLE
Avoid Lists::MoreUtils::XS because of EL 5 failures

### DIFF
--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -41,7 +41,11 @@ relative_path "App-Sqitch-#{version}"
 # See https://github.com/theory/sqitch for more
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-
+  # Lists-MoreUtils-XS does not build on RHEL 5 or SUSE 11 currently.
+  # This option is used by the Lists-MoreUtils build configuration to
+  # decide whether to use the -XS package or a pure perl
+  # implementation.
+  env["PERL_MM_OPT"] = "PUREPERL_ONLY=1"
   command "perl Build.PL", env: env
   command "./Build installdeps --cpan_client 'cpanm -v --notest'", env: env
   command "./Build", env: env


### PR DESCRIPTION
Lists::MoreUtils is a transitive dependency of sqitch.  In the default
configuration, it depends on Lists::MoreUtils::XS.

The Lists::MoreUtils::XS perl module fails to install correctly. The
issue is bad assumptions in its configuration script leading to a
duplicate definition of ssize_t leading to a failed compilation.

The PUREPERL_ONLY option avoids this module by substituting a pure
perl implementation.

Signed-off-by: Steven Danna <steve@chef.io>
