### PR TITLE
Update cacert to 7-22-20 release

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ license "MPL-2.0"
 license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
-default_version "2020-06-24"
+default_version "2020-07-22"
 
 source url: "https://curl.haxx.se/ca/cacert-#{version}.pem"
 
+version("2020-07-22") { source sha256: "2782f0f8e89c786f40240fc1916677be660fb8d8e25dede50c9f6f7b0c2c2178" }
 version("2020-06-24") { source sha256: "726889705b00f736200ed7999f7a50021b8735d53228d679c4e6665aa3b44987" }
-
 version("2019-10-16") { source sha256: "5cd8052fcf548ba7e08899d8458a32942bf70450c9af67a0850b4c711804a2e4" }
 
 relative_path "cacerts-#{version}"


### PR DESCRIPTION
Removes:
 - Verisign Class 3 Public Primary Certification Authority - G3
 - AddTrust External Root
 - Staat der Nederlanden Root CA - G2
 - LuxTrust Global Root 2

Adds:
 - Microsoft ECC Root Certificate Authority 2017
 - Microsoft RSA Root Certificate Authority 2017
 - e-Szigno Root CA 2017
 - certSIGN Root CA G2

Signed-off-by: Tim Smith <tsmith@chef.io>