### PR TITLE
Remove all support for Solaris 10

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -51,14 +51,8 @@ build do
 
   configure(*configure_command, env: env)
 
-  if solaris_10?
-    # run old make :(
-    make env: env, bin: "/usr/ccs/bin/make"
-    make "install", env: env, bin: "/usr/ccs/bin/make"
-  else
-    make "-j #{workers}", env: env
-    make "-j #{workers} install", env: env
-  end
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
 
   # libffi's default install location of header files is awful...
   copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -24,7 +24,6 @@ skip_transitive_dependency_licensing true
 
 dependency "libtool" if aix?
 dependency "config_guess"
-dependency "patch" if solaris_10?
 
 version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
 version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }
@@ -128,10 +127,6 @@ build do
     # use gnu install from the coreutils IBM rpm package
     env["INSTALL"] = "/opt/freeware/bin/install"
   end
-
-  # only Solaris 10 sh has a problem with
-  # parens enclosed case statement conditions the configure script
-  configure_command.unshift "bash" if solaris_10?
 
   command configure_command.join(" "), env: env
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -96,11 +96,6 @@ build do
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif omnios?
       "/bin/bash ./Configure solaris-x86-gcc"
-    elsif solaris_10?
-      # This should not require a /bin/sh, but without it we get
-      # Errno::ENOEXEC: Exec format error
-      platform = sparc? ? "solaris-sparcv9-gcc" : "solaris-x86-gcc"
-      "/bin/sh ./Configure #{platform} -static-libgcc"
     elsif solaris_11?
       platform = sparc? ? "solaris64-sparcv9-gcc" : "solaris64-x86_64-gcc"
       "/bin/bash ./Configure #{platform} -static-libgcc"

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -34,13 +34,7 @@ relative_path "perl-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  solaris_mapfile_path = File.expand_path(Omnibus::Config.solaris_linker_mapfile, Omnibus::Config.project_root)
-  if solaris_10?
-    cc_command = "-Dcc='gcc -static-libgcc'"
-    if File.exist?(solaris_mapfile_path)
-      cc_command = "-Dcc='gcc -static-libgcc -Wl,-M #{solaris_mapfile_path}'"
-    end
-  elsif solaris_11?
+  if solaris_11?
     cc_command = "-Dcc='gcc -m64 -static-libgcc'"
   elsif aix?
     cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -32,6 +32,7 @@ dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
 
+version("2.6.0")      { source sha256: "f3c35b924a11c88ff111f0956ded3cdc12c90c04b72b266ac61076d3697fc072" }
 version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c" }
 version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
@@ -90,14 +91,6 @@ elsif aix?
   env["SOLIBS"] = "-lm -lc"
   # need to use GNU m4, default m4 doesn't work
   env["M4"] = "/opt/freeware/bin/m4"
-elsif solaris_10?
-  if sparc?
-    # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9"
-    env["LDFLAGS"] << " -mcpu=v9"
-  else
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe"
-  end
 elsif solaris_11?
   env["CFLAGS"] << " -std=c99"
   env["CPPFLAGS"] << " -D_XOPEN_SOURCE=600 -D_XPG6"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -118,10 +118,6 @@ build do
   patch_env = env.dup
   patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}" if aix?
 
-  if solaris_10?
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
-  end
-
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.


### PR DESCRIPTION
We haven't supported Solaris 10 for a while. Let's cleanup these configs
a bit by removing it.

Signed-off-by: Tim Smith <tsmith@chef.io>