### PR TITLE
Add mpfr 3.1.6 and add license information

### DIFF
--- a/config/software/mpfr.rb
+++ b/config/software/mpfr.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2014-2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@ default_version "3.1.2"
 
 dependency "gmp"
 
-version("3.1.2") { source md5: "181aa7bb0e452c409f2788a4a7f38476" }
-version("3.1.3") { source md5: "7b650781f0a7c4a62e9bc8bdaaa0018b" }
+license "LGPL-3.0-or-later"
+license_file "COPYING.LESSER"
+
+version("3.1.2") { source sha256: "176043ec07f55cd02e91ee3219db141d87807b322179388413a9523292d2ee85" }
+version("3.1.3") { source sha256: "b87feae279e6da95a0b45eabdb04f3a35422dab0d30113d58a7803c0d73a79dc" }
+version("3.1.6") { source sha256: "569ceb418aa935317a79e93b87eeb3f956cab1a97dfb2f3b5fd8ac2501011d62" }
 
 source url: "http://www.mpfr.org/mpfr-#{version}/mpfr-#{version}.tar.gz"
 


### PR DESCRIPTION
Add the mpfr license, switch to sha256, and add 3.1.6 release

Signed-off-by: Tim Smith <tsmith@chef.io>