### PR TITLE
[SHACK-295] Backport Ruby patch for Nokogiri build support

### DIFF
--- a/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
+++ b/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
@@ -1,4 +1,4 @@
-Backporting https://github.com/ruby/ruby/commit/4f03a239dcd6704e4ae7a7029dc6b31d579e9f7c and https://github.com/ruby/ruby/commit/7184e03eb259b31a1e2fda200e63924ec4a041b3 to Ruby 2.5.1 to solve an error preventing Nokogiri 1.8.3 from building. See https://chefio.slack.com/archives/CBFU62ZK3/p1530317076000086 for more details.
+Backporting https://github.com/ruby/ruby/commit/4f03a239dcd6704e4ae7a7029dc6b31d579e9f7c and https://github.com/ruby/ruby/commit/7184e03eb259b31a1e2fda200e63924ec4a041b3 to Ruby < 2.6.0 to solve an error preventing Nokogiri 1.8.3 from building. See https://chefio.slack.com/archives/CBFU62ZK3/p1530317076000086 for more details.
 ---
 diff --git a/lib/mkmf.rb b/lib/mkmf.rb
 index 7f53bb4b97..74b42289b1 100644

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -166,10 +166,10 @@ build do
     patch source: "prelude_25_el6_no_pragma.patch", plevel: 0, env: patch_env
   end
 
-  # Backporting a 2.6.0 fix to 2.5.1. This allows us to build Nokogiri 1.8.3. Basically we only
-  # include `-Werror` linker warnings when building native gems if we are on Windows. This
-  # prevents some "expected" warnings from failing the build.
-  if version == "2.5.1"
+  # Backporting a 2.6.0 fix to 2.5.1 (and 2.4.4 for ChefDK 2). This allows us to build Nokogiri 1.8.3.
+  # Basically we only include `-Werror` linker warnings when building native gems if we are on Windows.
+  # This prevents some "expected" warnings from failing the build.
+  if version == "2.5.1" || version == "2.4.4"
     patch source: "ruby-only-compiler-warnings-on-windows.patch", plevel: 1, env: patch_env
   end
 


### PR DESCRIPTION
### Description

This applies https://github.com/chef/omnibus-software/pull/963 to the
version of Ruby that the ChefDK 2.x branch uses

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [x] Verify with a ChefDK 2.x build in manhattan using this branch

--------------------------------------------------

Signed-off-by: tyler-ball <tball@chef.io>