### PR TITLE
ruby-cleanup: add missing dep

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -26,6 +26,8 @@ default_version "1.0.0"
 license :project_license
 skip_transitive_dependency_licensing true
 
+dependency "ruby"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 


### PR DESCRIPTION
When using omnibus caches ruby-cleanup always causes a failure because it is missing a dependency on ruby. 

## Description
When using omnibus caches ruby-cleanup always causes a failure because it is missing a dependency on ruby. 

## Related Issue
https://gitlab.com/cinc-project/distribution/server/-/issues/7
if you fix nokogiri ruby-cleanup fails next.  I believe this belong upstream. 

I currently have my chef environment building 
Duration: 15 minutes 25 seconds

From 57 minutes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
