### PR TITLE
[JEX-707] WIP - Configure expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,0 +1,19 @@
+# Documentation available at https://expeditor-docs.es.chef.io/
+
+# Slack channel in Chef Software slack to send notifications about build failures, etc
+slack:
+  notify_channel: eng-services-notify
+
+github:
+  # The Github Team primarily responsible for handling incoming Pull Requests.
+  maintainer_group: chef/engineering-services
+  # Which Github branches to build Omnibus releases from, and what versions
+  release_branch:
+    - master
+
+# These actions are taken, in order they are specified, anytime a Pull Request is merged.
+merge_actions:
+   - built_in:trigger_omnibus_build:
+      ignore_labels:
+        - "Omnibus: Skip Build"
+        - "Expeditor: Skip All"


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Configure expeditor so, we can have other projects subscribe to the "pull_request_merged" action, allowing them to run adhoc (or release) builds anytime it's updated.

### TODOs

Check with @tduffield on how to enable expire cache for this trigger.

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
