### PR TITLE
Skip all the binaries in liblzma

### DIFF
--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -42,6 +42,11 @@ build do
     "--disable-dependency-tracking",
     "--disable-doc",
     "--disable-scripts",
+    "--disable-lzma-links",
+    "--disable-lzmainfo",
+    "--disable-lzmadec",
+    "--disable-xzdec",
+    "--disable-xz",
   ]
   config_command << "--disable-nls" if windows?
 


### PR DESCRIPTION
We're interested in the library and not all the binaries that come along
with it. This saves us 197k on disk.

Signed-off-by: Tim Smith <tsmith@chef.io>