### PR TITLE
bump the minor versions of some deps.

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxml2"
-default_version "2.9.9"
+default_version "2.9.10"
 
 license "MIT"
 license_file "COPYING"
@@ -25,6 +25,7 @@ dependency "zlib"
 dependency "liblzma"
 dependency "config_guess"
 
+version("2.9.10") { source sha256: "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f" }
 version("2.9.9") { source sha256: "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871" }
 version("2.9.8") { source sha256: "0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732" }
 version("2.9.7") { source sha256: "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c" }

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxslt"
-default_version "1.1.30"
+default_version "1.1.34"
 
 license "MIT"
 license_file "COPYING"
@@ -24,6 +24,10 @@ skip_transitive_dependency_licensing true
 dependency "libxml2"
 dependency "liblzma"
 dependency "config_guess"
+
+version "1.1.34" do
+  source sha256: "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
+end
 
 version "1.1.30" do
   source sha256: "ba65236116de8326d83378b2bd929879fa185195bc530b9d1aba72107910b6b3"

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -15,7 +15,7 @@
 #
 
 name "server-jre"
-default_version "8u162"
+default_version "8u202"
 
 unless _64_bit?
   raise "Server-jre can only be installed on x86_64 systems."
@@ -40,6 +40,17 @@ whitelist_file "jre/bin/appletviewer"
 
 license_warning = "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
 license_cookie = "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie"
+
+# This is the final release of the Oracle Java under the 'Oracle Binary Code License Agreement'
+version "8u202" do
+  source url: "https://download.oracle.com/otn/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/server-jre-8u202-linux-x64.tar.gz",
+         sha256: "61292e9d9ef84d9702f0e30f57b208e8fbd9a272d87cd530aece4f5213c98e4e",
+         cookie: license_cookie,
+         warning: license_warning,
+         unsafe:  true
+
+  relative_path "jdk1.8.0_202"
+end
 
 version "8u162" do
   # https://www.oracle.com/webfolder/s/digest/8u162checksum.html


### PR DESCRIPTION
libxml2 2.9.9 -> 2.9.10
libxslt 1.1.30 -> 1.1.34
server-jre 8u162 -> 8u202 (the last version with the friendly license)
