### PR TITLE
add openssl 1.0.2n and make default version

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -25,7 +25,7 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.0.2m"
+default_version "1.0.2n"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
@@ -33,6 +33,7 @@ source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract:
 
 version("1.1.0g") { source sha256: "de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af" }
 version("1.1.0f") { source sha256: "12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765" }
+version("1.0.2n") { source sha256: "370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" }
 version("1.0.2m") { source sha256: "8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f" }
 version("1.0.2l") { source sha256: "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c" }
 version("1.0.2k") { source sha256: "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" }


### PR DESCRIPTION
Upgrade openssl to 1.0.2n to address CVE-2017-3737.

[Version published announcement](http://www.mail-archive.com/openssl-announce@openssl.org/msg00258.html).
[Security Advisory](http://www.mail-archive.com/openssl-announce@openssl.org/msg00259.html).