### PR TITLE
Add patchelf

### DIFF
--- a/config/software/patchelf.rb
+++ b/config/software/patchelf.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2019-2020 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This software definition installs project called 'patchelf' which can be
+# used to change rpath of a precompiled binary.
+
+name "patchelf"
+
+default_version "0.10"
+
+license :project_license
+
+skip_transitive_dependency_licensing true
+
+version("0.10") { source md5: "228ade8c1b4033670bcf7f77c0ea1fb7" }
+
+source url: "https://nixos.org/releases/patchelf/patchelf-#{version}/patchelf-#{version}.tar.gz"
+
+relative_path "patchelf-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  configure "--prefix #{install_dir}/embedded"
+  make env: env
+  make "install", env: env
+end

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -29,6 +29,10 @@ skip_transitive_dependency_licensing true
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # patchelf was only installed to change the rpath for adoptopenjre binary
+  # delete
+  command "find #{install_dir} -name patchelf -delete"
+
   # Remove static object files for all platforms
   # except AIX which uses them at runtime.
   unless aix?


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Since we are using a precompiled-jre, it will look for zlib in the following path:
```
  vagrant@default-ubuntu-1604:~$ chrpath jdk-11.0.4+11-jre/bin/java
  jdk-11.0.4+11-jre/bin/java: RPATH=$ORIGIN/../lib/jli:$ORIGIN/../lib
```

 This errors since it cannot find the libz.so.1 file that is installed
as a part of the omnibus environment.
  We need to change the RPATH of the binary to be able to find omnibus installed zlib.

## Description
Allows Chef-Infra-Server and Chef-Backend to use AdoptOpenJRE

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Checklist:
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
