### PR TITLE
Add cacerts 2019-01-23 file

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,9 +20,11 @@ license "MPL-2.0"
 license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
-default_version "2018-12-05"
+default_version "2019-01-23"
 
 source url: "https://curl.haxx.se/ca/cacert-#{version}.pem"
+
+version("2019-01-23") { source sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000" }
 
 version("2018-12-05") { source sha256: "4d89992b90f3e177ab1d895c00e8cded6c9009bec9d56981ff4f0a59e9cc56d6" }
 

--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-sugar", ">= 3.4.0"
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Adds these new roots:
  - GTS Root R1
  - GTS Root R2
  - GTS Root R3
  - GTS Root R4
  - UCA Global G2 Root
  - UCA Extended Validation Root
  - Certigna Root CA

This PR also nukes the test files config in the gemspec that doesn't
make sense since we have no test files in this repo.

Signed-off-by: Tim Smith <tsmith@chef.io>