### PR TITLE
revert chef-14 inspec-core

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -96,7 +96,6 @@ build do
       appbundle "chef", lockdir: project_dir, gem: "ohai", without: excluded_groups, env: env
     else
       # Chef < 15
-      appbundle "inspec-core", env: env
       appbundle "chef", env: env
       appbundle "ohai", env: env
     end


### PR DESCRIPTION
we'd need a software defn for this and the way its built makes that
mildly annoying so revert for now.
