### PR TITLE
Require omnibus 8 or later

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
-  s.add_dependency "omnibus", ">= 6.0.0"
+  s.add_dependency "omnibus", ">= 8.0.0"
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
I bumped us from 5->6, but the change that needed to be done was
actually 5 -> 8.

Signed-off-by: Tim Smith <tsmith@chef.io>