### PR TITLE
Add back building the chef gem

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -69,6 +69,12 @@ build do
   # use the rake install task to build/install chef-config
   bundle "exec rake install", env: env
 
+  gemspec_name = windows? ? "chef-universal-mingw32.gemspec" : "chef.gemspec"
+
+  # This step will build native components as needed - the event log dll is
+  # generated as part of this step.  This is why we need devkit.
+  gem "build #{gemspec_name}", env: env
+
   # ensure we put the gems in the right place to get picked up by the publish scripts
   delete "pkg"
   mkdir "pkg"


### PR DESCRIPTION
Rake install handles building / installing it, but it doesn't drop it
into the correct place. Without it being in pkg we don't ship it to
Artifactory and then we fail to promote it.

Signed-off-by: Tim Smith <tsmith@chef.io>