### PR TITLE
[redis] Bump default version to 5.0.7

### DIFF
--- a/config/patches/redis/password-from-environment-5.patch
+++ b/config/patches/redis/password-from-environment-5.patch
@@ -1,0 +1,19 @@
+diff --git a/src/server.c b/src/server.c
+index 280470f6..105bcd4d 100644
+--- a/src/server.c
++++ b/src/server.c
+@@ -4188,6 +4188,14 @@ int main(int argc, char **argv) {
+         serverLog(LL_WARNING, "Configuration loaded");
+     }
+ 
++    if (!server.requirepass) {
++      const char *password = getenv("REDIS_PASSWORD");
++      if (password != NULL) {
++        server.requirepass = zstrdup(password);
++      }
++      unsetenv("REDIS_PASSWORD");
++    }
++
+     server.supervised = redisIsSupervised(server.supervised_mode);
+     int background = server.daemonize && !server.supervised;
+     if (background) daemonize();

--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -21,7 +21,11 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 dependency "config_guess"
-default_version "3.0.7"
+default_version "5.0.7"
+
+version "5.0.7" do
+  source sha256: "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"
+end
 
 version "3.0.7" do
   source md5: "84ed3f486e7a6f0ebada6917370f3532"
@@ -54,10 +58,10 @@ build do
 
   update_config_guess
 
-  # This patch was written against 3.0.7.  A slightly different patch
-  # will be needed if we upgrade to 3.2 or unstable.
   if version.satisfies?(">= 3.0.7", "< 3.1")
     patch source: "password-from-environment.patch", plevel: 1, env: env
+  elsif version.satisfies?(">= 5.0", "< 6.0")
+    patch source: "password-from-environment-5.patch", plevel: 1, env: env
   end
 
   make "-j #{workers}", env: env


### PR DESCRIPTION
This bumps us to the latest stable redis version. Our REDIS_PASSWORD
patch remains the same but is now applied to a different file as the
code has moved around a bit.

Signed-off-by: Steven Danna <steve@chef.io>