### PR TITLE
Update source download URLs for openssl following the move.

### DIFF
--- a/config/software/openssl-fips.rb
+++ b/config/software/openssl-fips.rb
@@ -21,17 +21,20 @@ license "OpenSSL"
 license_file "https://www.openssl.org/source/license.html"
 skip_transitive_dependency_licensing true
 
-version("2.0.16") { source sha256: "a3cd13d0521d22dd939063d3b4a0d4ce24494374b91408a05bdaca8b681c63d4" }
-version("2.0.14") { source sha256: "8ea069ec39f9c49d85b9831b16daa29936b4527446998336cf93e575f07626c0" }
-version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
-version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
-version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
-
 # HAHAHA According to the FIPS manual, you need to "securely" fetch the source
 # such as asking some humans to mail you a CD-ROM or something.
 # You are then supposed to manually verify the PGP signatures.
 # When making an "official" build - make sure you go do that...
-source url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
+source url: "https://www.openssl.org/source/old/fips/openssl-fips-#{version}.tar.gz", extract: :lax_tar
+
+version("2.0.16") {
+  source sha256: "a3cd13d0521d22dd939063d3b4a0d4ce24494374b91408a05bdaca8b681c63d4", \
+         url: "https://www.openssl.org/source/openssl-fips-#{version}.tar.gz", extract: :lax_tar
+}
+version("2.0.14") { source sha256: "8ea069ec39f9c49d85b9831b16daa29936b4527446998336cf93e575f07626c0" }
+version("2.0.11") { source sha256: "a6532875956d357a05838ca2c9865b8eecac211543e4246512684b17acbbdfac" }
+version("2.0.10") { source sha256: "a42ccf5f08a8b510c0c78da1ba889532a0ce24e772b576604faf09b4d6a0f771" }
+version("2.0.9") { source md5: "c8256051d7a76471c6ad4fb771404e60" }
 
 relative_path "openssl-fips-#{version}"
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,7 +27,7 @@ default_version "1.0.2u"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
-source url: "https://www.openssl.org/source/old/#{version}/openssl-#{version}.tar.gz", extract: :lax_tar
+source url: "https://www.openssl.org/source/old/#{version[/\d*\.\d*\.\d*/, 0]}/openssl-#{version}.tar.gz", extract: :lax_tar
 
 # Openssl builds engines as libraries into a special directory. We need to include
 # that directory in lib_dirs so omnibus can sign them during macOS deep signing.

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,12 +27,16 @@ default_version "1.0.2u"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
-source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
+source url: "https://www.openssl.org/source/old/#{version}/openssl-#{version}.tar.gz", extract: :lax_tar
 
 # Openssl builds engines as libraries into a special directory. We need to include
 # that directory in lib_dirs so omnibus can sign them during macOS deep signing.
 lib_dirs lib_dirs.concat ["#{install_dir}/embedded/lib/engines"]
 
+version("1.1.1f") {
+  source sha256: "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35", \
+         url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
+}
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
 version("1.1.0l") { source sha256: "74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -33,8 +33,8 @@ source url: "https://www.openssl.org/source/old/#{version[/\d*\.\d*\.\d*/, 0]}/o
 # that directory in lib_dirs so omnibus can sign them during macOS deep signing.
 lib_dirs lib_dirs.concat ["#{install_dir}/embedded/lib/engines"]
 
-version("1.1.1f") {
-  source sha256: "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35", \
+version("1.1.1g") {
+  source sha256: "ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46", \
          url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 }
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }


### PR DESCRIPTION
Also add openssl-1.1.1f and update openssl-fips URLs.

## Description
The openssl sources have moved again — breaking the downloads in the same was as described in #833. This change attempts to adjust the download URL pattern for older versions, while still keeping the latest version at the original URL pattern.

## Related Issue
Fixes #833

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
- [ ] ~~All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).~~