### PR TITLE
Remove cmake dependency to build libarchive on windows

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -38,10 +38,6 @@ dependency "bzip2"
 dependency "zlib"
 dependency "liblzma"
 
-if windows?
-  dependency "cmake"
-end
-
 build do
   env = with_standard_compiler_flags(with_embedded_path)
   update_config_guess(target: "build/autoconf/")
@@ -61,13 +57,8 @@ build do
     configure_args << "--disable-xattr --disable-acl"
   end
 
-  if windows?
-    command "cmake -G \"MSYS Makefiles\" -D ENABLE_COVERAGE=OFF -D ENABLE_EXPAT=OFF -D ENABLE_ICONV=OFF -D ENABLE_OPENSSL=OFF -D ENABLE_TAR=OFF -D ENABLE_CPIO=OFF -D ENABLE_TEST=OFF -D ENABLE_NETTLE=OFF -D ENABLE_CAT=OFF -D ENABLE_LZO=OFF -D CMAKE_INSTALL_PREFIX=\"#{install_dir}/embedded\" .", env: env
-    command "mingw32-make -j #{workers}", env: env
-    command "mingw32-make -j #{workers} install", env: env
-  else
-    configure configure_args.join(" "), env: env
-    make "-j #{workers}", env: env
-    make "-j #{workers} install", env: env
-  end
+  configure configure_args.join(" "), env: env
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
 end


### PR DESCRIPTION
Remove cmake dependency here as we now add cmake to toolchain

### Description

We are adding cmake for Windows to our omnibus-toolchain https://github.com/chef/omnibus-toolchain/pull/98

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
