### PR TITLE
add latest stable nginx version 1.12.2

### DIFF
--- a/config/software/nginx.rb
+++ b/config/software/nginx.rb
@@ -25,6 +25,7 @@ license_file "LICENSE"
 
 source url: "http://nginx.org/download/nginx-#{version}.tar.gz"
 
+version("1.12.2") { source sha256: "305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416" }
 version("1.10.2") { source md5: "e8f5f4beed041e63eb97f9f4f55f3085" }
 version("1.9.1") { source md5: "fc054d51effa7c80a2e143bc4e2ae6a7" }
 version("1.8.1") { source md5: "2e91695074dbdfbf1bcec0ada9fda462" }


### PR DESCRIPTION
v1.12.1 addresses [CVE-2017-7529](http://mailman.nginx.org/pipermail/nginx-announce/2017/000200.html) - cache file header with possibly sensitive info could be returned with crafted request. Went ahead and took it to 1.12.2.