### PR TITLE
Add the latest stable Nginx (1.12.2)

### DIFF
--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -25,6 +25,7 @@ license_file "LICENSE"
 
 source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
 
+version("1.12.2") { source sha256: "305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416" }
 version("1.10.2") { source md5: "e8f5f4beed041e63eb97f9f4f55f3085" }
 version("1.9.1") { source md5: "fc054d51effa7c80a2e143bc4e2ae6a7" }
 version("1.8.1") { source md5: "2e91695074dbdfbf1bcec0ada9fda462" }


### PR DESCRIPTION
### Description

Adds Nginx 1.12.2. That's it. Builds the same as 1.10.2, 1.8.1... in my test project.

Signed-off-by: Jonathan Hartman <j@hartman.io>

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
