### PR TITLE
Fail the build if we have multiple copies of bundler installed

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -58,4 +58,14 @@ build do
   delete "#{install_dir}/embedded/man"
   delete "#{install_dir}/embedded/share/info"
   delete "#{install_dir}/embedded/info"
+
+  # Check for multiple versions of the `bundler` gem and fail the build if we find more than 1.
+  # Having multiple versions has burned us too many times in the past - causes warnings when
+  # invoking binaries.
+  block "Ensure only 1 copy of bundler is installed" do
+    bundler = shellout!("#{install_dir}/embedded/bin/gem list '^bundler$'", env: env).stdout.chomp
+    if bundler.include?(",")
+      raise "Multiple copies of bundler installed, ensure only 1 remains. Output:\n" + bundler
+    end
+  end
 end


### PR DESCRIPTION
## Description
When we have multiple copies of bundler installed we get warnings like the following:

```
$ inspec --help
WARN: Unresolved or ambigious specs during Gem::Specification.reset:
      bundler (>= 1.10)
      Available/installed versions of this gem:
      - 1.17.3
      - 1.17.2
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
```

## Related Issue
Fixes https://github.com/chef/chef-workstation/issues/405

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
