### PR TITLE
Properly escape the \ in the find command

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -31,7 +31,7 @@ build do
 
   # patchelf was only installed to change the rpath for adoptopenjre binary
   # delete
-  command "find #{install_dir} -name patchelf -exec rm -rf {} \;" unless windows?
+  command "find #{install_dir} -name patchelf -exec rm -rf {} \\;" unless windows?
 
   # Remove static object files for all platforms
   # except AIX which uses them at runtime.


### PR DESCRIPTION
Ruby will strip this unless we escape it

Signed-off-by: Tim Smith <tsmith@chef.io>