### PR TITLE
Add libarchive 3.3.2 as the default

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -18,14 +18,16 @@
 # https://github.com/berkshelf/api.berkshelf.com
 
 name "libarchive"
-default_version "3.1.2"
+default_version "3.3.2"
 
 license "BSD-2-Clause"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
-       md5: "efad5a503f66329bb9d2f4308b5de98a"
+version("3.3.2") { source sha256: "ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce" }
+version("3.1.2") { source md5: "efad5a503f66329bb9d2f4308b5de98a" }
+
+source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
 
 relative_path "libarchive-#{version}"
 

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -25,7 +25,7 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 version("3.3.2") { source sha256: "ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce" }
-version("3.1.2") { source md5: "efad5a503f66329bb9d2f4308b5de98a" }
+version("3.1.2") { source sha256: "eb87eacd8fe49e8d90c8fdc189813023ccc319c5e752b01fb6ad0cc7b2c53d5e" }
 
 source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
 


### PR DESCRIPTION
Multiple security issues and a huge pile of bug fixes.

Signed-off-by: Tim Smith <tsmith@chef.io>