### PR TITLE
Update windows-git to 2.24.1

### DIFF
--- a/config/software/git-windows.rb
+++ b/config/software/git-windows.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Chef Software Inc.
+# Copyright 2016-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 
 name "git-windows"
+default_version "2.24.1"
 default_version "2.23.0"
 
 license "LGPL-2.1"
@@ -34,6 +35,7 @@ arch_suffix = windows_arch_i386? ? "32" : "64"
 source url: "https://github.com/git-for-windows/git/releases/download/v#{version}.windows.1/PortableGit-#{version}-#{arch_suffix}-bit.7z.exe"
 
 if windows_arch_i386?
+  version("2.24.1") { source sha256: "88f5525999228b0be8bb51788bfaa41b14430904bc65f1d4bbdcf441cac1f7fc" }
   version("2.23.0") { source sha256: "33388028d45c685201490b0c621d2dbfde89d902a7257771f18de9bb37ae1b9a" }
   version("2.20.0") { source sha256: "d00e31b9d5db9b434d9da10bafb1028de3ea388bab3721d02ad5edb6d46d6507" }
   version("2.18.0") { source sha256: "28e68a781a78009913fef3d6c1074a6c91b05e4010bfd9efaff7b8398c87e017" }
@@ -42,6 +44,7 @@ if windows_arch_i386?
   version("2.8.1") { source sha256: "0b6efaaeb4b127edb3a534261b2c9175bd86ee8683dff6e12ccb194e6abb990e" }
   version("2.8.2") { source sha256: "da25bc12efa864cda53dc6485c84dd8b0d41883dd360db505c026c284ef58d8e" }
 else
+  version("2.24.1") { source sha256: "cb75e4a557e01dd27b5af5eb59dfe28adcbad21638777dd686429dd905d13899" }
   version("2.23.0") { source sha256: "501d8be861ebb8694df3f47f1f673996b1d1672e12559d4a07fae7a2eca3afc7" }
   version("2.20.0") { source sha256: "4f0c60a1d0ac23637d600531da34b48700fcaee7ecd79d36e2f5369dc8fcaef6" }
   version("2.18.0") { source sha256: "cd84a13b6c7aac0e924cb4db2476e2f4379aab4b8e60246992a6c5eebeac360c" }

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -30,7 +30,7 @@ dependency "expat"
 
 relative_path "git-#{version}"
 
-version("2.24.1") { source sha256: "e3396c90888111a01bf607346db09b0fbf49a95bc83faf9506b61195936f0cfe" }
+version("2.24.1") { source sha256: "ad5334956301c86841eb1e5b1bb20884a6bad89a10a6762c958220c7cf64da02" }
 version("2.23.0") { source sha256: "e3396c90888111a01bf607346db09b0fbf49a95bc83faf9506b61195936f0cfe" }
 version("2.19.2") { source sha256: "db893ad69c9ac9498b09677c5839787eba2eb3b7ef2bc30bfba7e62e77cf7850" }
 version("2.17.1") { source sha256: "ec6452f0c8d5c1f3bcceabd7070b8a8a5eea11d4e2a04955c139b5065fd7d09a" }


### PR DESCRIPTION
This resolves the same CVEs that were fixed in the standard git def by
bumping to 2.24.1:

CVE-2019-1348, CVE-2019-1349, CVE-2019-1350, CVE-2019-1351, CVE-2019-1352, CVE-2019-1353, CVE-2019-1354, CVE-2019-1387, and CVE-2019-19604.

Signed-off-by: Tim Smith <tsmith@chef.io>