### PR TITLE
Update curl to 7.65

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.63.0"
+default_version "7.65.0"
 
 dependency "zlib"
 dependency "openssl"
@@ -24,6 +24,7 @@ dependency "cacerts"
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
+version("7.65.0") { source sha256: "2a65f4f858a1fa949c79f926ddc2204c2be353ccbad014e95cd322d4a87d82ad" }
 version("7.63.0") { source sha256: "d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41" }
 version("7.59.0") { source sha256: "099d9c32dc7b8958ca592597c9fabccdf4c08cfb7c114ff1afbbc4c6f13c9e9e" }
 version("7.56.0") { source sha256: "f1bc17a7e5662dbd8d4029750a6dbdb72a55cf95826a270ab388b05075526104" }


### PR DESCRIPTION
This has a huge number of bug fixes and enhancements plus:

CVE-2019-5435: Integer overflows in curl_url_set
CVE-2019-5436: tftp: use the current blksize for recvfrom()
CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
CVE-2019-3823: SMTP end-of-response out-of-bounds read

Signed-off-by: Tim Smith <tsmith@chef.io>