### PR TITLE
Grab popt from linuxfromscratch.org

### DIFF
--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -23,8 +23,8 @@ skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 
-source url: "http://rpm5.org/files/popt/popt-#{version}.tar.gz",
-       md5: "3743beefa3dd6247a73f8f7a32c14c33"
+source url: "ftp://anduin.linuxfromscratch.org/BLFS/popt/popt-#{version}.tar.gz",
+       sha256: "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
 
 relative_path "popt-#{version}"
 


### PR DESCRIPTION
rpm5.org is no longer a thing

Signed-off-by: Tim Smith <tsmith@chef.io>