### PR TITLE
Ma/update erlang

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -35,7 +35,7 @@ if version.satisfies?("<= 18.3") || version.satisfies?("=20.0")
   relative_path "otp_src_#{version}"
 else
   source url: "https://github.com/erlang/otp/archive/OTP-#{version}.tar.gz"
-  relative_path "OTP-#{version}"
+  relative_path "otp-OTP-#{version}"
 end
 
 version("18.1") { source md5: "fa64015fdd133e155b5b19bf90ac8678" }
@@ -97,6 +97,17 @@ build do
   # See also https://sourceware.org/ml/binutils/2015-05/msg00148.html
   hipe = ppc64le? ? "disable" : "enable"
 
+  if !File.exist?("./configure")
+    # Building from github source requires this step
+    command "./otp_build autoconf"
+  end
+  # Note: et, debugger and observer applications require wx to
+  # build. The tarballs from the downloads site has prebuilt the beam
+  # files, so we were able to get away without disabling them and
+  # still build. When building from raw source we must disable them
+  # explicitly.
+  wx = "without"
+
   command "./configure" \
           " --prefix=#{install_dir}/embedded" \
           " --enable-threads" \
@@ -105,7 +116,10 @@ build do
           " --enable-dynamic-ssl-lib" \
           " --enable-shared-zlib" \
           " --#{hipe}-hipe" \
-          " --without-wx" \
+          " --#{wx}-wx" \
+          " --#{wx}-et" \
+          " --#{wx}-debugger" \
+          " --#{wx}-observer" \
           " --without-megaco" \
           " --without-javac" \
           " --with-ssl=#{install_dir}/embedded" \

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -26,13 +26,26 @@ dependency "openssl"
 dependency "ncurses"
 dependency "config_guess"
 
-source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
-relative_path "otp_src_#{version}"
+#
+# OTP only puts minor version updates in the downloads page. E.g. 18.3 is present, but 18.3.4.9 wouldn't be
+# It's nice to be able to have those updates, so we're moving to using the github releases instead
+# However for backcompat leave the prior stuff alone.
+if version.satisfies?("<= 18.3") || version.satisfies?("=20.0")
+  source url: "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
+  relative_path "otp_src_#{version}"
+else
+  source url: "https://github.com/erlang/otp/archive/OTP-#{version}.tar.gz"
+  relative_path "OTP-#{version}"
+end
 
 version("18.1") { source md5: "fa64015fdd133e155b5b19bf90ac8678" }
 version("18.2") { source md5: "b336d2a8ccfbe60266f71d102e99f7ed" }
 version("18.3") { source md5: "7e4ff32f97c36fb3dab736f8d481830b" }
+version("18.3.4.9") { source sha256: "25ef8ba3824cb726c4830abf32c2a2967925b1e33a8e8851dba596e933e2689a" }
+version("19.3.6.11") { source sha256: "c857ea6d2c901bfb633d9ceeb5e05332475357f185dd5112b7b6e4db80072827" }
 version("20.0") { source md5: "2faed2c3519353e6bc2501ed4d8e6ae7" }
+version("20.3.8.9") { source sha256: "897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519" }
+version("21.1") { source sha256: "7212f895ae317fa7a086fa2946070de5b910df5d41263e357d44b0f1f410af0f" }
 
 build do
   if version.satisfies?(">= 18.3")


### PR DESCRIPTION
Update the erlang definition to pull from github

The downloads site doesn't seem to have patch releases, only minor versions. This means we miss out on some security releases, such as those to ssl in 18.3.4.9

This adds 18.3.4.9, 19.3.6.11, 20.3.8.9, and 21.1 to the supported version matrix.

The debugger, et, and observer applications need wx, and were disabled. 