### PR TITLE
remove cisco builds

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2019, Chef Software Inc.
+# Copyright 2012-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,13 +123,6 @@ build do
     else
       patch source: "ruby-win32_warning_removal_25_and_below.patch", plevel: 1, env: patch_env
     end
-  end
-
-  # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
-  # disable ruby from linking against it, but Cisco switches will not have the
-  # library.  Disabling it as we do for Solaris.
-  if ios_xr?
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
   end
 
   # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we


### PR DESCRIPTION
we don't build on this anymore, don't support it and this is
necessary to getting off of chef-sugar and onto chef-utils
