### PR TITLE
Backporting a Ruby 2.6.0 fix to 2.5.1

### DIFF
--- a/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
+++ b/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
@@ -1,0 +1,16 @@
+Backporting https://github.com/ruby/ruby/commit/4f03a239dcd6704e4ae7a7029dc6b31d579e9f7c and https://github.com/ruby/ruby/commit/7184e03eb259b31a1e2fda200e63924ec4a041b3 to Ruby 2.5.1 to solve an error preventing Nokogiri 1.8.3 from building. See https://chefio.slack.com/archives/CBFU62ZK3/p1530317076000086 for more details.
+---
+diff --git a/lib/mkmf.rb b/lib/mkmf.rb
+index 7f53bb4b97..74b42289b1 100644
+--- a/lib/mkmf.rb
++++ b/lib/mkmf.rb
+@@ -657,7 +657,8 @@ def with_ldflags(flags)
+   end
+
+   def try_ldflags(flags, opts = {})
+-    try_link(MAIN_DOES_NOTHING, flags, {:werror => true}.update(opts))
++    opts = {:werror => true}.update(opts) if $mswin
++    try_link(MAIN_DOES_NOTHING, flags, opts)
+   end
+
+   def append_ldflags(flags, *opts)

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -195,6 +195,13 @@ build do
     patch source: "prelude_25_el6_no_pragma.patch", plevel: 0, env: patch_env
   end
 
+  # Backporting a 2.6.0 fix to 2.5.1. This allows us to build Nokogiri 1.8.3. Basically we only
+  # include `-Werror` linker warnings when building native gems if we are on Windows. This
+  # prevents some "expected" warnings from failing the build.
+  if version == "2.5.1"
+    patch source: "ruby-only-compiler-warnings-on-windows.patch", plevel: 1, env: patch_env
+  end
+
   configure_command = ["--with-out-ext=dbm,readline",
                        "--enable-shared",
                        "--disable-install-doc",


### PR DESCRIPTION
### Description

This disables '-Werror' when compiling native gems and prevents some
"expected" warnings from failing a native gem compile.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [x] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------

Signed-off-by: tyler-ball <tball@chef.io>
