### PR TITLE
Update cacerts to 2018-01-17

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,20 +20,20 @@ license "MPL-2.0"
 license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
-default_version "2017-06-07"
+default_version "2018-01-17"
 
 source url: "https://curl.haxx.se/ca/cacert-#{version}.pem"
+
+version("2018-01-17") { source sha256: "defe310a0184a12e4b1b3d147f1d77395dd7a09e3428373d019bef5d542ceba3" }
 
 version("2017-06-07") { source sha256: "e78c8ab7b4432bd466e64bb942d988f6c0ac91cd785017e465bdc96d42fe9dd0" }
 
 version("2017-01-18") { source sha256: "e62a07e61e5870effa81b430e1900778943c228bd7da1259dd6a955ee2262b47" }
 
-version "2016-04-20" do
-  source md5: "782dcde8f5d53b1b9e888fdf113c42b9"
-end
+version("2016-04-20") { source sha256: "2c6d4960579b0d4fd46c6cbf135545116e76f2dbb7490e24cf330f2565770362" }
 
 version "2016.01.20" do
-  source md5: "06629db7f712ff3a75630eccaecc1fe4"
+  source sha256: "674f211b2a5898f2740ea62f3003ce817cdbf5f00325ab3169b7bb9922fc7808"
   source url: "https://curl.haxx.se/ca/cacert-2016-01-20.pem"
 end
 


### PR DESCRIPTION
Adds:

SSL.com EV Root Certification Authority ECC
SSL.com EV Root Certification Authority RSA R2
SSL.com Root Certification Authority ECC
SSL.com Root Certification Authority RSA
TrustCor ECA-1
TrustCor RootCert CA-2
TrustCor RootCert CA-1
GDCA TrustAUTH R5 ROOT

Removes:
CA WoSign ECC Root
Certification Authority of WoSign G2
WoSign China
WoSign
Swisscom Root EV CA 2
Swisscom Root CA 2
China Internet Network Information Center EV Certificates Root
PSCProcert
TURKTRUST Certificate Services Provider Root 2007
StartCom Certification Authority G2
StartCom Certification Authority
Certinomis - Autorité Racine
ACEDICOM Root
CNNIC ROOT
T\xc3\x9c\x42\xC4\xB0TAK UEKAE K\xC3\xB6k Sertifika Hizmet Sa\xC4\x9Flay\xc4\xb1\x63\xc4\xb1s\xc4\xb1 - S\xC3\xBCr\xC3\xBCm 3
Swisscom Root CA 1
StartCom Certification Authority
UTN USERFirst Hardware Root CA
Comodo Trusted Services root
Comodo Secure Services root
Certum Root CA
GeoTrust Global CA 2
AddTrust Qualified Certificates Root
AddTrust Public Services Root
AddTrust Low-Value Services Root

Signed-off-by: Tim Smith <tsmith@chef.io>