### PR TITLE
Cleanup additional files in the ruby installs

### DIFF
--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -36,7 +36,7 @@ relative_path "bash-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-# We do not install bashbug in macos as it fails Notarization
+  # We do not install bashbug in macos as it fails Notarization
   patch source: "mac_Makefile.patch", plevel: 0, env: env if mac_os_x?
 
   configure_command = ["./configure",

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -79,7 +79,7 @@ build do
   end
 
   if mac_os_x? ||
-    # Clang became the default compiler in FreeBSD 10+
+      # Clang became the default compiler in FreeBSD 10+
       (freebsd? && ohai["os_version"].to_i >= 1000024)
     # References:
     # https://github.com/Homebrew/homebrew-dupes/issues/43

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -103,10 +103,12 @@ build do
     files = %w{
       .appveyor.yml
       .autotest
+      .bnsignore
       .circleci
       .codeclimate.yml
       .concourse.yml
       .coveralls.yml
+      .dockerignore
       .document
       .ebert.yml
       .gemtest
@@ -117,26 +119,25 @@ build do
       .irbrc
       .kokoro
       .pelusa.yml
+      .repo-metadata.json
       .rock.yml
       .rspec
-      .rubocop_*.yml
       .rubocop.yml
+      .rubocop_*.yml
       .ruby-gemset
       .ruby-version
       .rvmrc
       .simplecov
       .tool-versions
-      Gemfile.travis
       .travis.yml
       .yardopts
+      .yardopts_guide
+      .yardopts_i18n
       .yardstick.yml
-      bundle_install_all_ruby_versions.sh
-      Appraisals
-      appveyor.yml
+      .zuul.yaml
       ARCHITECTURE.md
+      Appraisals
       CHANGELOG
-      release-script.txt
-      run_specs_all_ruby_versions.sh
       CHANGELOG.md
       CHANGELOG.rdoc
       CHANGELOG.txt
@@ -144,42 +145,52 @@ build do
       CHANGES.md
       CHANGES.txt
       CODE_OF_CONDUCT.md
-      Code-of-Conduct.md
-      concourse
       CONTRIBUTING.md
       CONTRIBUTING.rdoc
       CONTRIBUTORS.md
-      donate.png
+      Code-of-Conduct.md
       FAQ.txt
-      Guardfile
       GUIDE.md
+      Gemfile.travis
+      Guardfile
       HISTORY
       HISTORY.md
-      History.rdoc
       HISTORY.txt
+      History.rdoc
       INSTALL
       ISSUE_TEMPLATE.md
       JSON-Schema-Test-Suite
-      logo.png
+      MIGRATING.md
       Manifest
       Manifest.txt
-      MIGRATING.md
       NEWS.md
       README
-      README_INDEX.rdoc
       README.*md
-      readme.erb
+      README.euc
       README.markdown
       README.rdoc
       README.txt
-      README.euc
+      README_INDEX.rdoc
       SECURITY.md
       SPEC.rdoc
       THANKS.txt
-      travis_build_script.sh
       TODO
       TODO*.md
       UPGRADING.md
+      VERSION
+      appveyor.yml
+      azure-pipelines.yml
+      builder.blurb
+      bundle_install_all_ruby_versions.sh
+      codecov.yml
+      concourse
+      docker-compose.yml
+      donate.png
+      logo.png
+      readme.erb
+      release-script.txt
+      run_specs_all_ruby_versions.sh
+      travis_build_script.sh
     }
 
     Dir.glob(Dir.glob("#{gemdir}/gems/*/{#{files.join(",")}}")).each do |f|

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -101,6 +101,7 @@ build do
 
     # find the embedded ruby gems dir and clean it up for globbing
     files = %w{
+      **/.gitkeep
       .appveyor.yml
       .autotest
       .bnsignore


### PR DESCRIPTION
This cleans up 18 additional files in our Workstation installs:

Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/ffi-rzmq-2.0.7/.bnsignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/rake-12.3.3/azure-pipelines.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/kramdown-2.2.1/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/builder-3.2.4/builder.blurb
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/os-1.1.0/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/gssapi-1.3.0/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/google-api-client-0.34.1/.repo-metadata.json
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/yard-0.9.25/.dockerignore
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/yard-0.9.25/.yardopts_guide
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/yard-0.9.25/.yardopts_i18n
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/kramdown-parser-gfm-1.1.0/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/aws-sdk-core-3.95.0/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/tins-1.25.0/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/lumberjack-1.2.4/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/term-ansicolor-1.7.1/VERSION
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/public_suffix-4.0.5/codecov.yml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/fog-openstack-1.0.10/.zuul.yaml
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/fog-openstack-1.0.10/docker-compose.yml

Signed-off-by: Tim Smith <tsmith@chef.io>