### PR TITLE
Remove bundler / rubygems dependencies and rely on built-in versions

### DIFF
--- a/config/software/bcrypt_pbkdf-ruby.rb
+++ b/config/software/bcrypt_pbkdf-ruby.rb
@@ -24,8 +24,6 @@ license "MIT"
 license_file "COPYING"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_embedded_path

--- a/config/software/berkshelf-no-depselector.rb
+++ b/config/software/berkshelf-no-depselector.rb
@@ -25,14 +25,12 @@ source git: "https://github.com/berkshelf/berkshelf.git"
 relative_path "berkshelf"
 
 dependency "ruby"
-dependency "rubygems"
 
 unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
   dependency "libarchive"
 end
 
 dependency "nokogiri"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/berkshelf.rb
+++ b/config/software/berkshelf.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014-2018 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,35 +15,19 @@
 #
 
 name "berkshelf"
-default_version "master"
 
 license "Apache-2.0"
-license_file "LICENSE"
-
-source git: "https://github.com/berkshelf/berkshelf.git"
-
-relative_path "berkshelf"
-
-dependency "ruby"
-dependency "rubygems"
-
-unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
-  dependency "libarchive"
-end
+license_file "https://raw.githubusercontent.com/berkshelf/berkshelf/master/LICENSE"
+# berkshelf does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
 dependency "nokogiri"
-dependency "bundler"
 dependency "dep-selector-libgecode"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install" \
-         " --jobs #{workers}" \
-         " --without guard", env: env
-
-  bundle "exec thor gem:build", env: env
-
-  gem "install pkg/berkshelf-*.gem" \
-      " --no-document", env: env
+  gem "install berkshelf" \
+      "  --no-document", env: env
 end

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -21,7 +21,6 @@ license "Apache-2.0"
 license_file "https://raw.githubusercontent.com/chef/chef/master/LICENSE"
 
 dependency "ruby"
-dependency "rubygems"
 dependency "libffi"
 dependency "rb-readline"
 

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -48,8 +48,6 @@ end
 relative_path "chef"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 dependency "ohai"
 dependency "appbundler"
 dependency "libarchive" # for archive resource

--- a/config/software/dep-selector-libgecode.rb
+++ b/config/software/dep-selector-libgecode.rb
@@ -23,7 +23,7 @@ license_file "https://raw.githubusercontent.com/chef/dep-selector-libgecode/mast
 # rubygems here.
 skip_transitive_dependency_licensing true
 
-dependency "rubygems"
+dependency "ruby"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/ffi-yajl.rb
+++ b/config/software/ffi-yajl.rb
@@ -25,9 +25,7 @@ license_file "LICENSE"
 
 dependency "ruby"
 
-dependency "rubygems"
 dependency "libyajl2-gem"
-dependency "bundler"
 
 build do
   env = with_embedded_path

--- a/config/software/google-protobuf.rb
+++ b/config/software/google-protobuf.rb
@@ -24,7 +24,6 @@ name "google-protobuf"
 default_version "v3.5.2"
 
 dependency "ruby"
-dependency "rubygems"
 
 source git: "https://github.com/google/protobuf.git"
 

--- a/config/software/highline-gem.rb
+++ b/config/software/highline-gem.rb
@@ -25,7 +25,6 @@ license_file "http://www.ruby-lang.org/en/LICENSE.txt"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/inspec.rb
+++ b/config/software/inspec.rb
@@ -23,8 +23,6 @@ license_file "LICENSE"
 source git: "https://github.com/chef/inspec.git"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 dependency "nokogiri"
 # Dependency added to avoid this pry error:
 # "Sorry, you can't use Pry without Readline or a compatible library."

--- a/config/software/libyajl2-gem.rb
+++ b/config/software/libyajl2-gem.rb
@@ -24,8 +24,6 @@ license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_embedded_path

--- a/config/software/mysql2.rb
+++ b/config/software/mysql2.rb
@@ -31,7 +31,6 @@ name "mysql2"
 default_version versions_to_install.join("-")
 
 dependency "ruby"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -30,8 +30,6 @@ unless using_prebuilt_ruby
   dependency "zlib"
 end
 
-dependency "rubygems"
-
 #
 # NOTE: As of nokogiri 1.6.4 it will superficially 'work' to remove most
 # of the nonsense in this file and simply gem install nokogiri on most

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -26,8 +26,6 @@ source git: "https://github.com/chef/ohai.git"
 relative_path "ohai"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/omnibus-ctl.rb
+++ b/config/software/omnibus-ctl.rb
@@ -23,8 +23,6 @@ license_file "https://raw.githubusercontent.com/chef/omnibus-ctl/master/LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 source git: "https://github.com/chef/omnibus-ctl.git"
 

--- a/config/software/pg-gem.rb
+++ b/config/software/pg-gem.rb
@@ -25,7 +25,6 @@ license_file "https://raw.githubusercontent.com/ged/ruby-pg/master/BSDL"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/rb-readline.rb
+++ b/config/software/rb-readline.rb
@@ -22,7 +22,6 @@ license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 source git: "https://github.com/ConnorAtherton/rb-readline.git"
 

--- a/config/software/rbnacl-libsodium.rb
+++ b/config/software/rbnacl-libsodium.rb
@@ -24,8 +24,6 @@ license "MIT"
 license_file "LICENSE"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_embedded_path

--- a/config/software/rbzmq.rb
+++ b/config/software/rbzmq.rb
@@ -25,7 +25,6 @@ skip_transitive_dependency_licensing true
 dependency "libzmq"
 dependency "libsodium"
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/redis-gem.rb
+++ b/config/software/redis-gem.rb
@@ -24,7 +24,6 @@ license_file "https://raw.githubusercontent.com/redis/redis-rb/master/LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/sequel-gem.rb
+++ b/config/software/sequel-gem.rb
@@ -24,7 +24,6 @@ license_file "https://raw.githubusercontent.com/jeremyevans/sequel/master/MIT-LI
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/veil-gem.rb
+++ b/config/software/veil-gem.rb
@@ -22,7 +22,6 @@ license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   delete "veil-*.gem"


### PR DESCRIPTION
## Description

Ruby 2.6+ come with rubygems and bundler built-in and installing over those versions cause failures in our omnibus installs. We've been pinning to the same versions that ship within ruby, but we really should just remove the definitions that install over the built-ins.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
