### PR TITLE
Remove the redundant encoding comment

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "omnibus-software/version"
 


### PR DESCRIPTION
The encoding is utf-8 in Ruby 2+

Signed-off-by: Tim Smith <tsmith@chef.io>