### PR TITLE
Force disable arc4random on solaris

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -247,6 +247,11 @@ build do
     # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
     configure_command << "ac_cv_func_dl_iterate_phdr=no"
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  elsif solaris2?
+    # In ruby-2.5.0 on Solaris 11 Random.urandom defaults to arc4random_buf() as
+    # its implementation which is buggy and returns nothing but zeros.  We therefore
+    # force that API off.
+    configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
     if version.satisfies?(">= 2.3") &&
         version.satisfies?("< 2.5")


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

In ruby 2.5.0 the way that ruby's SecureRandom library works changed from /dev/random to /dev/urandom. However, due to something we can't explain, it's still using the old arc4random library on our SPARC server, which causes all random functions to return 0's. This is obviously super bad.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
