### PR TITLE
remove build time deps from chef builds

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2015 Chef Software, Inc.
+# Copyright 2012-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@ default_version "3.2.1"
 license "MIT"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
-
-# Is libtool actually necessary? Doesn't configure generate one?
-dependency "libtool" unless windows?
 
 version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
 version("3.2.1")  { source md5: "83b89587607e3eb65c70d361f13bab43" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Chef Software, Inc.
+# Copyright 2012-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "cacerts"
-dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
 default_version "1.0.2t"


### PR DESCRIPTION
removes libtool and makedepend

passed builds here:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/141#b2622207-8a44-4372-ab29-3fc3e7e3ef0d

this has probably been in omnibus-toolchain fully for ages but was never removed.