### PR TITLE
Bump libxml2 to 2.9.7

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017, Chef Software Inc.
+# Copyright 2012-2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 name "libxml2"
-default_version "2.9.5"
+default_version "2.9.7"
 
 license "MIT"
 license_file "COPYING"
@@ -24,6 +24,10 @@ skip_transitive_dependency_licensing true
 dependency "zlib"
 dependency "liblzma"
 dependency "config_guess"
+
+version "2.9.7" do
+  source sha256: "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c"
+end
 
 version "2.9.5" do
   source sha256: "4031c1ecee9ce7ba4f313e91ef6284164885cdb69937a123f6a83bb6a72dcd38"


### PR DESCRIPTION
2.9.7: Nov 02 2017

    Documentation:
    xmlcatalog: refresh man page wrt. quering system catalog easily (Jan Pokorný)
    Portability:
    Fix deprecated Travis compiler flag (Nick Wellnhofer),
    Add declaration for DllMain (J. Peter Mugaas),
    Fix preprocessor conditional in threads.h (J. Peter Mugaas),
    Fix pointer comparison warnings on 64-bit Windows (J. Peter Mugaas),
    Fix macro redefinition warning (J. Peter Mugaas),
    Default to native threads on MinGW-w64 (Nick Wellnhofer),
    Simplify Windows IO functions (Nick Wellnhofer),
    Fix runtest on Windows (Nick Wellnhofer),
    socklen_t is always int on Windows (Nick Wellnhofer),
    Don't redefine socket error codes on Windows (Nick Wellnhofer),
    Fix pointer/int cast warnings on 64-bit Windows (Nick Wellnhofer),
    Fix Windows compiler warnings in xmlCanonicPath (Nick Wellnhofer)
    Bug Fixes:
    xmlcatalog: restore ability to query system catalog easily (Jan Pokorný),
    Fix comparison of nodesets to strings (Nick Wellnhofer)
    Improvements:
    Add Makefile rules to rebuild HTML man pages (Nick Wellnhofer),
    Fix mixed decls and code in timsort.h (Nick Wellnhofer),
    Rework handling of return values in thread tests (Nick Wellnhofer),
    Fix unused variable warnings in testrecurse (Nick Wellnhofer),
    Fix -Wimplicit-fallthrough warnings (J. Peter Mugaas),
    Upgrade timsort.h to latest revision (Nick Wellnhofer),
    Increase warning level to /W3 under MSVC (Nick Wellnhofer),
    Fix a couple of warnings in dict.c and threads.c (Nick Wellnhofer),
    Update .gitignore for Windows (Nick Wellnhofer),
    Fix unused variable warnings in nanohttp.c (Nick Wellnhofer),
    Fix the Windows header mess (Nick Wellnhofer),
    Don't include winsock2.h in xmllint.c (Nick Wellnhofer),
    Remove generated file python/setup.py from version control (Nick Wellnhofer),
    Use __linux__ macro in generated code (Nick Wellnhofer)

v2.9.6: Oct 06 2017

    Portability:
    Change preprocessor OS tests to __linux__ (Nick Wellnhofer)
    Bug Fixes:
    Fix XPath stack frame logic (Nick Wellnhofer),
    Report undefined XPath variable error message (Nick Wellnhofer),
    Fix regression with librsvg (Nick Wellnhofer),
    Handle more invalid entity values in recovery mode (Nick Wellnhofer),
    Fix structured validation errors (Nick Wellnhofer),
    Fix memory leak in LZMA decompressor (Nick Wellnhofer),
    Set memory limit for LZMA decompression (Nick Wellnhofer),
    Handle illegal entity values in recovery mode (Nick Wellnhofer),
    Fix debug dump of streaming XPath expressions (Nick Wellnhofer),
    Fix memory leak in nanoftp (Nick Wellnhofer),
    Fix memory leaks in SAX1 parser (Nick Wellnhofer)

Signed-off-by: Tim Smith <tsmith@chef.io>