### PR TITLE
Bump the default Ruby to 2.7.2

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,7 +25,7 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.7.1"
+default_version "2.7.2"
 
 dependency "zlib"
 dependency "openssl"


### PR DESCRIPTION
We shouldn't have the default include CVEs

Signed-off-by: Tim Smith <tsmith@chef.io>