### PR TITLE
Cleanup additional files from Ruby installs

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -127,22 +127,30 @@ build do
       Code-of-Conduct.md
       CODE_OF_CONDUCT.md
       CONTRIBUTING.md
+      CONTRIBUTING.rdoc
       CONTRIBUTORS.md
+      FAQ.txt
       Guardfile
       GUIDE.md
       HISTORY
       HISTORY.md
       History.rdoc
       HISTORY.txt
+      INSTALL
       ISSUE_TEMPLATE.md
+      Manifest
+      Manifest.txt
       MIGRATING.md
       README
-      README.markdown
       README.*md
+      readme.erb
+      README.markdown
       README.rdoc
       README.txt
+      README_INDEX.rdoc
+      THANKS.txt
       TODO
-      TODO.md
+      TODO*.md
       UPGRADING.md
     }
 


### PR DESCRIPTION
We've been cleaning these from our workstation install. Makes it a small amount smaller and faster to install on Windows.

Signed-off-by: Tim Smith <tsmith@chef.io>