### PR TITLE
update libxml2 and libxslt

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxml2"
-default_version "2.9.4"
+default_version "2.9.5"
 
 license "MIT"
 license_file "COPYING"
@@ -24,6 +24,10 @@ skip_transitive_dependency_licensing true
 dependency "zlib"
 dependency "liblzma"
 dependency "config_guess"
+
+version "2.9.5" do
+  source sha256: "4031c1ecee9ce7ba4f313e91ef6284164885cdb69937a123f6a83bb6a72dcd38"
+end
 
 version "2.9.4" do
   source md5: "ae249165c173b1ff386ee8ad676815f5"

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxslt"
-default_version "1.1.29"
+default_version "1.1.30"
 
 license "MIT"
 license_file "COPYING"
@@ -24,6 +24,10 @@ skip_transitive_dependency_licensing true
 dependency "libxml2"
 dependency "liblzma"
 dependency "config_guess"
+
+version "1.1.30" do
+  source sha256: "ba65236116de8326d83378b2bd929879fa185195bc530b9d1aba72107910b6b3"
+end
 
 version "1.1.29" do
   source md5: "a129d3c44c022de3b9dcf6d6f288d72e"


### PR DESCRIPTION
Based on the work done in the nokogiri project to address multiple CVEs
in libxml2 and libxslt.

https://usn.ubuntu.com/usn/usn-3424-1/

CVE-2017-0663, CVE-2017-7375, CVE-2017-7376, CVE-2017-9047,
CVE-2017-9048, CVE-2017-9049, CVE-2017-9050

https://github.com/sparklemotion/nokogiri/issues/1673
https://github.com/sparklemotion/nokogiri/issues/1670

SHA256 generated from downloads. Downloads verified with GPG:

    gpg --verify libxml2-2.9.5.tar.gz.asc libxml2-2.9.5.tar.gz
    gpg: Signature made Mon Sep  4 09:00:53 2017 EDT using RSA key ID 596BEA5D
    gpg: Good signature from "Daniel Veillard (Red Hat work email) <veillard@redhat.com>" [unknown]
    gpg:                 aka "Daniel Veillard <Daniel.Veillard@w3.org>" [unknown]
    gpg: WARNING: This key is not certified with a trusted signature!
    gpg:          There is no indication that the signature belongs to the owner.
    Primary key fingerprint: C744 15BA 7C9C 7F78 F02E  1DC3 4606 B8A5 DE95 BC1F
         Subkey fingerprint: DB46 681B B91A DCEA 170F  A2D4 1558 8B26 596B EA5D

    gpg --verify libxslt-1.1.30.tar.gz.asc libxslt-1.1.30.tar.gz
    gpg: Signature made Mon Sep  4 09:36:06 2017 EDT using RSA key ID 596BEA5D
    gpg: Good signature from "Daniel Veillard (Red Hat work email) <veillard@redhat.com>" [unknown]
    gpg:                 aka "Daniel Veillard <Daniel.Veillard@w3.org>" [unknown]
    gpg: WARNING: This key is not certified with a trusted signature!
    gpg:          There is no indication that the signature belongs to the owner.
    Primary key fingerprint: C744 15BA 7C9C 7F78 F02E  1DC3 4606 B8A5 DE95 BC1F
         Subkey fingerprint: DB46 681B B91A DCEA 170F  A2D4 1558 8B26 596B EA5D
