### PR TITLE
Avoid realpath'ing in requires to greatly speed up requires / reduce lstats

### DIFF
--- a/config/patches/ruby/ruby-faster-load_26.patch
+++ b/config/patches/ruby/ruby-faster-load_26.patch
@@ -1,0 +1,11 @@
+--- a/load.c
++++ b/load.c
+@@ -605,7 +605,7 @@ rb_load_internal0(rb_execution_context_t *ec, VALUE fname, int wrap)
+ 	    rb_parser_set_context(parser, NULL, FALSE);
+ 	    ast = (rb_ast_t *)rb_parser_load_file(parser, fname);
+ 	    iseq = rb_iseq_new_top(&ast->body, rb_fstring_lit("<top (required)>"),
+-			    fname, rb_realpath_internal(Qnil, fname, 1), NULL);
++			    fname, fname, NULL);
+ 	    rb_ast_dispose(ast);
+ 	}
+         rb_exec_event_hook_script_compiled(ec, iseq, Qnil);

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -135,6 +135,8 @@ build do
   # cost of this behavior in core ruby is enormous.
   patch source: "ruby-fast-load_26.patch", plevel: 1, env: patch_env
 
+  patch source: "ruby-faster-load_26.patch", plevel: 1, env: patch_env
+
   # disable libpath in mkmf across all platforms, it trolls omnibus and
   # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
   # this was a good idea, but it breaks our use case hard.  AIX cannot even


### PR DESCRIPTION
This passes all our tests in all our builds.

It pretty much can't cause any issues on modern Linuxen (Ubuntu 19.04) since ruby uses openat(2) which does the equivalent of a File.expand_path, so its pointless for ruby to call it.

Testing on centos6 (which does not have openat(2)) with ruby's `make test` also does not fail.  Manually trying to abuse the API by inserting paths with dots into `require` statements also does not fail.  Most things which call this routine already seem to be `expand_path`'d ahead of time (so symlink in the $LOAD_PATH are expanded before this is ever called, and require_relative does its own clearly-necessary expansion before calling require).

This speeds up `chef-client --version` on my Windows 2016 box from about 4.0 seconds to about 3.0 seconds, so the perf speedup is large.  On Linux this avoids 10,000s of lstat(2) calls.