### PR TITLE
Ruby 2.7.1 rubygems perf patch

### DIFF
--- a/config/patches/ruby/ruby-2.7.1-rubygemsperf.patch
+++ b/config/patches/ruby/ruby-2.7.1-rubygemsperf.patch
@@ -1,0 +1,115 @@
+diff -ur ruby-2.7.1/lib/rubygems/core_ext/kernel_require.rb ruby-2.7.1.fixed/lib/rubygems/core_ext/kernel_require.rb
+--- ruby-2.7.1/lib/rubygems/core_ext/kernel_require.rb	2020-03-31 03:44:55.000000000 -0700
++++ ruby-2.7.1.fixed/lib/rubygems/core_ext/kernel_require.rb	2020-05-26 14:50:28.154073337 -0700
+@@ -39,49 +39,40 @@
+ 
+     path = path.to_path if path.respond_to? :to_path
+ 
+-    # Ensure -I beats a default gem
+-    # https://github.com/rubygems/rubygems/pull/1868
+-    resolved_path = begin
+-      rp = nil
+-      $LOAD_PATH[0...Gem.load_path_insert_index || -1].each do |lp|
+-        safe_lp = lp.dup.tap(&Gem::UNTAINT)
+-        begin
+-          if File.symlink? safe_lp # for backward compatibility
+-            next
+-          end
+-        rescue SecurityError
+-          RUBYGEMS_ACTIVATION_MONITOR.exit
+-          raise
+-        end
+-
++    if spec = Gem.find_unresolved_default_spec(path)
++      # Ensure -I beats a default gem
++      resolved_path = begin
++        rp = nil
++        load_path_check_index = Gem.load_path_insert_index - Gem.activated_gem_paths
+         Gem.suffixes.each do |s|
+-          full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))
+-          if File.file?(full_path)
+-            rp = full_path
+-            break
++          $LOAD_PATH[0...load_path_check_index].each do |lp|
++            safe_lp = lp.dup.tap(&Gem::UNTAINT)
++            begin
++              if File.symlink? safe_lp # for backward compatibility
++                next
++              end
++            rescue SecurityError
++              RUBYGEMS_ACTIVATION_MONITOR.exit
++              raise
++            end
++
++            full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))
++            if File.file?(full_path)
++              rp = full_path
++              break
++            end
+           end
++          break if rp
+         end
+-        break if rp
+-      end
+-      rp
+-    end
+-
+-    if resolved_path
+-      begin
+-        RUBYGEMS_ACTIVATION_MONITOR.exit
+-        return gem_original_require(resolved_path)
+-      rescue LoadError
+-        RUBYGEMS_ACTIVATION_MONITOR.enter
++        rp
+       end
+-    end
+ 
+-    if spec = Gem.find_unresolved_default_spec(path)
+       begin
+         Kernel.send(:gem, spec.name, Gem::Requirement.default_prerelease)
+       rescue Exception
+         RUBYGEMS_ACTIVATION_MONITOR.exit
+         raise
+-      end
++      end unless resolved_path
+     end
+ 
+     # If there are no unresolved deps, then we can use just try
+diff -ur ruby-2.7.1/lib/rubygems.rb ruby-2.7.1.fixed/lib/rubygems.rb
+--- ruby-2.7.1/lib/rubygems.rb	2020-03-31 03:44:55.000000000 -0700
++++ ruby-2.7.1.fixed/lib/rubygems.rb	2020-05-26 14:48:43.438679744 -0700
+@@ -657,22 +657,25 @@
+ 
+     index = $LOAD_PATH.index RbConfig::CONFIG['sitelibdir']
+ 
+-    index
++    index || 0
++  end
++
++  ##
++  # The number of paths in the `$LOAD_PATH` from activated gems. Used to
++  # prioritize `-I` and `ENV['RUBYLIB`]` entries during `require`.
++
++  def self.activated_gem_paths
++    @activated_gem_paths ||= 0
+   end
+ 
+   ##
+   # Add a list of paths to the $LOAD_PATH at the proper place.
+ 
+   def self.add_to_load_path(*paths)
+-    insert_index = load_path_insert_index
++    @activated_gem_paths = activated_gem_paths + paths.size
+ 
+-    if insert_index
+-      # gem directories must come after -I and ENV['RUBYLIB']
+-      $LOAD_PATH.insert(insert_index, *paths)
+-    else
+-      # we are probably testing in core, -I and RUBYLIB don't apply
+-      $LOAD_PATH.unshift(*paths)
+-    end
++    # gem directories must come after -I and ENV['RUBYLIB']
++    $LOAD_PATH.insert(Gem.load_path_insert_index, *paths)
+   end
+ 
+   @yaml_loaded = false

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -147,6 +147,13 @@ build do
     patch source: "ruby-faster-load_27.patch", plevel: 1, env: patch_env
   end
 
+  # rubygems 3.1.x perf improvements, this will fail once the rubygems patches are
+  # merged into mainline ruby 2.7
+  #
+  if version.satisfies?("~> 2.7") && version.satisfies?(">= 2.7.0")
+    patch source: "ruby-2.7.1-rubygemsperf.patch", plevel: 1, env: patch_env
+  end
+
   # disable libpath in mkmf across all platforms, it trolls omnibus and
   # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
   # this was a good idea, but it breaks our use case hard.  AIX cannot even


### PR DESCRIPTION
This is a "backport" of https://github.com/rubygems/rubygems/pull/3639

Once this patch fails to apply it should be able to remove it.
