### PR TITLE
appbundle inspec for quicker runs

### DIFF
--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -29,6 +29,7 @@ dependency "nokogiri"
 # Dependency added to avoid this pry error:
 # "Sorry, you can't use Pry without Readline or a compatible library."
 dependency "rb-readline"
+dependency "appbundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -38,4 +39,6 @@ build do
   gem "build inspec.gemspec", env: env
   gem "install inspec-*.gem" \
       " --no-ri --no-rdoc", env: env
+
+  appbundle "inspec", env: env
 end


### PR DESCRIPTION
### Description

Appbundling inspec in order to:
 * make it quicker by only loading it's dependent gems
 * have cleaner output as rpsec is no longer complaining about gem versions, like before:
```
[root@ap-ca66 ~]# time /opt/delivery/embedded/bin/inspec version
WARN: Unresolved specs during Gem::Specification.reset:
      net-ssh (< 5.0, >= 2.6.5, >= 2.9)
      httpclient (>= 2.2.0.2, ~> 2.2)
      multi_json (~> 1.10)
      winrm-fs (~> 1.0)
      docker-api (~> 1.26)
      thor (~> 0.19)
      rake (>= 0)
      rspec (~> 3)
      addressable (~> 2.4)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
1.45.4
```