### PR TITLE
Update OpenResty to 1.15.8.1

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -28,6 +28,7 @@ dependency "lua" if ppc64? || ppc64le? || s390x?
 source_package_name = "openresty"
 
 # Versions above 1.11.2.2 require SSE4.2 CPU support
+version("1.15.8.1") { source sha256: "89a1238ca177692d6903c0adbea5bdf2a0b82c383662a73c03ebf5ef9f570842" }
 version("1.13.6.2") { source sha256: "946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942" }
 version("1.11.2.5") { source sha256: "f8cc203e8c0fcd69676f65506a3417097fc445f57820aa8e92d7888d8ad657b9" }
 version("1.11.2.2") { source sha256: "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01" }


### PR DESCRIPTION
## Description
Add latest version of openresty for use in chef-server

Signed-off-by: Mark Anderson <mark@chef.io>


