### PR TITLE
Add libiconv as a dependency to rust

### DIFF
--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -32,6 +32,8 @@ end
 # Default architecture is x86_64
 arch = "x86_64"
 
+dependency "libiconv"
+
 if windows?
   host_triple = "pc-windows-gnu"
 


### PR DESCRIPTION
We have found some failures on the delivery-cli pipeline with the
following error:
```
  dyld: Symbol not found: _iconv
  Referenced from: /usr/lib/libcups.2.dylib
  Expected in: /opt/chef-workstation/embedded/lib/libiconv.2.dylib in /usr/lib/libcups.2.dylib
error: Could not compile `proc-macro2`.
```

We are hoping this dependency will fix it.

Signed-off-by: Salim Afiune <afiune@chef.io>