### PR TITLE
Update gem install options

### DIFF
--- a/config/software/appbundler.rb
+++ b/config/software/appbundler.rb
@@ -32,5 +32,5 @@ build do
 
   gem "build appbundler.gemspec", env: env
   gem "install appbundler-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-document", env: env
 end

--- a/config/software/bcrypt_pbkdf-ruby.rb
+++ b/config/software/bcrypt_pbkdf-ruby.rb
@@ -36,5 +36,5 @@ build do
   delete "pkg/*java*"
 
   gem "install pkg/bcrypt_pbkdf-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-document", env: env
 end

--- a/config/software/berkshelf-no-depselector.rb
+++ b/config/software/berkshelf-no-depselector.rb
@@ -44,5 +44,5 @@ build do
   bundle "exec thor gem:build", env: env
 
   gem "install pkg/berkshelf-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-document", env: env
 end

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -45,5 +45,5 @@ build do
   bundle "exec thor gem:build", env: env
 
   gem "install pkg/berkshelf-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-document", env: env
 end

--- a/config/software/berkshelf2.rb
+++ b/config/software/berkshelf2.rb
@@ -34,25 +34,25 @@ build do
 
   gem "install celluloid" \
       " --version '~> 0.16.0'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   gem "install celluloid-io" \
       " --version '~> 0.16.1'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   gem "install hashie" \
       " --version '~> 2.0.0'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   gem "install varia_model" \
       " --version '0.3.2'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   gem "install i18n" \
       " --version '0.6.11'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   gem "install berkshelf" \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -29,6 +29,6 @@ build do
   gem [
     "install bundler",
     v_opts,
-    "--no-ri --no-rdoc --force",
+    " --no-document --force",
   ].compact.join(" "), env: env
 end

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -31,5 +31,5 @@ build do
   gem "install chef" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -33,5 +33,5 @@ build do
 
   gem "build chef-vault.gemspec", env: env
   gem "install chef-vault-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/chefspec.rb
+++ b/config/software/chefspec.rb
@@ -32,5 +32,5 @@ build do
 
   gem "build chefspec.gemspec", env: env
   gem "install chefspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -43,5 +43,5 @@ build do
 
   gem "install dep-selector-libgecode" \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/fauxhai.rb
+++ b/config/software/fauxhai.rb
@@ -31,5 +31,5 @@ build do
 
   gem "build fauxhai.gemspec", env: env
   gem "install fauxhai-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -42,5 +42,5 @@ build do
   delete "pkg/*java*"
 
   gem "install pkg/ffi-yajl-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/foodcritic.rb
+++ b/config/software/foodcritic.rb
@@ -32,5 +32,5 @@ build do
 
   gem "build foodcritic.gemspec", env: env
   gem "install foodcritic-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -33,5 +33,5 @@ build do
   gem "install highline" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -38,7 +38,7 @@ build do
 
   gem "build inspec.gemspec", env: env
   gem "install inspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   appbundle "inspec", env: env
 end

--- a/config/software/kitchen-inspec.rb
+++ b/config/software/kitchen-inspec.rb
@@ -32,5 +32,5 @@ build do
 
   gem "build kitchen-inspec.gemspec", env: env
   gem "install kitchen-inspec-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -31,5 +31,5 @@ build do
 
   gem "build kitchen-vagrant.gemspec", env: env
   gem "install kitchen-vagrant-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/knife-spork.rb
+++ b/config/software/knife-spork.rb
@@ -31,5 +31,5 @@ build do
 
   gem "build knife-spork.gemspec", env: env
   gem "install knife-spork-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/knife-windows.rb
+++ b/config/software/knife-windows.rb
@@ -31,5 +31,5 @@ build do
 
   gem "build knife-windows.gemspec", env: env
   gem "install knife-windows-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -40,5 +40,5 @@ build do
   delete "pkg/*java*"
 
   gem "install pkg/libyajl2-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/mysql2.rb
+++ b/config/software/mysql2.rb
@@ -40,7 +40,7 @@ build do
 
   gem "install rake-compiler" \
       " --version '0.8.3'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 
   mkdir cache_path
 

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -36,5 +36,5 @@ build do
 
   gem "build ohai.gemspec", env: env
   gem "install ohai*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -37,7 +37,7 @@ build do
   delete "omnibus-ctl-*.gem"
 
   gem "build omnibus-ctl.gemspec", env: env
-  gem "install omnibus-ctl-*.gem --no-rdoc --no-ri", env: env
+  gem "install omnibus-ctl-*.gem --no-document ", env: env
 
   touch "#{install_dir}/embedded/service/omnibus-ctl/.gitkeep"
 end

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -33,5 +33,5 @@ build do
   gem "install pg" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/pry.rb
+++ b/config/software/pry.rb
@@ -27,10 +27,10 @@ dependency "rubygems"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem_command = [ "install pry --no-ri --no-rdoc" ]
+  gem_command = [ "install pry  --no-document" ]
   gem_command << "--version '#{version}'" unless version.nil?
 
   gem gem_command.join(" "), env: env
 
-  gem "install pry-remote pry-byebug pry-stack_explorer --no-ri --no-rdoc"
+  gem "install pry-remote pry-byebug pry-stack_explorer  --no-document"
 end

--- a/config/software/rbnacl-libsodium.rb
+++ b/config/software/rbnacl-libsodium.rb
@@ -36,5 +36,5 @@ build do
   delete "pkg/*java*"
 
   gem "install pkg/rbnacl-libsodium-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -32,5 +32,5 @@ build do
   gem "install redis" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/rubocop.rb
+++ b/config/software/rubocop.rb
@@ -30,5 +30,5 @@ build do
 
   gem "build rubocop.gemspec", env: env
   gem "install rubocop-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -76,7 +76,7 @@ build do
 
   if source
     # Building from source:
-    ruby "setup.rb --no-ri --no-rdoc", env: env
+    ruby "setup.rb  --no-document", env: env
   else
     # Installing direct from rubygems:
     # If there is no version, this will get latest.

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -32,5 +32,5 @@ build do
   gem "install sequel" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/test-kitchen.rb
+++ b/config/software/test-kitchen.rb
@@ -49,5 +49,5 @@ build do
   bundle "exec rake build", env: env
 
   gem "install pkg/test-kitchen-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/train.rb
+++ b/config/software/train.rb
@@ -33,5 +33,5 @@ build do
   bundle "install --without development test integration tools", env: env
 
   gem "build train.gemspec", env: env
-  gem "install train-*.gem --no-ri --no-rdoc", env: env
+  gem "install train-*.gem  --no-document", env: env
 end

--- a/config/software/unicorn.rb
+++ b/config/software/unicorn.rb
@@ -24,5 +24,5 @@ build do
 
   gem "install unicorn" \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/uuidtools.rb
+++ b/config/software/uuidtools.rb
@@ -25,5 +25,5 @@ build do
 
   gem "install uuidtools" \
       " --version '#{version}'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/veil-gem.rb
+++ b/config/software/veil-gem.rb
@@ -32,5 +32,5 @@ build do
   bundle "install --without development", env: env
 
   gem "build veil.gemspec", env: env
-  gem "install veil*.gem --no-rdoc --no-ri --without development", env: env
+  gem "install veil*.gem --no-document  --without development", env: env
 end

--- a/config/software/winrm-fs.rb
+++ b/config/software/winrm-fs.rb
@@ -30,5 +30,5 @@ build do
 
   gem "build winrm-fs.gemspec", env: env
   gem "install winrm-fs-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/winrm-transport.rb
+++ b/config/software/winrm-transport.rb
@@ -30,5 +30,5 @@ build do
 
   gem "build winrm-transport.gemspec", env: env
   gem "install winrm-transport-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end

--- a/config/software/yajl.rb
+++ b/config/software/yajl.rb
@@ -27,5 +27,5 @@ build do
   gem "install yajl-ruby" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/bin'" \
-      " --no-ri --no-rdoc", env: env
+      "  --no-document", env: env
 end


### PR DESCRIPTION
Replace deprecated "--no-ri --no-rdoc" with "--no-document"

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Replace deprecated "--no-ri --no-rdoc" with "--no-document"

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
