### PR TITLE
Rename chef-cleanup to ruby-cleanup

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -16,9 +16,9 @@
 #
 
 #
-# Common cleanup routines for chef + chef-dk omnibus packages
+# Common cleanup routines for ruby apps (InSpec, Workstation, Chef, etc)
 #
-name "chef-cleanup"
+name "ruby-cleanup"
 
 license :project_license
 skip_transitive_dependency_licensing true


### PR DESCRIPTION
This is a ruby cleanup thing not a chef cleanup thing. We're going to
use it in InSpec, etc.

Signed-off-by: Tim Smith <tsmith@chef.io>