### PR TITLE
Patch Ruby 2.6 to remove C99 features that snuck in

### DIFF
--- a/config/patches/ruby/0001-Don-t-use-C99-features-yet.patch
+++ b/config/patches/ruby/0001-Don-t-use-C99-features-yet.patch
@@ -1,0 +1,51 @@
+From 46861309169c43b5d72d65e4827f33c350538e2f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?V=C3=ADt=20Ondruch?= <vondruch@redhat.com>
+Date: Wed, 9 Jan 2019 17:23:52 +0100
+Subject: [PATCH] Don't use C99 features yet.
+
+Fixes #15519
+---
+ addr2line.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/addr2line.c b/addr2line.c
+index a11d32b73d..e3527f1174 100644
+--- a/addr2line.c
++++ b/addr2line.c
+@@ -1194,6 +1194,7 @@ static char *
+ di_find_abbrev(DebugInfoReader *reader, uint64_t abbrev_number)
+ {
+     char *p;
++    uint64_t n;
+     if (abbrev_number < ABBREV_TABLE_SIZE) {
+         return reader->abbrev_table[abbrev_number];
+     }
+@@ -1207,7 +1208,7 @@ di_find_abbrev(DebugInfoReader *reader, uint64_t abbrev_number)
+         uint64_t form = uleb128(&p);
+         if (!at && !form) break;
+     }
+-    for (uint64_t n = uleb128(&p); abbrev_number != n; n = uleb128(&p)) {
++    for (n = uleb128(&p); abbrev_number != n; n = uleb128(&p)) {
+         if (n == 0) {
+             fprintf(stderr,"%d: Abbrev Number %"PRId64" not found\n",__LINE__, abbrev_number);
+             exit(1);
+@@ -1511,6 +1512,7 @@ debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
+         DIE die;
+         ranges_t ranges = {};
+         line_info_t line = {};
++	int i;
+ 
+         if (!di_read_die(reader, &die)) continue;
+         /* fprintf(stderr,"%d:%tx: <%d>\n",__LINE__,die.pos,reader->level,die.tag); */
+@@ -1555,7 +1557,7 @@ debug_info_read(DebugInfoReader *reader, int num_traces, void **traces,
+         }
+         /* ranges_inspect(reader, &ranges); */
+         /* fprintf(stderr,"%d:%tx: %x ",__LINE__,diepos,die.tag); */
+-        for (int i=offset; i < num_traces; i++) {
++        for (i=offset; i < num_traces; i++) {
+             uintptr_t addr = (uintptr_t)traces[i];
+             uintptr_t offset = addr - reader->obj->base_addr + reader->obj->vmaddr;
+             uintptr_t saddr = ranges_include(reader, &ranges, offset);
+-- 
+2.20.1
+

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -154,6 +154,12 @@ build do
     patch source: "prelude_25_el6_no_pragma.patch", plevel: 0, env: patch_env
   end
 
+  # ruby 2.6.0 snuck in C99 features. This *should* be fixed in 2.6.1 as it's merged to trunk as of 1/22/19
+  # https://bugs.ruby-lang.org/issues/15519
+  if version == "2.6.0"
+    patch source: "0001-Don-t-use-C99-features-yet.patch", plevel: 1, env: patch_env
+  end
+
   # Backporting a 2.6.0 fix to 2.5.1 (and 2.4.4 for ChefDK 2). This allows us to build Nokogiri 1.8.3.
   # Basically we only include `-Werror` linker warnings when building native gems if we are on Windows.
   # This prevents some "expected" warnings from failing the build.


### PR DESCRIPTION
This is causing omnibus builds using 2.6 to fail to compile. I've confirmed this fixes chef/chef ruby 2.6 failures via Jenkins.

Signed-off-by: Tim Smith <tsmith@chef.io>