### PR TITLE
Adding OpenSSL 1.0.2s

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.0.2r"
+default_version "1.0.2s"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
@@ -37,6 +37,7 @@ version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }
 version("1.1.0g") { source sha256: "de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af" }
 version("1.1.0f") { source sha256: "12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765" }
+version("1.0.2s") { source sha256: "cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96" }
 version("1.0.2r") { source sha256: "ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6" }
 version("1.0.2q") { source sha256: "5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" }
 version("1.0.2p") { source sha256: "50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00" }


### PR DESCRIPTION
### Description
https://github.com/openssl/openssl/commit/cf9143f945a67f3d540e2704fdbdf1bdc985233d

*) Change the default RSA, DSA and DH size to 2048 bit instead of 1024.
    This changes the size when using the genpkey app when no size is given. It
    fixes an omission in earlier changes that changed all RSA, DSA and DH
    generation apps to use 2048 bits by default.
    [Kurt Roeckx]

*) Add FIPS support for Android Arm 64-bit

    Support for Android Arm 64-bit was added to the OpenSSL FIPS Object
    Module in Version 2.0.10. For some reason, the corresponding target
    'android64-aarch64' was missing OpenSSL 1.0.2, whence it could not be
    built with FIPS support on Android Arm 64-bit. This omission has been
    fixed.
    [Matthias St. Pierre]

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
