### PR TITLE
Add Ruby 2.6.3 as the new default

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,13 +25,14 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.6.2"
+default_version "2.6.3"
 
 dependency "zlib"
 dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
 
+version("2.6.3")      { source sha256: "577fd3795f22b8d91c1d4e6733637b0394d4082db659fccf224c774a2b1c82fb" }
 version("2.6.2")      { source sha256: "a0405d2bf2c2d2f332033b70dff354d224a864ab0edd462b7a413420453b49ab" }
 version("2.6.1")      { source sha256: "17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8" }
 version("2.5.5")      { source sha256: "28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c" }


### PR DESCRIPTION
This is mostly about adding support for the new Japanese cal era, but it
fixes a few minor bugs as well.

https://github.com/ruby/ruby/compare/v2_6_2...v2_6_3

Signed-off-by: Tim Smith <tsmith@chef.io>