### PR TITLE
get rubygems' submodules else source builds fail

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -76,6 +76,8 @@ build do
 
   if source
     # Building from source:
+    command "git submodule init", env: env
+    command "git submodule update", env: env
     ruby "setup.rb  --no-document", env: env
   else
     # Installing direct from rubygems:


### PR DESCRIPTION
## Description

[rubygems/rubygems started vendoring bundler as a submodule in 2016](https://github.com/rubygems/rubygems/commit/aa83d3799579b8714b1f9c8c78afdb4e176bba58#diff-db852b71825b722d7e0dcb631d77414d). Possibly we don't have any projects using RubyGems from a git reference since then. But in trying to do so, builds of rubygems from a get ref error out with:

    ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory @ dir_chdir - bundler/lib

So, as much as submodules sadden me, to run rubygems' setup.rb, we need to initialize and update the repo's submodules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
