### PR TITLE
Fix libxslt header path for libxml2

### DIFF
--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -57,8 +57,6 @@ build do
   # style path to accomodate
   configure_commands = [
     "--with-libxml-prefix=#{install_dir.sub("C:", "/C")}/embedded",
-    "--with-libxml-include-prefix=#{install_dir}/embedded/include",
-    "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
     "--without-python",
     "--without-crypto",
   ]


### PR DESCRIPTION
We were previously running 1.1.30 because of issues getting libxslt  > 1.1.30 building, which I believe were related to a number of changes related to the configure script in libxslt 1.1.31. 

Switching `--with-libxml-include-prefix` to `...include/libxml2` instead of just `...include` fixed an issue finding a header, but then hit some issues with library paths. Ultimately removing `--with-libxml-include-prefix` and `--with-libxml-libs-prefix` but leaving `--with-libxml-prefix` pointing to our `--prefix` (specified elsewhere in omnibus) worked for both 1.1.30 and 1.1.34 (latest).