### PR TITLE
exclude all groups plus new chefstyle group on Chef-15

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -59,7 +59,7 @@ build do
 
   # compiled ruby on windows 2k8R2 x86 is having issues compiling
   # native extensions for pry-byebug so excluding for now
-  excluded_groups = %w{server docgen maintenance pry travis integration ci}
+  excluded_groups = %w{server docgen maintenance pry travis integration ci chefstyle}
   excluded_groups << "ruby_prof" if aix?
   excluded_groups << "ruby_shadow" if aix?
   excluded_groups << "ed25519" if solaris2?
@@ -90,9 +90,9 @@ build do
   block do
     if Dir.exist?("#{project_dir}/chef-bin")
       # Chef >= 15
-      appbundle "chef", lockdir: project_dir, gem: "chef-bin", env: env
-      appbundle "chef", lockdir: project_dir, gem: "chef", env: env
-      appbundle "chef", lockdir: project_dir, gem: "ohai", env: env
+      appbundle "chef", lockdir: project_dir, gem: "chef-bin", without: excluded_groups, env: env
+      appbundle "chef", lockdir: project_dir, gem: "chef", without: excluded_groups, env: env
+      appbundle "chef", lockdir: project_dir, gem: "ohai", without: excluded_groups, env: env
     else
       # Chef < 15
       appbundle "chef", env: env


### PR DESCRIPTION
the --without argument to bundle install removes the chefstyle gem from
the shipped artifact.

this also applies to the excludes to the merged gemfile lock that we
should be using in testing, but i believe we are still not.
