### PR TITLE
chef: exclude ed25519 gem group on solaris

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018, Chef Software Inc.
+# Copyright 2012-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ build do
   excluded_groups = %w{server docgen maintenance pry travis integration ci}
   excluded_groups << "ruby_prof" if aix?
   excluded_groups << "ruby_shadow" if aix?
+  excluded_groups << "ed25519" if solaris2?
 
   # install the whole bundle first
   bundle "install --without #{excluded_groups.join(' ')}", env: env


### PR DESCRIPTION
This is necessary to fix chef/chef#8170