### PR TITLE
Clean up additional files in omnibus ruby installs

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -49,7 +49,7 @@ build do
     remove_directory "#{gemdir}/build_info"
   end
 
-  # Clean up docs and gem/bundler leftovers
+  # Clean up docs
   delete "#{install_dir}/embedded/docs"
   delete "#{install_dir}/embedded/share/man"
   delete "#{install_dir}/embedded/share/doc"
@@ -58,9 +58,17 @@ build do
   delete "#{install_dir}/embedded/man"
   delete "#{install_dir}/embedded/share/info"
   delete "#{install_dir}/embedded/info"
-  delete "#{install_dir}/embedded/lib/ruby/gems/*/bundler/gems/*"
-  delete "#{install_dir}/embedded/lib/ruby/gems/*/extensions/*/*/*/gem_make.out"
-  delete "#{install_dir}/embedded/lib/ruby/gems/*/extensions/*/*/*/mkmf.log"
+
+  block "Remove leftovers from compiling gems" do
+    # find the embedded ruby gems dir and clean it up for globbing
+    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/".tr('\\', "/")
+
+    # find gem_make.out and mkmf.log files
+    Dir.glob(Dir.glob("#{target_dir}/**/{gem_make.out,mkmf.log}")).each do |f|
+      puts "Deleting #{f}"
+      File.delete(f)
+    end
+  end
 
   # Check for multiple versions of the `bundler` gem and fail the build if we find more than 1.
   # Having multiple versions has burned us too many times in the past - causes warnings when

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -49,7 +49,7 @@ build do
     remove_directory "#{gemdir}/build_info"
   end
 
-  # Clean up docs
+  # Clean up docs and gem/bundler leftovers
   delete "#{install_dir}/embedded/docs"
   delete "#{install_dir}/embedded/share/man"
   delete "#{install_dir}/embedded/share/doc"
@@ -58,6 +58,9 @@ build do
   delete "#{install_dir}/embedded/man"
   delete "#{install_dir}/embedded/share/info"
   delete "#{install_dir}/embedded/info"
+  delete "#{install_dir}/embedded/lib/ruby/gems/*/bundler/gems/*"
+  delete "#{install_dir}/embedded/lib/ruby/gems/*/extensions/*/*/*/gem_make.out"
+  delete "#{install_dir}/embedded/lib/ruby/gems/*/extensions/*/*/*/mkmf.log"
 
   # Check for multiple versions of the `bundler` gem and fail the build if we find more than 1.
   # Having multiple versions has burned us too many times in the past - causes warnings when


### PR DESCRIPTION
Clean up various files in native gems

In workstation this saves us 300k on disk and 26 files. Nothing amazing, but why not.

```
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/dep-selector-libgecode-1.3.1/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/google-protobuf-3.5.2/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ffi-yajl-2.3.1/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ffi-yajl-2.3.1/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/byebug-11.0.1/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ed25519-1.2.4/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/bcrypt_pbkdf-1.0.1/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/nokogiri-1.10.4/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/nokogiri-1.10.4/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/jaro_winkler-1.5.4/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/debug_inspector-0.0.3/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ffi-1.11.1/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ffi-1.11.1/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/http_parser.rb-0.6.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ruby-shadow-2.5.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ruby-shadow-2.5.0/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/unf_ext-0.0.7.2/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/unf_ext-0.0.7.2/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/binding_of_caller-0.8.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/dep_selector-1.0.6/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/dep_selector-1.0.6/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/json-2.2.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/json-2.2.0/mkmf.log
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/libyajl2-1.2.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ruby-prof-1.0.0/gem_make.out
Deleting /opt/chef-workstation//embedded/lib/ruby/gems/2.6.0//extensions/x86_64-darwin-17/2.6.0/ruby-prof-1.0.0/mkmf.log
```

Signed-off-by: Tim Smith <tsmith@chef.io>