### PR TITLE
Update curl to 7.65.1

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.65.0"
+default_version "7.65.1"
 
 dependency "zlib"
 dependency "openssl"
@@ -24,6 +24,7 @@ dependency "cacerts"
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
+version("7.65.1") { source sha256: "821aeb78421375f70e55381c9ad2474bf279fc454b791b7e95fc83562951c690" }
 version("7.65.0") { source sha256: "2a65f4f858a1fa949c79f926ddc2204c2be353ccbad014e95cd322d4a87d82ad" }
 version("7.63.0") { source sha256: "d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41" }
 version("7.59.0") { source sha256: "099d9c32dc7b8958ca592597c9fabccdf4c08cfb7c114ff1afbbc4c6f13c9e9e" }

--- a/config/software/git-windows.rb
+++ b/config/software/git-windows.rb
@@ -84,7 +84,7 @@ build do
       base = File.basename(git_bin, ext)
       File.open("#{install_dir}/embedded/bin/#{base}.bat", "w") do |f|
         f.puts "@ECHO OFF"
-        f.print "START \"\" " if ["gitk", "git-gui"].include?(base.downcase)
+        f.print "START \"\" " if %w{gitk git-gui}.include?(base.downcase)
         f.puts "\"%~dp0..\\git\\cmd\\#{base}#{ext}\" %*"
       end
     end


### PR DESCRIPTION
This resolves https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5443

Signed-off-by: Tim Smith <tsmith@chef.io>