### PR TITLE
Remove libsodium dep from chef

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -53,7 +53,6 @@ dependency "bundler"
 dependency "ohai"
 dependency "appbundler"
 dependency "libarchive" # for archive resource
-dependency "libsodium" # for ed25519 support
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
We're not going to use rbnacl which required this. We'll get ed25519
support via net-ssh 5.x

Signed-off-by: Tim Smith <tsmith@chef.io>