### PR TITLE
Add skip_transitive_dependency_licensing for libsodium and libzmq

### DIFF
--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -21,6 +21,7 @@ default_version "1.0.2"
 
 license "ISC"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 # Depend on the msys2/mingw environment given to us and don't build our
 # own build tools on windows.

--- a/config/software/libzmq.rb
+++ b/config/software/libzmq.rb
@@ -21,6 +21,7 @@ default_version "2.1.11"
 license "LGPL-3.0"
 license_file "COPYING"
 license_file "COPYING.LESSER"
+skip_transitive_dependency_licensing true
 
 # Depend on the msys2/mingw environment given to us and don't build our
 # own build tools on windows.

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -279,6 +279,12 @@ build do
         copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
       end
     end
+
+    # Ruby 2.4 seems to mark rake.bat as read-only.
+    # Mark it as writable so that we can install other version of rake without
+    # running into permission errors.
+    command "attrib -r #{install_dir}/embedded/bin/rake.bat"
+
   end
 
 end


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
