### PR TITLE
Bump libarchive to 3.4.3 and liblzma to 5.2.5

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -18,12 +18,13 @@
 # https://github.com/berkshelf/api.berkshelf.com
 
 name "libarchive"
-default_version "3.4.2"
+default_version "3.4.3"
 
 license "BSD-2-Clause"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
+version("3.4.3") { source sha256: "ee1e749213c108cb60d53147f18c31a73d6717d7e3d2481c157e1b34c881ea39" }
 version("3.4.2") { source sha256: "b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176" }
 version("3.4.1") { source sha256: "fcf87f3ad8db2e4f74f32526dee62dd1fb9894782b0a503a89c9d7a70a235191" }
 version("3.4.0") { source sha256: "8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e" }

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -15,12 +15,13 @@
 #
 
 name "liblzma"
-default_version "5.2.4"
+default_version "5.2.5"
 
 license "Public-Domain"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
+version("5.2.5") { source sha256: "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10" }
 version("5.2.4") { source sha256: "b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145" }
 version("5.2.3") { source sha256: "71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb" }
 version("5.2.2") { source sha256: "73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2" }


### PR DESCRIPTION
Expands archive support and resolves C99/C11 warnings in liblzma

Signed-off-by: Tim Smith <tsmith@chef.io>