### PR TITLE
Configure erlang with FIPS by default.

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -123,6 +123,7 @@ build do
           " --enable-kernel-poll" \
           " --enable-dynamic-ssl-lib" \
           " --enable-shared-zlib" \
+          " --enable-fips" \
           " --#{hipe}-hipe" \
           " --#{wx}-wx" \
           " --#{wx}-et" \


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Enable FIPS by default. It will be used only if fips_mode is set to true, It will load crypto in the FIPS mode.

Builds and tests for FIPS and non FIPS seem to be working fine:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1033#7c68b428-a0a0-4f7a-8a42-90bdeb836a2f

Integration tests testing bootstrap, enabling FIPS in the kernel tested at: https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/45#70327566-5899-4dab-ab12-c4de39ded16d

From the Documentation, https://erlang.org/doc/apps/crypto/fips.html
Making the assumption that a build with FIPS enabled erlang on a system where FIPS is not set to true in the kernel, will still load the correct version of OpenSSl based on FIPS_mode_set (https://wiki.openssl.org/index.php/FIPS_mode_set()) and crypto.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
