### PR TITLE
Add OpenSSL 1.0.2v

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -41,9 +41,15 @@ version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
 version("1.1.0l") { source sha256: "74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148" }
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }
+
+version("1.0.2v") {
+  source sha256: "eff6ba99e06d87dc9fb00094bd84840950c0cf99d58dee50b1a098356c82bc45", \
+         url: "https://s3.amazonaws.com/chef-releng/openssl/openssl-#{version}.tar.gz", extract: :lax_tar
+}
 version("1.0.2u") { source sha256: "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" }
 version("1.0.2t") { source sha256: "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc" }
 version("1.0.2s") { source sha256: "cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96" }
+
 version("1.0.1u") { source sha256: "4312b4ca1215b6f2c97007503d80db80d5157f76f8f7d3febbe6b4c56ff26739" }
 version("1.0.1t") { source sha256: "4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088" }
 version("1.0.1s") { source sha256: "e7e81d82f3cd538ab0cdba494006d44aab9dd96b7f6233ce9971fb7c7916d511" }


### PR DESCRIPTION
This is an extended support release of 1.0.2. It is not publicly available, so
we have to self-host the package.

>  Changes between 1.0.2u and 1.0.2v [5 May 2020]
> 
>   *) Implemented coordinate blinding for the generic implementations of both
>      binary and prime elliptic curves to avoid leaking bits of the scalar and,
>      potentially, bug attacks. A group of security researchers and
>      cryptographers from academia and industry, listed below, reported a
>      successful cache timing attack in OpenSSL 1.0.2u against specific prime and
>      binary curves whose order or field length is close to a word boundary. They
>      also provided the fix. This attack does not fit the OpenSSL threat model
>      and so no CVE is assigned, but a fix is implemented nonetheless.
>      [Diego F. Aranha, Akira Takahashi, Mehdi Tibouchi, Yuval Yarom]