### PR TITLE
Prevent transitive licensing dependency checks

### DIFF
--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -20,6 +20,7 @@ default_version "2.68"
 license "GPL-3.0"
 license_file "COPYING"
 license_file "COPYING.EXCEPTION"
+skip_transitive_dependency_licensing true
 
 dependency "m4"
 

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -21,6 +21,7 @@ dependency "autoconf"
 
 license "GPL-2.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 version "1.15" do
   source md5: "716946a105ca228ab545fc37a70df3a3"

--- a/config/software/m4.rb
+++ b/config/software/m4.rb
@@ -19,6 +19,7 @@ default_version "1.4.18"
 
 license "GPL-3.0"
 license_file "COPYING"
+skip_transitive_dependency_licensing true
 
 version("1.4.18") { source sha256: "ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab" }
 version("1.4.17") { source sha256: "3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e" }


### PR DESCRIPTION
autoconf, automake, and m4 are triggering license scout, presumably
because it doesn't support computing transitive dependencies for c
projects. This is breaking the chef-server build.

### Description

Add skip_transitive_dependency_licensing true to those definitions

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ x ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
