### PR TITLE
Use libarchive in Chef and add compression deps to it

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017, Chef Software Inc.
+# Copyright 2012-2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ dependency "rubygems"
 dependency "bundler"
 dependency "ohai"
 dependency "appbundler"
+dependency "libarchive" # for archive resource
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2014-2018 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ source url: "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz"
 relative_path "libarchive-#{version}"
 
 dependency "config_guess"
+dependency "libxml2"
+dependency "bzip2"
+dependency "zlib"
+dependency "liblzma"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -39,17 +43,12 @@ build do
 
   configure_args = [
     "--prefix=#{install_dir}/embedded",
-    "--without-lzma",
     "--without-lzo2",
     "--without-nettle",
-    "--without-xml2",
     "--without-expat",
-    "--without-bz2lib",
     "--without-iconv",
-    "--without-zlib",
-    "--disable-bsdtar",
-    "--disable-bsdcpio",
-    "--without-lzmadec",
+    "--disable-bsdtar", # tar command line tool
+    "--disable-bsdcpio", # cpio command line tool
     "--without-openssl",
   ]
 

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -33,7 +33,6 @@ relative_path "libarchive-#{version}"
 
 dependency "config_guess"
 dependency "libxml2"
-dependency "bzip2"
 dependency "zlib"
 dependency "liblzma"
 
@@ -46,6 +45,7 @@ build do
     "--without-lzo2",
     "--without-nettle",
     "--without-expat",
+    "--without-bz2lib",
     "--without-iconv",
     "--disable-bsdtar", # tar command line tool
     "--disable-bsdcpio", # cpio command line tool


### PR DESCRIPTION
This adds libarchive to chef so we can manipulate archives within chef. It also updates our libarchive definition to support many common compression formats. Due to failures with bzip2 this doesn't include that *yet*. It does support the following:

- gzip
- compress
- uudecode
- xz, lzip, and lzma
- lzma