### PR TITLE
Set our Windows NT target version to 8+ for Ruby

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -216,7 +216,8 @@ build do
     # force that API off.
     configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
-    configure_command << " debugflags=-g"
+    configure_command << "debugflags=-g"
+    configure_command << "--with-winnt-ver=0x0602" # the default is 0x0600 which is Vista. 602 is Windows 8 (2012)
   else
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end


### PR DESCRIPTION
We should target the version of Ruby we actually support. From the source this doesn't seem like it unlocks anything (yet), but we should target what we use.

Signed-off-by: Tim Smith <tsmith@chef.io>