### PR TITLE
#985 - automake requires perl < 5.26

### DIFF
--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -17,6 +17,10 @@
 name "automake"
 default_version "1.11.2"
 
+# requires perl < 5.26 due to a bug in automake <= 1.15:
+# https://lists.gnu.org/archive/html/bug-automake/2017-06/msg00003.html
+dependency "perl"
+
 dependency "autoconf"
 
 license "GPL-2.0"


### PR DESCRIPTION
### Description

Potential fix for #985.  Tested with ad-hoc build of chef-dk omnibus project on Ubuntu 18.04.

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
