### PR TITLE
Revisited reverted patch to make to make it Ubuntu 18.04, Debian 10 and Raspbian-only

### DIFF
--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -30,6 +30,13 @@ relative_path "make-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Work around an error caused by Glibc 2.27
+  if debian_after_or_at_buster? || ubuntu_before_or_at_bionic? || raspbian?
+    # Thanks to: http://www.linuxfromscratch.org/lfs/view/8.2/chapter05/make.html
+    # sed -i is not supported so exclude the patch for FreeBSD, Solaris and AIX
+    command "sed -i '211,217 d; 219,229 d; 232 d' glob/glob.c", env: env
+  end
+
   command "./configure" \
           " --disable-nls" \
           " --prefix=#{install_dir}/embedded", env: env


### PR DESCRIPTION
Still an issue, but now the patch has a narrower scope.

See
https://github.com/chef/omnibus-software/pull/1085
and
https://github.com/chef/omnibus-software/commit/cca7d82fb20bd49ab06ae8958bce6b9a3599f759

Signed-off-by: Matt Ray <matthewhray@gmail.com>
