### PR TITLE
Fixes for omnibus-toolchain notarization

### DIFF
--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -39,9 +39,9 @@ version("2.14.1") { source sha256: "01925349b9683940e53a621ee48dd9d9ac3f9e59c079
 
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
-# git builds git-core as libraries into a special directory. We need to include
-# that directory in lib_dirs so omnibus can sign them during macOS deep signing.
-lib_dirs lib_dirs.concat ["#{install_dir}/embedded/libexec/git-core"]
+# git builds git-core as binaries into a special directory. We need to include
+# that directory in bin_dirs so omnibus can sign them during macOS deep signing.
+bin_dirs bin_dirs.concat ["#{install_dir}/embedded/libexec/git-core"]
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -23,7 +23,6 @@ license_file "http://invisible-island.net/ncurses/ncurses.faq.html"
 skip_transitive_dependency_licensing true
 
 dependency "config_guess"
-dependency "libtool" if aix?
 
 version("5.9") { source md5: "8cb9c412e5f2d96bc6f459aa8c6282a1", url: "https://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz" }
 version("5.9-20150530") { source md5: "bb2cbe1d788d3ab0138fc2734e446b43", url: "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz" }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Revert libtool dependency for AIX and update notarization binaries for git

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
