### PR TITLE
upgrade curl to 7.59.0 to address multiple CVEs

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.56.0"
+default_version "7.59.0"
 
 dependency "zlib"
 dependency "openssl"
@@ -24,6 +24,7 @@ dependency "cacerts"
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
+version("7.59.0") { source sha256: "099d9c32dc7b8958ca592597c9fabccdf4c08cfb7c114ff1afbbc4c6f13c9e9e" }
 version("7.56.0") { source sha256: "f1bc17a7e5662dbd8d4029750a6dbdb72a55cf95826a270ab388b05075526104" }
 version("7.53.1") { source sha256: "64f9b7ec82372edb8eaeded0a9cfa62334d8f98abc65487da01188259392911d" }
 version("7.51.0") { source sha256: "65b5216a6fbfa72f547eb7706ca5902d7400db9868269017a8888aa91d87977c" }


### PR DESCRIPTION
(fixed in 7.59)

CVE-2018-1000120
CVE-2018-1000121
CVE-2018-1000122

(fixed in 7.58)

[CVE-2018-1000007](https://nvd.nist.gov/vuln/detail/CVE-2018-1000007)
https://curl.haxx.se/docs/adv_2018-b3bf.html

Exerpts from curl's write-up:

## VULNERABILITY

curl might leak authentication data to third parties.

When asked to send custom headers in its HTTP requests, curl will send that set of headers first to the host in the initial URL but also, if asked to follow redirects and a 30X HTTP response code is returned, to the host mentioned in URL in the Location: response header value.

Sending the same set of headers to subsequest hosts is in particular a problem for applications that pass on custom Authorization: headers, as this header often contains privacy sensitive information or data that could allow others to impersonate the curl-using client's request.

## THE SOLUTION

In curl version 7.58.0, custom Authorization: headers will be limited the same way other such headers is controlled within curl: they will only be sent to the host used in the original URL unless curl is told
that it is ok to pass on to others using the [CURLOPT_UNRESTRICTED_AUTH](https://curl.haxx.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html) option.

**NOTE:** this solution creates a slight change in behavior. Users who actually want to pass on the header to other hosts now need to give curl that specific permission. You do this with [--location-trusted](https://curl.haxx.se/docs/manpage.html#--location-trusted) with the curl command line tool.