### PR TITLE
Revert "Added dependency to ruby-cleanup from gem-permissions."

### DIFF
--- a/config/software/gem-permissions.rb
+++ b/config/software/gem-permissions.rb
@@ -22,10 +22,6 @@ name "gem-permissions"
 
 default_version "0.0.1"
 
-dependency "ruby"
-dependency "rubygems"
-dependency "ruby-cleanup"
-
 license :project_license
 skip_transitive_dependency_licensing true
 


### PR DESCRIPTION
We want ruby-cleanup to take place at very specific portions in product
builds. By introducing it here we can't control that. This resulted in
45 megs of files not being cleaned up on Chef Workstation including
files that needed to be removed in order to pass Apple's package
notarization.

This reverts commit 085f7278bcfad95907b0c93ae51b017c031bc7f5.