### PR TITLE
Add openssl 1.1.1

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -30,6 +30,7 @@ default_version "1.0.2p"
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }
 version("1.1.0g") { source sha256: "de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af" }


### PR DESCRIPTION
This doesn't make it the default, but allows us to start using it.

Signed-off-by: Tim Smith <tsmith@chef.io>