### PR TITLE
Expand our Ruby cleanup to slim our Omnibus installs further

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,23 +30,43 @@ build do
   # except AIX which uses them at runtime.
   unless aix?
     block "Remove static libraries" do
-      # find the embedded ruby gems dir and clean it up for globbing
-      target_dir = "#{install_dir}/embedded/lib/ruby/gems".tr('\\', "/")
+      gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
 
       # find all the static *.a files and delete them
-      Dir.glob("#{target_dir}/**/*.a").each do |f|
+      Dir.glob("#{gemdir}/**/*.a").each do |f|
         puts "Deleting #{f}"
         File.delete(f)
       end
     end
   end
 
-  # Clear the now-unnecessary git caches, cached gems, build information
-  block "Delete bundler git cache and git installs" do
+  # Clear the now-unnecessary git caches, docs, and build information
+  block "Delete bundler git cache, docs, and build info" do
     gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+
     remove_directory "#{gemdir}/cache"
     remove_directory "#{gemdir}/doc"
     remove_directory "#{gemdir}/build_info"
+  end
+
+  block "Remove bundler gem caches" do
+     gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+
+    Dir.glob("#{gemdir}/bundler/gems/**").each do |f|
+      puts "Deleting #{f}"
+      remove_directory f
+    end
+  end
+
+  block "Remove leftovers from compiling gems" do
+    # find the embedded ruby gems dir and clean it up for globbing
+    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/".tr('\\', "/")
+
+    # find gem_make.out and mkmf.log files
+    Dir.glob(Dir.glob("#{target_dir}/**/{gem_make.out,mkmf.log}")).each do |f|
+      puts "Deleting #{f}"
+      File.delete(f)
+    end
   end
 
   # Clean up docs
@@ -60,19 +80,19 @@ build do
   delete "#{install_dir}/embedded/info"
 
   block "Remove leftovers from compiling gems" do
-    # find the embedded ruby gems dir and clean it up for globbing
-    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/".tr('\\', "/")
+    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
 
     # find gem_make.out and mkmf.log files
-    Dir.glob(Dir.glob("#{target_dir}/**/{gem_make.out,mkmf.log}")).each do |f|
+    Dir.glob("#{gemdir}/extensions/**/{gem_make.out,mkmf.log}").each do |f|
       puts "Deleting #{f}"
       File.delete(f)
     end
   end
 
   block "Removing random non-code files from installed gems" do
+    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+
     # find the embedded ruby gems dir and clean it up for globbing
-    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
       .codeclimate.yml
       .concourse.yml
@@ -80,6 +100,7 @@ build do
       .document
       .ebert.yml
       .gemtest
+      .github
       .gitignore
       .gitmodules
       .hound.yml
@@ -95,12 +116,38 @@ build do
       .travis.yml
       .yardopts
       .yardstick.yml
-      Guardfile
       appveyor.yml
+      ARCHITECTURE.md
+      CHANGELOG
+      CHANGELOG.md
+      CHANGELOG.rdoc
+      CHANGELOG.txt
+      CHANGES
+      CHANGES.md
+      CHANGES.txt
+      Code-of-Conduct.md
+      CODE_OF_CONDUCT.md
+      CONTRIBUTING.md
+      CONTRIBUTORS.md
+      Guardfile
+      GUIDE.md
+      HISTORY
+      HISTORY.md
+      History.rdoc
+      HISTORY.txt
       ISSUE_TEMPLATE.md
+      MIGRATING.md
+      README
+      README.markdown
+      README.*md
+      README.rdoc
+      README.txt
+      TODO
+      TODO.md
+      UPGRADING.md
     }
 
-    Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|
+    Dir.glob(Dir.glob("#{gemdir}/*/{#{files.join(",")}}")).each do |f|
       puts "Deleting #{f}"
       File.delete(f)
     end

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -50,7 +50,7 @@ build do
   end
 
   block "Remove bundler gem caches" do
-     gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
 
     Dir.glob("#{gemdir}/bundler/gems/**").each do |f|
       puts "Deleting #{f}"
@@ -100,7 +100,6 @@ build do
       .document
       .ebert.yml
       .gemtest
-      .github
       .gitignore
       .gitmodules
       .hound.yml
@@ -147,7 +146,7 @@ build do
       UPGRADING.md
     }
 
-    Dir.glob(Dir.glob("#{gemdir}/*/{#{files.join(",")}}")).each do |f|
+    Dir.glob(Dir.glob("#{gemdir}/gems/*/{#{files.join(",")}}")).each do |f|
       puts "Deleting #{f}"
       File.delete(f)
     end


### PR DESCRIPTION
This simplifies the existing logic, but also includes cleanup of the bundler caches. This will remove ohai and chefstyle caches in the chef/chef omnibus project which drops our install by 2.7 megs. This also includes logic we shipped in Workstation / DK to remove more markdown and txt files from gems, which speeds up installs on Windows and reduces overall package size.

Signed-off-by: Tim Smith <tsmith@chef.io>