### PR TITLE
Update PostgreSQL to 10.0 and build pg gem based on it

### DIFF
--- a/config/patches/postgresql/postgresql-10.0-do-not-build-server.patch
+++ b/config/patches/postgresql/postgresql-10.0-do-not-build-server.patch
@@ -1,0 +1,46 @@
+diff -ru postgresql-10.0-org/src/bin/Makefile postgresql-10.0/src/bin/Makefile
+--- postgresql-10.0-org/src/bin/Makefile	2017-10-22 14:56:50.371010822 +0300
++++ postgresql-10.0/src/bin/Makefile	2017-10-22 14:58:08.026272180 +0300
+@@ -14,22 +14,7 @@
+ include $(top_builddir)/src/Makefile.global
+ 
+ SUBDIRS = \
+-	initdb \
+-	pg_archivecleanup \
+-	pg_basebackup \
+-	pg_config \
+-	pg_controldata \
+-	pg_ctl \
+-	pg_dump \
+-	pg_resetwal \
+-	pg_rewind \
+-	pg_test_fsync \
+-	pg_test_timing \
+-	pg_upgrade \
+-	pg_waldump \
+-	pgbench \
+-	psql \
+-	scripts
++	pg_config
+ 
+ ifeq ($(PORTNAME), win32)
+ SUBDIRS += pgevent
+diff -ru postgresql-10.0-org/src/Makefile postgresql-10.0/src/Makefile
+--- postgresql-10.0-org/src/Makefile	2017-10-22 14:56:50.367010859 +0300
++++ postgresql-10.0/src/Makefile	2017-10-22 14:57:48.154461245 +0300
+@@ -15,14 +15,9 @@
+ SUBDIRS = \
+ 	common \
+ 	port \
+-	timezone \
+ 	backend \
+-	backend/utils/mb/conversion_procs \
+-	backend/snowball \
+ 	include \
+ 	interfaces \
+-	backend/replication/libpqwalreceiver \
+-	backend/replication/pgoutput \
+ 	fe_utils \
+ 	bin \
+ 	pl \
+Only in postgresql-10.0/src: Makefile.orig

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -15,15 +15,16 @@
 #
 
 name "pg-gem"
-default_version "0.17.1"
+default_version "0.21.0"
 
 license "BSD-2-Clause"
 license_file "https://raw.githubusercontent.com/ged/ruby-pg/master/LICENSE"
 license_file "https://raw.githubusercontent.com/ged/ruby-pg/master/BSDL"
-# pg gem does not have any dependencies. We only install it from
-# rubygems here.
+
 skip_transitive_dependency_licensing true
 
+# pg gem needs libpq through omnibus so to use same version of libssl
+dependency "postgresql"
 dependency "ruby"
 dependency "rubygems"
 
@@ -33,5 +34,7 @@ build do
   gem "install pg" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc" \
+      " -- " \
+      " --with-pg-config=#{install_dir}/embedded/bin/pg_config", env: env
 end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.2.10"
+default_version "10.0"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -27,6 +27,10 @@ dependency "libedit"
 dependency "ncurses"
 dependency "libossp-uuid"
 dependency "config_guess"
+
+version "10.0" do
+  source sha256: "712f5592e27b81c5b454df96b258c14d94b6b03836831e015c65d6deeae57fd1"
+end
 
 version "9.2.22" do
   source sha256: "a70e94fa58776b559a8f7b5301371ac4922c9e3ed313ccbef20862514de7c192"
@@ -124,8 +128,15 @@ source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{vers
 
 relative_path "postgresql-#{version}"
 
+dependency "openssl"
+dependency "zlib"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
+  if version.start_with? "10"
+    patch source: "postgresql-10.0-do-not-build-server.patch"
+  end
 
   update_config_guess(target: "config")
 
@@ -134,9 +145,11 @@ build do
           " --with-libedit-preferred" \
           " --with-openssl" \
           " --with-ossp-uuid" \
+          " --with-zlib" \
+          " --without-readline" \
           " --with-includes=#{install_dir}/embedded/include" \
           " --with-libraries=#{install_dir}/embedded/lib", env: env
 
-  make "world -j #{workers}", env: env
-  make "install-world", env: env
+  make "-j #{workers}", env: env
+  make "install", env: env
 end


### PR DESCRIPTION
### Description

Work based on https://github.com/chef/chef-rfc/blob/master/rfc063-omnibus-chef-native-gems.md

This allows adding postgresql gem (pg) to Chef client package

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
