### PR TITLE
Cleanup various CI related files in the root of installed gems

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -70,6 +70,35 @@ build do
     end
   end
 
+  block "Removing random non-code files from installed gems" do
+    # find the embedded ruby gems dir and clean it up for globbing
+    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
+    files = %w{
+      .travis.yml
+      .rspec
+      .gitignore
+      .document
+      .yardopts
+      .hound.yml
+      .rubocop.yml
+      appveyor.yml
+      .rubocop_todo.yml
+      .ruby-gemset
+      .gemtest
+      .ruby-version
+      .gitmodules
+      .coveralls.yml
+      .yardstick.yml
+      .irbrc
+      Guardfile
+    }
+
+    Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|
+      puts "Deleting #{f}"
+      File.delete(f)
+    end
+  end
+
   # Check for multiple versions of the `bundler` gem and fail the build if we find more than 1.
   # Having multiple versions has burned us too many times in the past - causes warnings when
   # invoking binaries.


### PR DESCRIPTION
For Chef-Workstation this is 269 files in our install that are entirely unused by Ruby

```
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-rzmq-2.0.7/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-rzmq-2.0.7/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gcewinpass-1.1.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gcewinpass-1.1.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gcewinpass-1.1.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gcewinpass-1.1.0/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rake-12.3.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/dep-selector-libgecode-1.3.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-rzmq-core-1.0.7/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-rzmq-core-1.0.7/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/google-api-client-0.23.9/.rubocop_todo.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/highline-1.7.10/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/highline-1.7.10/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/logging-2.2.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/logging-2.2.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rb-fsevent-0.10.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rb-fsevent-0.10.3/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wasabi-3.5.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wasabi-3.5.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wasabi-3.5.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/shellany-0.0.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/shellany-0.0.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/shellany-0.0.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wisper-2.0.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wisper-2.0.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/wisper-2.0.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/mdl-0.7.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/mdl-0.7.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/trollop-2.9.9/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/trollop-2.9.9/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/coercible-1.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/coercible-1.0.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/coercible-1.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/coercible-1.0.0/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ed25519-1.2.4/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ed25519-1.2.4/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ed25519-1.2.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ed25519-1.2.4/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ed25519-1.2.4/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-gateway-2.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-gateway-2.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-gateway-2.0.0/.ruby-version
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/bcrypt_pbkdf-1.0.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/akami-1.3.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/akami-1.3.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/akami-1.3.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/retriable-3.1.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/retriable-3.1.2/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/retriable-3.1.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/retriable-3.1.2/.hound.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/retriable-3.1.2/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.ruby-version
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equalizer-0.0.11/.yardstick.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/declarative-0.0.10/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/declarative-0.0.10/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/kartograph-0.2.7/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/kartograph-0.2.7/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/kartograph-0.2.7/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/descendants_tracker-0.0.4/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/descendants_tracker-0.0.4/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/descendants_tracker-0.0.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/descendants_tracker-0.0.4/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/descendants_tracker-0.0.4/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-cookie-1.0.3/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-cookie-1.0.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/debug_inspector-0.0.3/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/thor-0.20.3/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.11.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.11.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.11.1/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.11.1/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.11.1/.gitmodules
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gssapi-1.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/octokit-4.14.0/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ice_nine-0.11.2/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/logify-0.2.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/logify-0.2.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/nenv-0.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uber-0.1.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uber-0.1.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/.rubocop_todo.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rainbow-3.0.0/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/unf-0.1.4/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/unf-0.1.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/backports-3.15.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/backports-3.15.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/backports-3.15.0/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/backports-3.15.0/.gitmodules
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/backports-3.15.0/.irbrc
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-its-1.3.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-its-1.3.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-its-1.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-telnet-0.2.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-telnet-0.2.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-scp-2.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-scp-2.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/thread_safe-0.3.6/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/thread_safe-0.3.6/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/thread_safe-0.3.6/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/inifile-3.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/inifile-3.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/paint-1.0.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/paint-1.0.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/sslshake-1.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/.gitmodules
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/method_source-0.9.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/method_source-0.9.2/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/method_source-0.9.2/.gemtest
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/representable-3.0.4/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/representable-3.0.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ast-2.4.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ast-2.4.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ast-2.4.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-mocks-3.8.2/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-mocks-3.8.2/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/parser-2.6.5.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/parser-2.6.5.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/parser-2.6.5.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/timeliness-0.3.10/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/declarative-option-0.1.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/declarative-option-0.1.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/little-plugger-1.1.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/nori-2.6.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/nori-2.6.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/nori-2.6.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/sshkey-1.9.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/sshkey-1.9.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/public_suffix-3.1.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/public_suffix-3.1.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/public_suffix-3.1.1/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/public_suffix-3.1.1/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/public_suffix-3.1.1/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/xmlrpc-0.3.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/xmlrpc-0.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/faraday-cookie_jar-0.0.6/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/domain_name-0.5.20190701/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/domain_name-0.5.20190701/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/domain_name-0.5.20190701/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/memoist-0.16.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/memoist-0.16.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/multipart-post-2.1.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/multipart-post-2.1.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/multipart-post-2.1.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/multipart-post-2.1.1/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ipaddress-0.8.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ipaddress-0.8.3/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/httpi-2.4.4/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/httpi-2.4.4/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/httpi-2.4.4/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/os-1.0.1/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/power_assert-1.1.3/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/power_assert-1.1.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.2/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rubyntlm-0.6.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rubyntlm-0.6.2/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rubyntlm-0.6.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/term-ansicolor-1.7.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/term-ansicolor-1.7.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.ruby-version
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/.coveralls.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-2.2.2/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/slop-3.6.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/slop-3.6.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/cleanroom-1.0.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/cleanroom-1.0.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/did_you_mean-1.3.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/did_you_mean-1.3.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/did_you_mean-1.3.0/.ruby-version
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/diff-lcs-1.3/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/binding_of_caller-0.8.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/binding_of_caller-0.8.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/binding_of_caller-0.8.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/binding_of_caller-0.8.0/.gemtest
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/axiom-types-0.1.1/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rbvmomi-1.13.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rbvmomi-1.13.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rbvmomi-1.13.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/googleauth-0.6.7/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/googleauth-0.6.7/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/googleauth-0.6.7/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/googleauth-0.6.7/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/json-2.2.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/json-2.2.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/hashie-3.6.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/mini_portile2-2.4.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/mini_portile2-2.4.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/mini_portile2-2.4.0/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tins-1.22.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tins-1.22.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pry-stack_explorer-0.4.9.3/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pry-stack_explorer-0.4.9.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pry-stack_explorer-0.4.9.3/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pry-stack_explorer-0.4.9.3/.gemtest
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/yard-0.9.20/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.ruby-gemset
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/.ruby-version
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/virtus-1.0.5/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/savon-2.12.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/savon-2.12.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/savon-2.12.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/net-ssh-5.2.0/.rubocop_todo.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/r18n-core-3.2.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/appveyor.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http-form_data-1.0.3/Guardfile
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/resource_kit-0.1.7/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/resource_kit-0.1.7/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/resource_kit-0.1.7/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/jwt-2.2.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/jwt-2.2.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/jwt-2.2.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/jwt-2.2.1/.rubocop.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/r18n-desktop-3.2.0/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.2/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.2/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rb-inotify-0.10.0/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rb-inotify-0.10.0/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rb-inotify-0.10.0/.yardopts
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gyoku-1.3.1/.travis.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gyoku-1.3.1/.rspec
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/gyoku-1.3.1/.gitignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.8.6/.document
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.8.6/.yardopts
```