### PR TITLE
remove -fstack-protector-strong on RHEL6

### DIFF
--- a/config/patches/ruby/ruby-no-stack-protector-strong.patch
+++ b/config/patches/ruby/ruby-no-stack-protector-strong.patch
@@ -1,0 +1,11 @@
+--- ruby-2.6.5/configure.old	2019-12-06 13:03:20.962288441 -0800
++++ ruby-2.6.5/configure	2019-12-06 13:03:32.242919275 -0800
+@@ -8409,7 +8409,7 @@
+ esac
+     if test -z "${stack_protector+set}"; then :
+ 
+-	for opt in -fstack-protector-strong -fstack-protector
++	for opt in -fstack-protector
+ do :
+ 
+ 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -127,6 +127,17 @@ build do
     patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
   end
 
+  # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we
+  # cannot build modern ruby on the RHEL6 base compiler, and the configure script
+  # determines that it supports that flag and so includes it and then ultimately
+  # pushes that into native gem compilations which then blows up for end users when
+  # they try to install native gems.  So, we have to hack this up to avoid using
+  # that flag on RHEL6.
+  #
+  if rhel? && platform_version.satisfies?("< 7")
+    patch source: "ruby-no-stack-protector-strong.patch", plevel: 1, env: patch_env
+  end
+
   # accelerate requires of c-extension.
   #
   # this would break code which did `require "thing"` and loaded thing.so and


### PR DESCRIPTION

```
  # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we
  # cannot build modern ruby on the RHEL6 base compiler, and the configure script
  # determines that it supports that flag and so includes it and then ultimately
  # pushes that into native gem compilations which then blows up for end users when
  # they try to install native gems.  So, we have to hack this up to avoid using
  # that flag on RHEL6.
```