### PR TITLE
Surround bundler regex with double-quotes for Windows

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -63,7 +63,9 @@ build do
   # Having multiple versions has burned us too many times in the past - causes warnings when
   # invoking binaries.
   block "Ensure only 1 copy of bundler is installed" do
-    bundler = shellout!("#{install_dir}/embedded/bin/gem list '^bundler$'", env: env).stdout.chomp
+    # The bundler regex must be surrounded by double-quotes (not single) for Windows
+    # Under powershell, it would have to be escaped with a ` character, i.e. `"^bundler$`"
+    bundler = shellout!("#{install_dir}/embedded/bin/gem list \"^bundler$\"", env: env).stdout.chomp
     if bundler.include?(",")
       raise "Multiple copies of bundler installed, ensure only 1 remains. Output:\n" + bundler
     end


### PR DESCRIPTION
Fixes this:
```
C:/opscode/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/bundler/gems/omnibus-software-d671c6dadb4f/config/software/ruby-cleanup.rb:68:in `block (2 levels) in evaluate': Multiple copies of bundler installed, ensure only 1 remains. Output: (RuntimeError)
appbundler (0.13.1, 0.12.5)
bundler (default: 1.17.2)
```
