### PR TITLE
Update chef bundle process to match new rakefile

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -64,11 +64,7 @@ build do
   excluded_groups << "ruby_shadow" if aix?
 
   # install the whole bundle first
-  bundle "install --without #{excluded_groups.join(' ')}", env: env
-
-  # Install components that live inside Chef's git repo. For now this is just
-  # 'chef-config'
-  bundle "exec rake install_components", env: env
+  bundle install
 
   gemspec_name = windows? ? "chef-universal-mingw32.gemspec" : "chef.gemspec"
 


### PR DESCRIPTION
We ripped out some of the component craziness we had before. Now we just
have rake install which builds/install chef-config and then chef.

Signed-off-by: Tim Smith <tsmith@chef.io>