### PR TITLE
Point to AdoptOpenJDK instead of Oracle. Add version 6.8.1 for elasticsearch to definition.

### DIFF
--- a/config/software/elasticsearch.rb
+++ b/config/software/elasticsearch.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright 2020 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ end
 version "5.6.16" do
   source url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{version}.tar.gz",
          sha256: "6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f"
+end
+
+version "6.8.1" do
+  source url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{version}.tar.gz",
+         sha512: "1d484287e9b67b16c28f1a4d2267e7ceb5a4438a18b26b3a46d4a176bb3f2f6fcadcbda617a7a91418293880d38c027266cb81a4e8893a28adee9fa693b2318b"
 end
 
 target_path = "#{install_dir}/embedded/elasticsearch"

--- a/config/software/elasticsearch.rb
+++ b/config/software/elasticsearch.rb
@@ -17,7 +17,7 @@
 name "elasticsearch"
 default_version "5.4.1"
 
-dependency "server-jre"
+dependency "server-open-jre"
 
 license "Apache-2.0"
 license_file "LICENSE.txt"


### PR DESCRIPTION
## Related Issue
https://github.com/chef/chef-server/issues/1692

The next change would be to update omnibus-software for Chef-Backend, Automate(1) and Chef-Infra-Server.
