### PR TITLE
Move .NET assemblies to correct location for packaging.

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -88,6 +88,7 @@ build do
   if windows?
     mkdir "#{install_dir}/modules/chef"
     copy "distro/powershell/chef/*", "#{install_dir}/modules/chef"
+    move "distro/ruby_bin_folder/*", "#{install_dir}/embedded/bin" if Dir.exist?("distro/ruby_bin_folder")
   end
 
   appbundle "chef", env: env


### PR DESCRIPTION
### Description

A new feature being added to core Chef Client requires 3 dlls to be copied to the location where ruby.exe exists.  The 3 dlls are located into the `distro/ruby_bin_folder` directory and the change simply moves the content of this folder to the right place for packaging.

### TODOs

- [x] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
