### PR TITLE
Fix builds of delivery-cli on macOS > 10.12 & Add rust 1.37

### DIFF
--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -36,7 +36,7 @@ build do
   if linux?
     env["LD_LIBRARY_PATH"] = "#{install_dir}/embedded/lib"
   elsif mac_os_x? &&
-    platform_version.satisfies?("< 10.13")  # Setting DYLD PATH fails builds with library conflicts in 10.13
+      platform_version.satisfies?("< 10.13") # Setting DYLD PATH fails builds with library conflicts in 10.13
     env["DYLD_FALLBACK_LIBRARY_PATH"] = "#{install_dir}/embedded/lib:"
   end
 

--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -35,7 +35,8 @@ build do
   # The rust core libraries are dynamicaly linked
   if linux?
     env["LD_LIBRARY_PATH"] = "#{install_dir}/embedded/lib"
-  elsif mac_os_x?
+  elsif mac_os_x? &&
+    platform_version.satisfies?("< 10.13")  # Setting DYLD PATH fails builds with library conflicts in 10.13
     env["DYLD_FALLBACK_LIBRARY_PATH"] = "#{install_dir}/embedded/lib:"
   end
 

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -15,7 +15,7 @@
 #
 
 name "rust"
-default_version "1.32.0"
+default_version "1.37.0"
 
 license "Apache-2.0"
 license_file "LICENSE-APACHE"
@@ -38,11 +38,21 @@ if windows?
   if windows_arch_i386?
     arch = "i686"
 
+    version "1.37.0" do
+      source sha256: "52ad8448fd612b50ade0dd2a957115a2e386d1f34a81341b787018f26df0c307",
+             url: url_template % { host_triple: host_triple, arch: arch }
+    end
+
     version "1.32.0" do
       source sha256: "226b00e61095fe1b8a7f1f186087731a294235b4da53601b709517ca9dc624f0",
              url: url_template % { host_triple: host_triple, arch: arch }
     end
   else
+    version "1.37.0" do
+      source sha256: "607ecc8c1f9886956ca694a65fcc096bfe00c7776a5e88bb947786e941752e68",
+             url: url_template % { host_triple: host_triple, arch: arch }
+    end
+
     version "1.32.0" do
       source sha256: "358e1435347c67dbf33aa9cad6fe501a833d6633ed5d5aa1863d5dffa0349be9",
              url: url_template % { host_triple: host_triple, arch: arch }
@@ -52,12 +62,22 @@ if windows?
 elsif mac_os_x?
   host_triple = "apple-darwin"
 
+  version "1.37.0" do
+    source sha256: "b2310c97ffb964f253c4088c8d29865f876a49da2a45305493af5b5c7a3ca73d",
+           url: url_template % { host_triple: host_triple, arch: arch }
+  end
+
   version "1.32.0" do
     source sha256: "f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304",
            url: url_template % { host_triple: host_triple, arch: arch }
   end
 else
   host_triple = "unknown-linux-gnu"
+
+  version "1.37.0" do
+    source sha256: "cb573229bfd32928177c3835fdeb62d52da64806b844bc1095c6225b0665a1cb",
+           url: url_template % { host_triple: host_triple, arch: arch }
+  end
 
   version "1.32.0" do
     source sha256: "e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810",


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
With older rust versions the builds fail with `dyld: Symbol not found: _iconv` error due to a bug.  Update to latest stable rust version 1.37.0 resolves this build error

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
