### PR TITLE
Disable libquadmath in binutils

### DIFF
--- a/config/software/binutils.rb
+++ b/config/software/binutils.rb
@@ -36,7 +36,8 @@ build do
   update_config_guess
 
   configure_command = ["./configure",
-                     "--prefix=#{install_dir}/embedded"]
+                     "--prefix=#{install_dir}/embedded",
+                     "--disable-libquadmath"]
 
   command configure_command.join(" "), env: env
 


### PR DESCRIPTION
Don't build in support for this if it's on the system. It shouldn't be out of the box.

Signed-off-by: Tim Smith <tsmith@chef.io>