### PR TITLE
Update the groups we exclude in ohai

### DIFF
--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -32,7 +32,7 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development changelog ci", env: env
+  bundle "install --without development docs ci", env: env
 
   gem "build ohai.gemspec", env: env
   gem "install ohai*.gem" \


### PR DESCRIPTION
We don't have a changelog group anymore. We do have a docs group.

Signed-off-by: Tim Smith <tsmith@chef.io>