### PR TITLE
Make sure TYPE env var is not set for erlang

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -60,6 +60,8 @@ build do
   )
   env.delete("CPPFLAGS")
 
+  env.delete("TYPE")
+
   update_config_guess(target: "erts/autoconf")
   update_config_guess(target: "lib/common_test/priv/auxdir")
   update_config_guess(target: "lib/erl_interface/src/auxdir")


### PR DESCRIPTION
TYPE is used by the Makefile.
Our CI was also using TYPE for something else.
The conflict was causing the build to fail.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>