### PR TITLE
Add ruby 2.4.6

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -40,6 +40,7 @@ version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576
 version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
 
+version("2.4.6")      { source sha256: "909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" }
 version("2.4.5")      { source sha256: "6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198" }
 version("2.4.4")      { source sha256: "254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a" }
 version("2.4.3")      { source sha256: "fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98" }


### PR DESCRIPTION
This fixes a bunch of CVEs and some bugs and is the last release of Ruby 2.4 outside of security updates.

Signed-off-by: Tim Smith <tsmith@chef.io>