### PR TITLE
libxml2: remove old versions, skip debugger, add lzma path

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018, Chef Software Inc.
+# Copyright:: Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,11 +27,6 @@ dependency "config_guess"
 
 version("2.9.10") { source sha256: "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f" }
 version("2.9.9") { source sha256: "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871" }
-version("2.9.8") { source sha256: "0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732" }
-version("2.9.7") { source sha256: "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c" }
-version("2.9.5") { source sha256: "4031c1ecee9ce7ba4f313e91ef6284164885cdb69937a123f6a83bb6a72dcd38" }
-version("2.9.4") { source sha256: "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c" }
-version("2.9.3") { source sha256: "4de9e31f46b44d34871c22f54bfc54398ef124d6f7cafb1f4a5958fbcd3ba12d" }
 
 source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
 
@@ -42,9 +37,11 @@ build do
 
   configure_command = [
     "--with-zlib=#{install_dir}/embedded",
+    "--with-lzma=#{install_dir}/embedded",
     "--without-iconv",
     "--without-python",
     "--without-icu",
+    "--without-debug",
   ]
 
   update_config_guess


### PR DESCRIPTION
Not building the debug functionality drops the library from 6.2 meg to 6
megs

Signed-off-by: Tim Smith <tsmith@chef.io>