### PR TITLE
Update Windows msys2_path to custom installed msys2 lookup first

### DIFF
--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -61,7 +61,7 @@ build do
     copy "#{install_dir}/embedded/bin/libeay32.dll", "#{install_dir}/bin/libeay32.dll"
     copy "#{install_dir}/embedded/bin/zlib1.dll", "#{install_dir}/bin/zlib1.dll"
 
-    # Needed now that we switched to msys2 and have not figured out how to tell
+    # Needed now that we switched to installed version of msys2 and have not figured out how to tell
     # it how to statically link yet
     dlls = ["libwinpthread-1"]
     if windows_arch_i386?
@@ -71,7 +71,9 @@ build do
     end
     dlls.each do |dll|
       mingw = ENV["MSYSTEM"].downcase
-      msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+      # Starting omnibus-toolchain version 1.1.115 we do not build msys2 as a part of omnibus-toolchain anymore, but pre install it in image
+      # so here we set the path to default install of msys2 first and default to OMNIBUS_TOOLCHAIN_INSTALL_DIR for backward compatibility
+      msys_path = ENV["MSYS2_INSTALL_DIR"] ? "#{ENV["MSYS2_INSTALL_DIR"]}" : "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin"
       windows_path = "#{msys_path}/#{mingw}/bin/#{dll}.dll"
       if File.exist?(windows_path)
         copy windows_path, "#{install_dir}/bin/#{dll}.dll"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -239,7 +239,9 @@ build do
 
     dlls.each do |dll|
       mingw = ENV["MSYSTEM"].downcase
-      msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+      # Starting omnibus-toolchain version 1.1.115 we do not build msys2 as a part of omnibus-toolchain anymore, but pre install it in image
+      # so here we set the path to default install of msys2 first and default to OMNIBUS_TOOLCHAIN_INSTALL_DIR for backward compatibility
+      msys_path = ENV["MSYS2_INSTALL_DIR"] ? "#{ENV["MSYS2_INSTALL_DIR"]}" : "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin"
       windows_path = "#{msys_path}/#{mingw}/bin/#{dll}.dll"
       if File.exist?(windows_path)
         copy windows_path, "#{install_dir}/embedded/bin/#{dll}.dll"

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -55,7 +55,9 @@ build do
 
     mingw = ENV["MSYSTEM"].downcase
     target = (mingw == "mingw32" ? "mingw" : mingw)
-    msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+    # Starting omnibus-toolchain version 1.1.115 we do not build msys2 as a part of omnibus-toolchain anymore, but pre install it in image
+    # so here we set the path to default install of msys2 first and default to OMNIBUS_TOOLCHAIN_INSTALL_DIR for backward compatibility
+    msys_path = ENV["MSYS2_INSTALL_DIR"] ? "#{ENV["MSYS2_INSTALL_DIR"]}" : "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin"
 
     make target, env: env, cwd: "#{project_dir}/src"
 


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

This PR is in preparation for introducing MSYS_INSTALL_DIR environment variable in next release of omnibus-toolchain.  We do not ship msys2 for windows in omnibus-toolchain anymore, so this variable sets the PATH where msys2 is installed on the AMI

## Description
Set msys2_path to the path defined by MSYS_INSTALL_DIR for Windows builds