### PR TITLE
Set the default Ruby release to 2.7.1

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,7 +25,7 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.6.6"
+default_version "2.7.1"
 
 dependency "zlib"
 dependency "openssl"


### PR DESCRIPTION
It's time to consume 2.7.1 everywhere

Signed-off-by: Tim Smith <tsmith@chef.io>