### PR TITLE
add -O3 to windows ruby compiles

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -105,8 +105,7 @@ elsif solaris_11?
 elsif windows?
   env["CFLAGS"] = "-I#{install_dir}/embedded/include -DFD_SETSIZE=2048"
   if windows_arch_i386?
-    # 32-bit windows can't compile ruby with -O2 due to compiler bugs.
-    env["CFLAGS"] << " -m32 -march=i686 -O"
+    env["CFLAGS"] << " -m32 -march=i686 -O3"
   else
     env["CFLAGS"] << " -m64 -march=x86-64 -O3"
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -108,7 +108,7 @@ elsif windows?
     # 32-bit windows can't compile ruby with -O2 due to compiler bugs.
     env["CFLAGS"] << " -m32 -march=i686 -O"
   else
-    env["CFLAGS"] << " -m64 -march=x86-64 -O2"
+    env["CFLAGS"] << " -m64 -march=x86-64 -O3"
   end
   env["CPPFLAGS"] = env["CFLAGS"]
   env["CXXFLAGS"] = env["CFLAGS"]


### PR DESCRIPTION
RubyInstaller does this for both 32-bit and 64-bit.

The note on 32-bit is old.

build with 64-bit was successful:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/129

build adding the 32-bit was successful (modulo one unrelated macosx sunspot failure):

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/131