### PR TITLE
Move some more gem cleanup from chef/chef to all ruby projects

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -101,7 +101,6 @@ build do
 
     # find the embedded ruby gems dir and clean it up for globbing
     files = %w{
-      **/.gitkeep
       .appveyor.yml
       .autotest
       .bnsignore
@@ -123,8 +122,8 @@ build do
       .repo-metadata.json
       .rock.yml
       .rspec
-      .rubocop.yml
       .rubocop_*.yml
+      .rubocop.yml
       .ruby-gemset
       .ruby-version
       .rvmrc
@@ -136,8 +135,19 @@ build do
       .yardopts_i18n
       .yardstick.yml
       .zuul.yaml
-      ARCHITECTURE.md
+      **/.gitkeep
+      *Upgrade.md
       Appraisals
+      appveyor.yml
+      ARCHITECTURE.md
+      autotest
+      autotest/*
+      azure-pipelines.yml
+      bench
+      benchmark
+      benchmarks
+      builder.blurb
+      bundle_install_all_ruby_versions.sh
       CHANGELOG
       CHANGELOG.md
       CHANGELOG.rdoc
@@ -146,51 +156,62 @@ build do
       CHANGES.md
       CHANGES.txt
       CODE_OF_CONDUCT.md
+      Code-of-Conduct.md
+      codecov.yml
+      concourse
       CONTRIBUTING.md
       CONTRIBUTING.rdoc
       CONTRIBUTORS.md
-      Code-of-Conduct.md
+      doc
+      doc-api
+      docker-compose.yml
+      Dockerfile*
+      docs
+      donate.png
+      ed25519.png
       FAQ.txt
-      GUIDE.md
+      features
+      frozen_old_spec
       Gemfile.travis
       Guardfile
+      GUIDE.md
       HISTORY
       HISTORY.md
-      HISTORY.txt
       History.rdoc
+      HISTORY.txt
       INSTALL
+      INSTALL.txt
       ISSUE_TEMPLATE.md
       JSON-Schema-Test-Suite
-      MIGRATING.md
+      logo.png
+      man
       Manifest
       Manifest.txt
+      MIGRATING.md
+      minitest
       NEWS.md
+      on_what.rb
       README
+      README_INDEX.rdoc
       README.*md
+      readme.erb
       README.euc
       README.markdown
       README.rdoc
       README.txt
-      README_INDEX.rdoc
+      release-script.txt
+      run_specs_all_ruby_versions.sh
+      samus.json
       SECURITY.md
       SPEC.rdoc
+      test
+      tests
       THANKS.txt
       TODO
       TODO*.md
-      UPGRADING.md
-      appveyor.yml
-      azure-pipelines.yml
-      builder.blurb
-      bundle_install_all_ruby_versions.sh
-      codecov.yml
-      concourse
-      docker-compose.yml
-      donate.png
-      logo.png
-      readme.erb
-      release-script.txt
-      run_specs_all_ruby_versions.sh
       travis_build_script.sh
+      UPGRADING.md
+      yard-template
     }
 
     Dir.glob(Dir.glob("#{gemdir}/gems/*/{#{files.join(",")}}")).each do |f|


### PR DESCRIPTION
This is something I want to make sure everyone is aware of. The following files / directories in gems will now get removed:

      yard-template
      samus.json
      INSTALL.txt
      on_what.rb
      ed25519.png
      Dockerfile*
      docs
      *Upgrade.md
      autotest
      autotest/*
      bench
      benchmark
      benchmarks
      doc
      doc-api
      features
      frozen_old_spec
      man
      minitest
      test
      tests

We've been removing those from chef/chef without issue so this seems safe to do elsewhere to get the same install size wins.

Signed-off-by: Tim Smith <tsmith@chef.io>