### PR TITLE
install libgdbm-compat, not just build it

### DIFF
--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -48,4 +48,5 @@ build do
 
   make "-j #{workers}", env: env
   make "install", env: env
+  make "install-compat", env: env
 end


### PR DESCRIPTION
see also http://www.linuxfromscratch.org/blfs/view/6.3/general/gdbm.html

### Description

the current gdbm software definition is not executing the optional `make install-compat` step, any software depending on the gdbm compatibility feature will fail during health check or build. Fix is to not just call `make install` but also `make install-compat`.
