### PR TITLE
Don't build bsdcat with libarchive

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -54,6 +54,7 @@ build do
     "--without-iconv",
     "--disable-bsdtar", # tar command line tool
     "--disable-bsdcpio", # cpio command line tool
+    "--disable-bsdcat", # cat w/ decompression command line tool
     "--without-openssl",
     "--without-zstd",
     "--without-lz4",


### PR DESCRIPTION
This slims our installs by 579k on my mac and will speed up build times

Signed-off-by: Tim Smith <tsmith@chef.io>