### PR TITLE
Adjust symlink to CA bundle

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -47,7 +47,7 @@ build do
 
   # Windows does not support symlinks
   unless windows?
-    link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
+    link "certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
 
     block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
   end


### PR DESCRIPTION
CPIO does not like links with an absolute path... Use a relative path instead.

### Description

This should fix the Docker build.  `cpio` was erroring out about an unsafe symlink.

```
Symbolic  links  are  considered  unsafe  if they are absolute symlinks
       (start with /), empty, or if they contain  enough  ".."  components  to
       ascend from the directory being copied.
```

To reproduce the error, just try building the Docker image by hand in the Chef repo with `docker build .`

```
cpio: skipping unsafe symlink to '/opt/chef/embedded/ssl/certs/cacert.pem' in archive, set EXTRACT_UNSAFE_SYMLINKS=1 to extract
```

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
