### PR TITLE
Compile curl without libidn2

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -79,7 +79,7 @@ build do
     "--disable-gopher",
     "--disable-dependency-tracking",
     "--enable-ipv6",
-    "--without-libidn",
+    "--without-libidn2",
     "--without-gnutls",
     "--without-librtmp",
     "--without-zsh-functions-dir",


### PR DESCRIPTION
## Description
--without-libidn has disappeared and is now --without-libidn2

## Related Issue

Without this fix, building curl fails with
```
[HealthCheck] E | 2020-10-13T17:34:07+02:00 | The following libraries cannot be guaranteed to be on target systems:
    --> /lib64/libidn2.so.0 (0x00007f30488b2000)
    --> /lib64/libunistring.so.2 (0x00007f3048726000)
    --> /lib64/libidn2.so.0 (0x00007ffb88a8e000)
    --> /lib64/libunistring.so.2 (0x00007ffb88457000)
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
