### PR TITLE
Add newlines to the zeromq AIX patches

### DIFF
--- a/config/patches/libzmq/zeromq-aix-4.2.2-LARGE_FILES.patch
+++ b/config/patches/libzmq/zeromq-aix-4.2.2-LARGE_FILES.patch
@@ -53,3 +53,4 @@
 
           //  Close the connecting socket.
           void close ();
+

--- a/config/patches/libzmq/zeromq-aix-4.2.2-atomic-counter-fetch_and_add.patch
+++ b/config/patches/libzmq/zeromq-aix-4.2.2-atomic-counter-fetch_and_add.patch
@@ -56,3 +56,4 @@
   #undef ZMQ_ATOMIC_COUNTER_TILE
 
   #endif
+


### PR DESCRIPTION
This is a trivial issue but can be a red herring. This fixes:
```
btm@btm-thinkpad:~/src/libzmq ((v4.2.2))$ patch -p0 -i ../omnibus-software/config/patches/libzmq/zeromq-aix-4.2.2-LARGE_FILES.patch
patching file src/tcp_connecter.cpp
patch unexpectedly ends in middle of line
patching file src/tcp_connecter.hpp
patch unexpectedly ends in middle of line
```

And becomes:
```
btm@btm-thinkpad:~/src/libzmq ((v4.2.2))$ patch -p0 -i ../omnibus-software/config/patches/libzmq/zeromq-aix-4.2.2-LARGE_FILES.patch
patching file src/tcp_connecter.cpp
patching file src/tcp_connecter.hpp
```

Signed-off-by: Bryan McLellan <btm@loftninjas.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
