### PR TITLE
Update curl from 7.68 to 7.77.1

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.68.0"
+default_version "7.71.1"
 
 dependency "zlib"
 dependency "openssl"
@@ -24,11 +24,10 @@ dependency "cacerts"
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
+version("7.71.1") { source sha256: "59ef1f73070de67b87032c72ee6037cedae71dcb1d7ef2d7f59487704aec069d" }
 version("7.68.0") { source sha256: "1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358" }
 version("7.65.1") { source sha256: "821aeb78421375f70e55381c9ad2474bf279fc454b791b7e95fc83562951c690" }
 version("7.65.0") { source sha256: "2a65f4f858a1fa949c79f926ddc2204c2be353ccbad014e95cd322d4a87d82ad" }
-version("7.63.0") { source sha256: "d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41" }
-version("7.59.0") { source sha256: "099d9c32dc7b8958ca592597c9fabccdf4c08cfb7c114ff1afbbc4c6f13c9e9e" }
 
 source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz"
 


### PR DESCRIPTION
Tons of bug fixes, but also:

CVE-2019-15601: file: on Windows, refuse paths that start with \\

Signed-off-by: Tim Smith <tsmith@chef.io>