### PR TITLE
update curl

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.53.1"
+default_version "7.56.0"
 
 dependency "zlib"
 dependency "openssl"
@@ -24,7 +24,7 @@ dependency "cacerts"
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
-
+version("7.56.0") { source sha256: "f1bc17a7e5662dbd8d4029750a6dbdb72a55cf95826a270ab388b05075526104" }
 version("7.53.1") { source sha256: "64f9b7ec82372edb8eaeded0a9cfa62334d8f98abc65487da01188259392911d" }
 version("7.51.0") { source sha256: "65b5216a6fbfa72f547eb7706ca5902d7400db9868269017a8888aa91d87977c" }
 version("7.47.1") { source md5: "3f9d1be7bf33ca4b8c8602820525302b" }


### PR DESCRIPTION
This updates the version of curl to 7.56.0. This version is necessary because the newest versions of XCode and other software necessary to compile curl will cause older versions of curl to fail.

Of course, curl 7.56.0 also fixes several security issues, so we should update to it anyway.

Note that this change will break folks using the omnibus s3 chef cache since curl 7.56.0 is not cached there. I don't know how to get something cached there. :)



Signed-off-by: echohack <echohack@users.noreply.github.com>
