### PR TITLE
TRIVIAL: Add sha256 for Python 2.7.14

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -26,6 +26,7 @@ dependency "zlib"
 dependency "openssl"
 dependency "bzip2"
 
+version("2.7.14") { source sha256: "304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8" }
 version("2.7.13") { source md5: "17add4bf0ad0ec2f08e0cae6d205c700" }
 version("2.7.11") { source md5: "6b6076ec9e93f05dd63e47eb9c15728b" }
 version("2.7.9") { source md5: "5eebcaa0030dc4061156d3429657fb83" }


### PR DESCRIPTION
Signed-off-by: Eric G. Wolfe <eric.wolfe@microsoft.com>

### Description

Added sha256 checksum for Python 2.7.14

### TODOs

Was a software definition added? Or a new version to an existing definition?
Trivial update to existing definition.

- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
