### PR TITLE
bzip2 patching logic fix

### DIFF
--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -48,7 +48,7 @@ build do
   args = "PREFIX='#{install_dir}/embedded' VERSION='#{version}'"
   args << " CFLAGS='-qpic=small -qpic=large -O2 -g -D_ALL_SOURCE -D_LARGE_FILES'" if aix?
 
-  patch source: "makefile_take_env_vars.patch", plevel: 1, env: env
+  patch source: "makefile_take_env_vars.patch", plevel: 1, env: env if version == "1.0.6"
   patch source: "soname_install_dir-#{version}.patch", env: env if mac_os_x?
   patch source: "aix_makefile-#{version}.patch", env: env if aix?
 


### PR DESCRIPTION
makefile_take_env_vars.patch should only be applied if bzip2 version is 1.0.6. Patch fails to apply on 1.0.8.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
