### PR TITLE
Patch ruby to not throw win32 deprecation warnings

### DIFF
--- a/config/patches/ruby/ruby-win32_warning_removal.patch
+++ b/config/patches/ruby/ruby-win32_warning_removal.patch
@@ -1,0 +1,12 @@
+--- a/ext/win32/lib/Win32API.rb
++++ b/ext/win32/lib/Win32API.rb
+@@ -1,9 +1,6 @@
+ # -*- ruby -*-
+ # frozen_string_literal: true
+ 
+-# for backward compatibility
+-warn "Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead", uplevel: 2
+-
+ require 'fiddle/import'
+ 
+ class Win32API

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -120,6 +120,11 @@ build do
   patch_env = env.dup
   patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
 
+  if windows?
+    # remove the warning that the win32 api is going away.
+    patch source: "ruby-win32_warning_removal.patch", plevel: 1, env: patch_env
+  end
+
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.


### PR DESCRIPTION
These warnings are entirely useless to users. We previously avoided them by using the win32api gem that removes them. We can deal with the move once they actually remove win32, but I don't see that happening anytime soon since this is a 1.9.1+ warning.

Signed-off-by: Tim Smith <tsmith@chef.io>