### PR TITLE
Update make to 4.2.1 and fix the license

### DIFF
--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
 #
 
 name "make"
-default_version "4.1"
+default_version "4.2.1"
 
-license "Zlib"
-license_file "README"
+license "GPL-3.0"
+license_file "COPYING"
 
-source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz",
-       md5: "654f9117957e6fa6a1c49a8f08270ec9"
+version("4.2.1") { source sha256: "d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589" }
+version("4.1") { source sha256: "9fc7a9783d3d2ea002aa1348f851875a2636116c433677453cc1d1acc3fc4d55" }
+
+source url: "https://ftp.gnu.org/gnu/make/make-#{version}.tar.gz"
 
 relative_path "make-#{version}"
 


### PR DESCRIPTION
It's GPL v3 not zlib.

Version 4.2.1 (10 Jun 2016)

A complete list of bugs fixed in this version is available here:
h
ttp://sv.gnu.org/bugs/index.php?group=make&report_id=111&fix_release_id=107&set=custom


Version 4.2 (22 May 2016)

A complete list of bugs fixed in this version is available here:

http://sv.gnu.org/bugs/index.php?group=make&report_id=111&fix_release_id=106&set=custom

* New variable: $(.SHELLSTATUS) is set to the exit status of the last != or
  $(shell ...) function invoked in this instance of make.  This will be "0" if
  successful or not "0" if not successful.  The variable value is unset if no
  != or $(shell ...) function has been invoked.

* The $(file ...) function can now read from a file with $(file <FILE).
  The function is expanded to the contents of the file.  The contents are
  expanded verbatim except that the final newline, if any, is stripped.

* The makefile line numbers shown by GNU make now point directly to the
  specific line in the recipe where the failure or warning occurred.
  Sample changes suggested by Brian Vandenberg <phantall@gmail.com>

* The interface to GNU make's "jobserver" is stable as documented in the
  manual, for tools which may want to access it.

  WARNING: Backward-incompatibility! The internal-only command line option
  --jobserver-fds has been renamed for publishing, to --jobserver-auth.

* The amount of parallelism can be determined by querying MAKEFLAGS, even when
  the job server is enabled (previously MAKEFLAGS would always contain only
  "-j", with no number, when job server was enabled).

* VMS-specific changes:

  * Perl test harness now works.

  * Full support for converting Unix exit status codes to VMS exit status
    codes.  BACKWARD INCOMPATIBILITY Notice: On a child failure the VMS exit
    code is now the encoded Unix exit status that Make usually generates, not
    the VMS exit status of the child.



Signed-off-by: Tim Smith <tsmith@chef.io>