### PR TITLE
Update m4 to 1.4.18

### DIFF
--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef, Inc.
+# Copyright 2014-2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
 #
 
 name "m4"
-default_version "1.4.17"
+default_version "1.4.18"
 
 license "GPL-3.0"
 license_file "COPYING"
 
-source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz",
-       md5: "a5e9954b1dae036762f7b13673a2cf76"
+version("1.4.18") { source sha256: "ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab" }
+version("1.4.17") { source sha256: "3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e" }
+
+source url: "https://ftp.gnu.org/gnu/m4/m4-#{version}.tar.gz"
 
 relative_path "m4-#{version}"
 


### PR DESCRIPTION
* Noteworthy changes in release 1.4.18 (2016-12-31) [stable]

** Diagnose --word-regexp as unsupported if it was not configured.

** Preliminary support for OS/2.

** A number of portability improvements inherited from gnulib.

Signed-off-by: Tim Smith <tsmith@chef.io>