### PR TITLE
Fix building OpenSSL 1.1.0 (port no-docs patch to 1.1)

### DIFF
--- a/config/patches/openssl/openssl-1.1.0f-do-not-install-docs.patch
+++ b/config/patches/openssl/openssl-1.1.0f-do-not-install-docs.patch
@@ -1,0 +1,11 @@
+--- openssl-1.1.0f/Configurations/unix-Makefile.tmpl.orig	2017-10-22 13:23:48.592533617 +0300
++++ openssl-1.1.0f/Configurations/unix-Makefile.tmpl	2017-10-22 13:26:21.199065333 +0300
+@@ -260,7 +260,7 @@
+ 	@echo "Tests are not supported with your chosen Configure options"
+ 	@ : {- output_on() if !$disabled{tests}; "" -}
+ 
+-install: install_sw install_ssldirs install_docs
++install: install_sw install_ssldirs
+ 
+ uninstall: uninstall_docs uninstall_sw
+ 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -127,7 +127,11 @@ build do
                 env
               end
 
-  patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
+  if version.start_with? "1.0"
+    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
+  elsif version.start_with? "1.1"
+    patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
+  end
 
   if version == "1.0.2k"
     patch source: "openssl-1.0.2k-no-bang.patch", env: patch_env, plevel: 1


### PR DESCRIPTION
Signed-off-by: Anssi Kolehmainen <anssi.kolehmainen@vilant.com>

### Description

Currently omnibus fails to build openssl 1.1.x because existing patch (openssl-1.0.1f-do-not-build-docs) fails to apply.

Added version checks for the patch and made similar patch for openssl 1.1

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
