### PR TITLE
zlib: archive url is moved to https://zlib.net/fossils/

### DIFF
--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -27,7 +27,7 @@ version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"
 end
 
-source url: "https://zlib.net/zlib-#{version}.tar.gz"
+source url: "https://zlib.net/fossils/zlib-#{version}.tar.gz"
 
 license "Zlib"
 license_file "README"


### PR DESCRIPTION
Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

### Description

zlib software's link is broken.
https://zlib.net/ uses https://zlib.net/fossils/ for All released versions of zlib.