### PR TITLE
add dep on zlib to server-open-jre.

### DIFF
--- a/config/software/server-open-jre.rb
+++ b/config/software/server-open-jre.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+dependency "zlib"
 
 name "server-open-jre"
 default_version "11.0.4+11"


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Chef-backend currently fails with:
```

[HealthCheck] E \| 2020-02-13T19:02:57+00:00 \| The following binaries have unsafe or unmet dependencies:
--
  | --> /opt/chef-backend/embedded/open-jre/bin/keytool
  | --> /opt/chef-backend/embedded/open-jre/bin/jaotc
  | --> /opt/chef-backend/embedded/open-jre/bin/unpack200
  | --> /opt/chef-backend/embedded/open-jre/bin/rmiregistry
  | --> /opt/chef-backend/embedded/open-jre/bin/pack200
  | --> /opt/chef-backend/embedded/open-jre/bin/java
  | --> /opt/chef-backend/embedded/open-jre/bin/jrunscript
  | --> /opt/chef-backend/embedded/open-jre/bin/rmid
  | --> /opt/chef-backend/embedded/open-jre/bin/jjs
  |  
  | [HealthCheck] E \| 2020-02-13T19:02:57+00:00 \| The following libraries cannot be guaranteed to be on target systems:
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f097053d000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f68dc3be000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f0bde469000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f882bcb1000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd21b5a7000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd15f930000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007fec58a67000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f465cbad000)
  | --> /lib/x86_64-linux-gnu/libz.so.1 (0x00007f85330ab000)
  |  
  | [HealthCheck] E \| 2020-02-13T19:02:57+00:00 \| The precise failures were:
  | --> /opt/chef-backend/embedded/open-jre/bin/keytool
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f097053d000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/jaotc
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f68dc3be000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/unpack200
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f0bde469000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/rmiregistry
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f882bcb1000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/pack200
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd21b5a7000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/java
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd15f930000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/jrunscript
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007fec58a67000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/rmid
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f465cbad000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef-backend/embedded/open-jre/bin/jjs
  | DEPENDS ON: libz.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libz.so.1 (0x00007f85330ab000)
  | FAILED BECAUSE: Unsafe dependency
  |  
  | [HealthCheck] I \| 2020-02-13T19:02:57+00:00 \| Health check time: 6.8568s
  | The health check failed! Please see above for important information.
  |  
  |  
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/health_check.rb:167:in `block in run!'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/instrumentation.rb:23:in `measure'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/health_check.rb:67:in `run!'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/health_check.rb:35:in `run!'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/project.rb:1087:in `build'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/cli.rb:89:in `build'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bundler/gems/omnibus-5baaf7a1d4ee/lib/omnibus/cli/base.rb:33:in `dispatch'
  | /var/lib/buildkite-agent/builds/buildkite-omnibus-ubuntu-1604-x86-64-i-057b0818936219117-1/chef/chef-chef-backend-master-omnibu

```

This PR should fix that error.
