### PR TITLE
Replace cdn.rubyinstaller.org by dl.bintray

### DIFF
--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -23,17 +23,17 @@ skip_transitive_dependency_licensing true
 
 if windows_arch_i386?
   version "4.5.2-20111229-1559" do
-    source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
            md5: "4bf8f2dd1d582c8733a67027583e19a6"
   end
 
   version "4.7.2-20130224" do
-    source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-#{version}-1151-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-32-#{version}-1151-sfx.exe",
            md5: "9383f12958aafc425923e322460a84de"
   end
 else
   version "4.7.2-20130224" do
-    source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-64-#{version}-1432-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-#{version}-1432-sfx.exe",
            md5: "ce99d873c1acc8bffc639bd4e764b849"
   end
 end


### PR DESCRIPTION
Signed-off-by: Tensibai <tensibai@iabis.net>

Replace cdn.rubyinstaller.org by dl.bintray for ruby-windows-devkit

## Description
cdn.rubyinstaller.org seems to be dead (NXDOMAIN), links on the site have moved to bintray.
This PR use the new links from the site.

## Related Issue
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
