### PR TITLE
Do not patch latest gtar for osx

### DIFF
--- a/config/patches/gtar/aix_extra_case.patch
+++ b/config/patches/gtar/aix_extra_case.patch
@@ -11,4 +11,3 @@
                     case ENOTEMPTY:
                       /* Keep the record in list, in the hope we'll
                          be able to remove it later */
---- 124,129 ----

--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -46,9 +46,11 @@ build do
     # ios_xr and nexus don't support posix acls
     configure_command << " --without-posix-acls"
   elsif osx?
-    # lovingly borrowed from the awesome Homebrew project, thank you!
-    # https://github.com/Homebrew/homebrew-core/blob/de3b1aeec9cc8d36f849b0ae959ee4b7f6610c1f/Formula/gnu-tar.rb
-    patch source: "gnutar-configure-xattrs.patch", env: env
+    if version.satisfies?("<= 1.28")
+      # lovingly borrowed from the awesome Homebrew project, thank you!
+      # https://github.com/Homebrew/homebrew-core/blob/de3b1aeec9cc8d36f849b0ae959ee4b7f6610c1f/Formula/gnu-tar.rb
+      patch source: "gnutar-configure-xattrs.patch", env: env
+    end
     env["gl_cv_func_getcwd_abort_bug"] = "no"
   elsif aix?
     if version.satisfies?("<= 1.28")


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

"gnutar-configure-xattrs.patch" does not need to be applied for later versions on gnutar (> 1.28) on OSX
"aix_extra_case.patch" patch does not need to be applied for later versions on gnutar (> 1.28) on AIX

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [x] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
