### PR TITLE
Update git to 2.28 on *nix and 2.27 on Windows

### DIFF
--- a/config/software/git-windows.rb
+++ b/config/software/git-windows.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020, Chef Software Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 name "git-windows"
-default_version "2.26.2"
+default_version "2.27.0"
 
 license "LGPL-2.1"
 # the license file does not ship in the portable git package so pull from the source repo
@@ -34,25 +34,15 @@ arch_suffix = windows_arch_i386? ? "32" : "64"
 source url: "https://github.com/git-for-windows/git/releases/download/v#{version}.windows.1/PortableGit-#{version}-#{arch_suffix}-bit.7z.exe"
 
 if windows_arch_i386?
+  version("2.27.0") { source sha256: "8cbe1e3b57eb9d02e92cff12089454f2cf090c02958080d62e199ef8764542d3" }
   version("2.26.2") { source sha256: "e18f75db932ab314263c5f7fca7a9d638df3539629dbf5248a4089beb4e03685" }
   version("2.25.0") { source sha256: "5ad97ff1e806815aa461ab39794e42455f19c9a6ead08ca0e5b8f2bb085214a6" }
   version("2.23.0") { source sha256: "33388028d45c685201490b0c621d2dbfde89d902a7257771f18de9bb37ae1b9a" }
-  version("2.20.0") { source sha256: "d00e31b9d5db9b434d9da10bafb1028de3ea388bab3721d02ad5edb6d46d6507" }
-  version("2.18.0") { source sha256: "28e68a781a78009913fef3d6c1074a6c91b05e4010bfd9efaff7b8398c87e017" }
-  version("2.14.1") { source sha256: "df3f9b6c2dd2b12e5cb7035b9ca48d13b973d054a35b0939953aa6e7a00a0659" }
-  version("2.12.0") { source sha256: "0375ba0a05f9cd501cc8089b9af6f2adf8904a5efb1e5b9421e6561bd9f8c817" }
-  version("2.8.1") { source sha256: "0b6efaaeb4b127edb3a534261b2c9175bd86ee8683dff6e12ccb194e6abb990e" }
-  version("2.8.2") { source sha256: "da25bc12efa864cda53dc6485c84dd8b0d41883dd360db505c026c284ef58d8e" }
 else
+  version("2.27.0") { source sha256: "0fd2218ba73e07e5a664d06e0ce514edcd241a2de0ba29ceca123e7d36aa8f58" }
   version("2.26.2") { source sha256: "dd36f76a815b993165e67ad3cbc8f5b2976e5757a0c808a4a92fb72d1000e1c8" }
   version("2.25.0") { source sha256: "c191542f68e788f614f8a676460281399af0c9d32f19a5d208e9621dd46264fb" }
   version("2.23.0") { source sha256: "501d8be861ebb8694df3f47f1f673996b1d1672e12559d4a07fae7a2eca3afc7" }
-  version("2.20.0") { source sha256: "4f0c60a1d0ac23637d600531da34b48700fcaee7ecd79d36e2f5369dc8fcaef6" }
-  version("2.18.0") { source sha256: "cd84a13b6c7aac0e924cb4db2476e2f4379aab4b8e60246992a6c5eebeac360c" }
-  version("2.14.1") { source sha256: "3c3270a9df5f3db1f7637d86b94fb54a96e9145ba43c98a3e993cdffb1a1842e" }
-  version("2.12.0") { source sha256: "5bebd0ee21e5cf3976bc71826a28b2663c7a0c9b5c98f4ab46ff03c3c0d3556f" }
-  version("2.8.1") { source sha256: "dc9d971156cf3b6853bc0c1ad0ca76f1d2c24478cca80036919f12fe46acd64e" }
-  version("2.8.2") { source sha256: "553acbf46bacc67c73b954689ad3d9ac294bf9cbe249a5b78159a1f92f37105b" }
 end
 
 # The git portable archives come with their own copy of posix related tools

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -15,7 +15,7 @@
 #
 
 name "git"
-default_version "2.26.2"
+default_version "2.28.0"
 
 license "LGPL-2.1"
 license_file "LGPL-2.1"
@@ -30,6 +30,7 @@ dependency "expat"
 
 relative_path "git-#{version}"
 
+version("2.28.0") { source sha256: "f914c60a874d466c1e18467c864a910dd4ea22281ba6d4d58077cb0c3f115170" }
 version("2.26.2") { source sha256: "e1c17777528f55696815ef33587b1d20f5eec246669f3b839d15dbfffad9c121" }
 version("2.24.1") { source sha256: "ad5334956301c86841eb1e5b1bb20884a6bad89a10a6762c958220c7cf64da02" }
 version("2.23.0") { source sha256: "e3396c90888111a01bf607346db09b0fbf49a95bc83faf9506b61195936f0cfe" }
@@ -51,16 +52,13 @@ build do
   # clever.
   make "distclean"
 
-  # AIX needs /opt/freeware/bin only for patch
+  # In 2.13.1 they introduced some sha code that wasn't super good at endianness
   if aix?
+    # AIX needs /opt/freeware/bin only for patch
     patch_env = env.dup
     patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}"
 
-    # In 2.13.1 they introduced some sha code that wasn't super good at
-    # endianness. https://github.com/git/git/commit/6b851e536b05e0c8c61f77b9e4c3e7cedea39ff8
-    if version.satisfies?(">2.10.2")
-      patch source: "aix-endian-fix.patch", plevel: 0, env: patch_env
-    end
+    patch source: "aix-endian-fix.patch", plevel: 0, env: patch_env
   end
 
   config_hash = {


### PR DESCRIPTION
2.28 introduces a new config to control the default branch - `git config --global init.defaultBranch main`.

Signed-off-by: Tim Smith <tsmith@chef.io>