### PR TITLE
Uninstall the rubygems-update gem post rubygems install

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -67,6 +67,6 @@ build do
     # Installing direct from rubygems:
     # If there is no version, this will get latest.
     gem "update --no-document --system #{version}", env: env
-    gem "gem uninstall rubygems-update -ax"
+    gem "uninstall rubygems-update -ax"
   end
 end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -23,16 +23,7 @@ skip_transitive_dependency_licensing true
 dependency "ruby"
 
 if version && !source
-  # NOTE: 2.1.11 is the last version of rubygems before the 2.2.x change to native gem install location
-  #
-  #  https://github.com/rubygems/rubygems/issues/874
-  #
-  # This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
-  # We have switched from tarballs to just `gem update --system`, but for backcompat
-  # we pin the previously known tarballs.
   known_tarballs = {
-    "2.1.11" => "b561b7aaa70d387e230688066e46e448",
-    "2.2.1" => "1f0017af0ad3d3ed52665132f80e7443",
     "2.4.1" => "7e39c31806bbf9268296d03bd97ce718",
     "2.4.4" => "440a89ad6a3b1b7a69b034233cc4658e",
     "2.4.5" => "5918319a439c33ac75fbbad7fd60749d",
@@ -46,13 +37,6 @@ if version && !source
       relative_path "rubygems-#{vsn}"
     end
   end
-
-  version("v2.4.4_plus_debug") { source git: "https://github.com/danielsdeleo/rubygems.git" }
-  version("2.4.4.debug.1")     { source git: "https://github.com/danielsdeleo/rubygems.git" }
-  # This is the 2.4.8 release with a fix for
-  # windows so things like `gem install "pry"` still
-  # work
-  version("jdm/2.4.8-patched") { source git: "https://github.com/jaym/rubygems.git" }
 end
 
 # If we still don't have a source (if it's a tarball) grab from ruby ...
@@ -83,5 +67,6 @@ build do
     # Installing direct from rubygems:
     # If there is no version, this will get latest.
     gem "update --no-document --system #{version}", env: env
+    gem "gem uninstall rubygems-update -ax"
   end
 end


### PR DESCRIPTION
We really don't want to add this to our omnibus packages. It's added bulk and using it would likely break the packages.

I also removed ancient versions of rubygems

Signed-off-by: Tim Smith <tsmith@chef.io>