### PR TITLE
make 4.2.1 patch from LFS that the Habitat core plan was carrying

### DIFF
--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -30,6 +30,11 @@ relative_path "make-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Work around an error caused by Glibc 2.27
+  #
+  # Thanks to: http://www.linuxfromscratch.org/lfs/view/8.2/chapter05/make.html
+  command "sed -i '211,217 d; 219,229 d; 232 d' glob/glob.c", env: env
+
   command "./configure" \
           " --disable-nls" \
           " --prefix=#{install_dir}/embedded", env: env


### PR DESCRIPTION
This is a straight copy of the Habitat core plan patch to make:
https://bldr.habitat.sh/#/pkgs/core/make/4.2.1/20190115013626

Fixes https://github.com/chef/omnibus-software/issues/1070

Signed-off-by: Matt Ray <matthewhray@gmail.com>
