### PR TITLE
Use clang when building Perl on mac_os_x

### DIFF
--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -39,6 +39,8 @@ build do
     cc_command = "-Dcc='/opt/IBM/xlc/13.1.0/bin/cc_r -q64'"
   elsif freebsd? && ohai["os_version"].to_i >= 1000024
     cc_command = "-Dcc='clang'"
+  elsif mac_os_x?
+    cc_command = "-Dcc='clang'"
   else
     cc_command = "-Dcc='gcc -static-libgcc'"
   end


### PR DESCRIPTION
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>

Update Perl to use `clang` as the compiler when building on MacOS

## Description
After updating our pipeline to use MacOS 10.13 images (from 10.12), when building Perl the build errored with `clang: error: unsupported option '-static-libgcc'`
https://buildkite.com/chef/habitat-sh-mac-bootstrapper-master-omnibus-build/builds/14#5b0ccf4f-a70e-4528-b62c-9df87da71fe8

After doing some digging, Perl looks to have been brought in as a transitive dependency for automake in e7aae886480aa14848163b2ba5503fa8044c68ab , so I believe the platform version change was only the event, rather than a cause of the build failures. 

Changing the `cc_command` to `clang` when building on MacOS 10.14.6 allowed the build of Perl to succeed.  I don't have ready access to a MacOS 10.12, 10.13 or >10.14 to validate this change works on those versions.  Since clang has been the default compiler for some time on MacOS, I doubt the Perl software definition in Omnibus has ever been built on MacOS, so this should be a fairly safe change to make.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
