### PR TITLE
Add automake-1.16

### DIFF
--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -23,13 +23,9 @@ license "GPL-2.0"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version "1.15" do
-  source md5: "716946a105ca228ab545fc37a70df3a3"
-end
-
-version "1.11.2" do
-  source md5: "79ad64a9f6e83ea98d6964cef8d8a0bc"
-end
+version("1.16") { source md5: "7fb7155e553dc559ac39cf525f0bb5de" }
+version("1.15") { source md5: "716946a105ca228ab545fc37a70df3a3" }
+version("1.11.2") { source md5: "79ad64a9f6e83ea98d6964cef8d8a0bc" }
 
 source url: "https://ftp.gnu.org/gnu/automake/automake-#{version}.tar.gz"
 
@@ -38,7 +34,7 @@ relative_path "automake-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  if version.satisfies?(">= 1.15")
+  if version.satisfies?(">= 1.15") && version.satisfies?("< 1.16")
     command "./bootstrap.sh", env: env
   else
     command "./bootstrap", env: env


### PR DESCRIPTION
This is needed to get chef-dk to build properly on CentOS 8. Also, this version
seems to rename the bootstrap.sh script back to bootstrap.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
