### PR TITLE
Fix the without groups for chef + ohai

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,12 +57,12 @@ build do
 
   # compiled ruby on windows 2k8R2 x86 is having issues compiling
   # native extensions for pry-byebug so excluding for now
-  excluded_groups = %w{server docgen maintenance pry travis integration ci chefstyle debug}
+  excluded_groups = %w{docgen chefstyle}
   excluded_groups << "ruby_prof" if aix?
   excluded_groups << "ruby_shadow" if aix?
   excluded_groups << "ed25519" if solaris2?
 
-  # install the whole bundle first
+  # The --without groups here MUST match groups in https://github.com/chef/chef/blob/master/Gemfile
   bundle "install --without #{excluded_groups.join(" ")}", env: env
 
   # use the rake install task to build/install chef-config

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -55,14 +55,12 @@ dependency "libarchive" # for archive resource
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # compiled ruby on windows 2k8R2 x86 is having issues compiling
-  # native extensions for pry-byebug so excluding for now
+  # The --without groups here MUST match groups in https://github.com/chef/chef/blob/master/Gemfile
   excluded_groups = %w{docgen chefstyle}
   excluded_groups << "ruby_prof" if aix?
   excluded_groups << "ruby_shadow" if aix?
   excluded_groups << "ed25519" if solaris2?
 
-  # The --without groups here MUST match groups in https://github.com/chef/chef/blob/master/Gemfile
   bundle "install --without #{excluded_groups.join(" ")}", env: env
 
   # use the rake install task to build/install chef-config

--- a/config/software/ohai.rb
+++ b/config/software/ohai.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,8 @@ dependency "ruby"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development docs ci", env: env
+  # The --without groups here MUST match groups in https://github.com/chef/ohai/blob/master/Gemfile
+  bundle "install --without development docs debug", env: env
 
   gem "build ohai.gemspec", env: env
   gem "install ohai*.gem" \


### PR DESCRIPTION
Removes all extra gems from ohai, particularly pry which was causing
double-pry issues.

Removes all stale groups from the chef without that we haven't had for
years.  Removes chefstyle from the shipping artifact.

This does include pry, by design, so that pry is installed in the
Gemfile.lock install, so that it becomes correctly appbundled and
version locked (this protects against issues caused by double-pry).
