### PR TITLE
update chef defn for open source software work

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -81,12 +81,18 @@ build do
   mkdir "pkg"
   copy "chef*.gem", "pkg"
 
+  extra_bin_files = []
+  Dir["#{project_dir}/spec/support/bin/*"].each do |binstub|
+    extra_bin_files << File.basename(binstub)
+    copy binstub, "#{install_dir}/embedded/bin"
+  end
+
   # Always deploy the powershell modules in the correct place.
   if windows?
     mkdir "#{install_dir}/modules/chef"
     copy "distro/powershell/chef/*", "#{install_dir}/modules/chef"
   end
 
-  appbundle "chef", env: env
+  appbundle "chef", extra_bin_files: extra_bin_files, env: env
   appbundle "ohai", env: env
 end


### PR DESCRIPTION
in Chef-15 the binstubs are going to live in spec/support/bin and not be shipped
with the gem, so omnibus needs to place them back in.

this is written to be backcompatible with Chef-14 via just looking for
the presence of the files or not.
