### PR TITLE
Bump git to 2.24.1 to resolve multiple CVEs

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2019 Chef Software, Inc.
+# Copyright 2014-2020 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 name "git"
-default_version "2.23.0"
+default_version "2.24.1"
 
 license "LGPL-2.1"
 license_file "LGPL-2.1"
@@ -30,6 +30,7 @@ dependency "expat"
 
 relative_path "git-#{version}"
 
+version("2.24.1") { source sha256: "e3396c90888111a01bf607346db09b0fbf49a95bc83faf9506b61195936f0cfe" }
 version("2.23.0") { source sha256: "e3396c90888111a01bf607346db09b0fbf49a95bc83faf9506b61195936f0cfe" }
 version("2.19.2") { source sha256: "db893ad69c9ac9498b09677c5839787eba2eb3b7ef2bc30bfba7e62e77cf7850" }
 version("2.17.1") { source sha256: "ec6452f0c8d5c1f3bcceabd7070b8a8a5eea11d4e2a04955c139b5065fd7d09a" }


### PR DESCRIPTION
CVE-2019-1348, CVE-2019-1349, CVE-2019-1350, CVE-2019-1351,
CVE-2019-1352, CVE-2019-1353, CVE-2019-1354, CVE-2019-1387, and
CVE-2019-19604

Signed-off-by: Tim Smith <tsmith@chef.io>