### PR TITLE
Use solaris2? helper throughout

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -58,7 +58,7 @@ build do
     # otherwise gawk will die during ./configure with variations on the theme of:
     # "/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded"
     env["LIBPATH"] = "/usr/lib:/lib"
-  elsif solaris?
+  elsif solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
   end

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -46,7 +46,7 @@ build do
 
   env = with_standard_compiler_flags(with_embedded_path)
 
-  patch source: "libxslt-solaris-configure.patch", env: env if solaris? || omnios? || smartos?
+  patch source: "libxslt-solaris-configure.patch", env: env if solaris2? || omnios? || smartos?
 
   if windows? && version.satisfies?(">=1.1.30")
     patch source: "libxslt-windows-relocate-1.1.30.patch", env: env


### PR DESCRIPTION
Use the same helper everywhere we're checking for Solaris.

Signed-off-by: Tim Smith <tsmith@chef.io>