### PR TITLE
Make sure the include directory exists for libffi

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -52,6 +52,7 @@ build do
   make "-j #{workers} install", env: env
 
   # libffi's default install location of header files is awful...
-  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
+  mkdir "#{install_dir}/embedded/include"
+  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
 
 end


### PR DESCRIPTION
If nothing else happens to have written to the include directory, libffi
will quietly copy all the files in the club to a file named 'include'
rather than into a directory. The build later fails when something else
tries to install into that directory.
