### PR TITLE
Update libsodium to 1.0.18

### DIFF
--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -24,7 +24,7 @@ license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
 version("1.0.17") { source sha256: "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1" }
-version("1.0.18") { source sha256: "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1" }
+version("1.0.18") { source sha256: "6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1" }
 
 source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 

--- a/config/software/libsodium.rb
+++ b/config/software/libsodium.rb
@@ -17,35 +17,16 @@
 
 # We use the version in util-linux, and only build the libuuid subdirectory
 name "libsodium"
-default_version "1.0.17"
+default_version "1.0.18"
 
 license "ISC"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-version "1.0.17" do
-  source sha256: "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1"
-end
+version("1.0.17") { source sha256: "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1" }
+version("1.0.18") { source sha256: "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1" }
 
-# perhaps use git https://github.com/jedisct1/libsodium/
-version "1.0.12" do
-  source sha256: "b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95"
-end
-version "1.0.8" do
-  source md5: "0a66b86fd3aab3fe4c858edcd2772760"
-end
-version "1.0.2" do
-  source md5: "dc40eb23e293448c6fc908757738003f"
-end
-version "0.7.1" do
-  source md5: "c224fe3923d1dcfe418c65c8a7246316"
-end
-
-if version.satisfies?(">= 1.0.9")
-  source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
-else
-  source url: "https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-#{version}.tar.gz"
-end
+source url: "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
 
 relative_path "libsodium-#{version}"
 


### PR DESCRIPTION
Also nuke the very old builds.

Signed-off-by: Tim Smith <tsmith@chef.io>