### PR TITLE
Remove chef-sugar dependency entirely

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
   s.add_dependency "omnibus", ">= 5.6.1"
-  s.add_dependency "chef-sugar", ">= 5.0.0"
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
This is part of omnibus and we dep on omnibus.

Signed-off-by: Tim Smith <tsmith@chef.io>