### PR TITLE
Disable libzstd support in libarchive

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -52,6 +52,7 @@ build do
     "--disable-bsdtar", # tar command line tool
     "--disable-bsdcpio", # cpio command line tool
     "--without-openssl",
+    "--without-zstd",
   ]
 
   if s390x?


### PR DESCRIPTION
## Description
Fixes healthcheck errors after building on a host that has libzstd installed

## Related Issue
none - happy to create one if necessary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [n/a] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
