### PR TITLE
Adds Golang 1.13.1 as a Software definition

### DIFF
--- a/config/software/go-uninstall.rb
+++ b/config/software/go-uninstall.rb
@@ -25,5 +25,8 @@ build do
   %w{go gofmt}.each do |bin|
     delete "#{install_dir}/embedded/bin/#{bin}"
   end
-  remove_directory "#{install_dir}/embedded/go"
+
+  block "Delete Go language from embedded directory" do
+    remove_directory "#{install_dir}/embedded/go"
+  end
 end

--- a/config/software/go-uninstall.rb
+++ b/config/software/go-uninstall.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2019 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "go-uninstall"
+default_version "0.0.1"
+license :project_license
+dependency "go"
+
+build do
+  # Until Omnibus has full support for build depedencies (see chef/omnibus#483)
+  # we are going to manually uninstall Go
+  %w{go gofmt}.each do |bin|
+    delete "#{install_dir}/embedded/bin/#{bin}"
+  end
+  remove_directory "#{install_dir}/embedded/go"
+end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -53,7 +53,7 @@ end
 
 build do
   # We do not use 'sync' since we've found multiple errors with other software definitions
-  copy "#{project_dir}/", "#{install_dir}/embedded/"
+  copy "#{project_dir}/go", "#{install_dir}/embedded/go"
   mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
     link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -54,7 +54,6 @@ end
 build do
   # We do not use 'sync' since we've found multiple errors with other software definitions
   copy "#{project_dir}/go", "#{install_dir}/embedded/go"
-  mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
     link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
   end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -54,6 +54,6 @@ end
 build do
   mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
-    copy "#{project_dir}/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
+    link "#{project_dir}/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
   end
 end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -1,0 +1,60 @@
+#
+# Copyright 2019 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "go"
+default_version "1.13.1"
+license "BSD-3-Clause"
+license_file "https://raw.githubusercontent.com/golang/go/master/LICENSE"
+
+# Check golang releases at: https://golang.org/dl/
+url_template = "https://dl.google.com/go/go#{version}.%{platform}-%{arch}.tar.gz"
+
+# Default architecture
+arch = "amd64"
+
+if windows?
+  platform = "windows"
+
+  # On windows Go uses either '.zip' or '.msi'
+  url_template = "https://dl.google.com/go/go#{version}.%{platform}-%{arch}.zip"
+
+  version "1.13.1" do
+    source sha256: "24cb08d369c1962cccacedc56fd79dc130f623b3b667a316554621ad6ac9b442",
+           url: url_template % { platform: platform, arch: arch }
+  end
+elsif mac_os_x?
+  platform = "darwin"
+
+  version "1.13.1" do
+    source sha256: "f3985fced3adecb62dd1e636cfa5eb9fea8f3e98101d9fcc4964d8f1ec255b7f",
+           url: url_template % { platform: platform, arch: arch }
+  end
+else
+  platform = "linux"
+
+  version "1.13.1" do
+    source sha256: "94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124",
+           url: url_template % { platform: platform, arch: arch }
+  end
+end
+
+build do
+  sync  "#{project_dir}/", "#{install_dir}/embedded/"
+  mkdir "#{install_dir}/embedded/bin"
+  %w{go gofmt}.each do |bin|
+    link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
+  end
+end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -52,9 +52,8 @@ else
 end
 
 build do
-  sync  "#{project_dir}/", "#{install_dir}/embedded/"
   mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
-    link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
+    copy "#{project_dir}/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
   end
 end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -52,8 +52,10 @@ else
 end
 
 build do
+  # We do not use 'sync' since we've found multiple errors with other software definitions
+  copy "#{project_dir}/", "#{install_dir}/embedded/"
   mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
-    link "#{project_dir}/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
+    link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
   end
 end


### PR DESCRIPTION
## Description
Adds Golang as an Omnibus Software definition.

## Related Issue
https://github.com/chef/chef-workstation/issues/497

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
