### PR TITLE
Enable deep signing Chef Infra

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "omnibus", git: "https://github.com/chef/omnibus"
+  gem "omnibus", git: "https://github.com/chef/omnibus", branch: "jm/deep_sign"
   gem "highline"
   gem "rake"
   gem "chefstyle"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "omnibus", git: "https://github.com/chef/omnibus", branch: "jm/deep_sign"
+  gem "omnibus", git: "https://github.com/chef/omnibus"
   gem "highline"
   gem "rake"
   gem "chefstyle"

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -101,7 +101,9 @@ build do
     end
   end
 
-  block "Delete test folder from problem gems" do
+  # The rubyzip gem ships with some test fixture data compressed in a format Apple's notarization service
+  # cannot understand. We need to delete that archive to pass notarization.
+  block "Delete test folder of rubyzip gem so downstream projects pass notarization" do
     env["VISUAL"] = "echo"
     %w{rubyzip}.each do |gem|
       gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open #{gem}", env: env).stdout.chomp

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -100,4 +100,12 @@ build do
       appbundle "ohai", env: env
     end
   end
+
+  block "Delete test folder from problem gems" do
+    env["VISUAL"] = "echo"
+    %w{rubyzip}.each do |gem|
+      gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open #{gem}", env: env).stdout.chomp
+      remove_directory "#{gem_install_dir}/test"
+    end
+  end
 end

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -79,4 +79,10 @@ build do
   end
 
   gem gem_command.join(" "), env: env
+
+  block "Delete test folder of mini-portile2 gem so downstream projects pass notarization" do
+    env["VISUAL"] = "echo"
+    gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open mini_portile2", env: env).stdout.chomp
+    remove_directory "#{gem_install_dir}/test"
+  end
 end

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -80,6 +80,8 @@ build do
 
   gem gem_command.join(" "), env: env
 
+  # The mini-portile2 gem ships with some test fixture data compressed in a format Apple's notarization
+  # service cannot understand. We need to delete that archive to pass notarization.
   block "Delete test folder of mini-portile2 gem so downstream projects pass notarization" do
     env["VISUAL"] = "echo"
     gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open mini_portile2", env: env).stdout.chomp

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -29,7 +29,12 @@ default_version "1.0.2u"
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+lib_dirs lib_dirs.concat ["#{install_dir}/embedded/lib/engines"]
+
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
+version("1.1.1b") { source sha256: "5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" }
+version("1.1.1a") { source sha256: "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41" }
+version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
 version("1.1.0l") { source sha256: "74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148" }
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -29,12 +29,11 @@ default_version "1.0.2u"
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+# Openssl builds engines as libraries into a special directory. We need to include
+# that directory in lib_dirs so omnibus can sign them during macOS deep signing.
 lib_dirs lib_dirs.concat ["#{install_dir}/embedded/lib/engines"]
 
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
-version("1.1.1b") { source sha256: "5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" }
-version("1.1.1a") { source sha256: "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41" }
-version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
 version("1.1.0l") { source sha256: "74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148" }
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -19,6 +19,7 @@
 # Common cleanup routines for ruby apps (InSpec, Workstation, Chef, etc)
 #
 name "ruby-cleanup"
+default_version "1.0.0"
 
 license :project_license
 skip_transitive_dependency_licensing true

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -54,6 +54,13 @@ version("2.3.8")      { source sha256: "b5016d61440e939045d4e22979e04708ed6c8e1c
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
+semver = version.match(/(\d*)\.*(\d*)\.*(\d*)\.*/)
+ruby_mmv = "#{semver[1]}.#{semver[2]}.0"
+ruby_dir = "#{install_dir}/embedded/lib/ruby/#{ruby_mmv}"
+gem_dir = "#{install_dir}/embedded/lib/ruby/gems/#{ruby_mmv}"
+bin_dirs bin_dirs.concat ["#{gem_dir}/gems/*/bin/**"]
+lib_dirs ["#{ruby_dir}/**", "#{gem_dir}/extensions/**", "#{gem_dir}/gems/*", "#{gem_dir}/gems/*/lib/**", "#{gem_dir}/gems/*/ext/**"]
+
 relative_path "ruby-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -54,8 +54,10 @@ version("2.3.8")      { source sha256: "b5016d61440e939045d4e22979e04708ed6c8e1c
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
-semver = version.match(/(\d*)\.*(\d*)\.*(\d*)\.*/)
-ruby_mmv = "#{semver[1]}.#{semver[2]}.0"
+# In order to pass notarization we need to sign any binaries and libraries included in the package.
+# This makes sure we include and bins and libs that are brought in by gems.
+semver = Gem::Version.create(version).segments
+ruby_mmv = "#{semver[0..1].join(".")}.0"
 ruby_dir = "#{install_dir}/embedded/lib/ruby/#{ruby_mmv}"
 gem_dir = "#{install_dir}/embedded/lib/ruby/gems/#{ruby_mmv}"
 bin_dirs bin_dirs.concat ["#{gem_dir}/gems/*/bin/**"]


### PR DESCRIPTION
DO NOT MERGE UNTIL REFERENCE OMNIBUS CHANGE MERGES AND GEMFILE IS UPDATED

##  Description
* Updates openssl and ruby definitions to add bin_dirs and lib_dirs to support deep signing projects that depend on them so that they will pass notarization. These changes will require a newer version of omnibus.
* Updates chef software definition to delete test dir from rubyzip gem because fixtures contain zip files that the notarization service cannot inspect.
* Updates nokogiri software definition to delete test dir from mini_portile2 gem because fixtures contain zip files that the notarization service cannot inspect.
* Added default version to ruby cleanup so it's build can be cached.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Related Issue
https://github.com/chef/omnibus/pull/924

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
