### PR TITLE
Don't patch ruby 2.5 with ruby-no-stack-protector-strong.patch

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -126,7 +126,7 @@ build do
   # they try to install native gems.  So, we have to hack this up to avoid using
   # that flag on RHEL6.
   #
-  if rhel? && platform_version.satisfies?("< 7")
+  if rhel? && platform_version.satisfies?("< 7") && version.satisfies?(">= 2.6")
     patch source: "ruby-no-stack-protector-strong.patch", plevel: 1, env: patch_env
   end
 


### PR DESCRIPTION
We were trying to remove a flag that wasn't supported on RHEL 6, but this flag isn't present in Ruby 2.5 so there's nothing to do there.

Signed-off-by: Tim Smith <tsmith@chef.io>