### PR TITLE
appbundle inspec binary

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -90,11 +90,13 @@ build do
   block do
     if Dir.exist?("#{project_dir}/chef-bin")
       # Chef >= 15
+      appbundle "chef", lockdir: project_dir, gem: "inspec-core-bin", without: excluded_groups, env: env
       appbundle "chef", lockdir: project_dir, gem: "chef-bin", without: excluded_groups, env: env
       appbundle "chef", lockdir: project_dir, gem: "chef", without: excluded_groups, env: env
       appbundle "chef", lockdir: project_dir, gem: "ohai", without: excluded_groups, env: env
     else
       # Chef < 15
+      appbundle "inspec-core", env: env
       appbundle "chef", env: env
       appbundle "ohai", env: env
     end


### PR DESCRIPTION
bugs have been reported using /opt/chef/embedded/bin/inspec in
the presence of other gems, appbundling the inspec bin will
fix that.
