### PR TITLE
updated the libarchive version to 3.5.1

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -18,12 +18,13 @@
 # https://github.com/berkshelf/api.berkshelf.com
 
 name "libarchive"
-default_version "3.4.3"
+default_version "3.5.1"
 
 license "BSD-2-Clause"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
+version("3.5.1") { source sha256: "9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a" }
 version("3.5.0") { source sha256: "fc4bc301188376adc18780d35602454cc8df6396e1b040fbcbb0d4c0469faf54" }
 version("3.4.3") { source sha256: "ee1e749213c108cb60d53147f18c31a73d6717d7e3d2481c157e1b34c881ea39" }
 version("3.4.2") { source sha256: "b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176" }


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <nikhilgupta2102@gmail.com>

Update libarchive to 3.5.1

## Description
Added the sha for libarchive version 3.5.1 and make it to the default version

## Related Issue
[https://github.com/chef/chef-workstation/issues/1618]

