### PR TITLE
WIP Apple M1 Fixes

### DIFF
--- a/config/patches/openssl/openssl-1.0.2x-darwin-arm64.patch
+++ b/config/patches/openssl/openssl-1.0.2x-darwin-arm64.patch
@@ -1,0 +1,54 @@
+diff -ur openssl-1.0.2x/Configure openssl-1.0.2x.new/Configure
+--- openssl-1.0.2x/Configure	2020-12-08 13:23:12.000000000 +0000
++++ openssl-1.0.2x.new/Configure	2021-01-12 08:24:27.000000000 +0000
+@@ -156,6 +156,7 @@
+ 
+ my $x86_elf_asm="$x86_asm:elf";
+ 
++my $arm64_asm="arm64cpuid.o:arm64-gcc.o arm64-mont.o arm64-mont5.o arm64-gf2m.o modexp512-arm64.o::aes-arm64.o vpaes-arm64.o bsaes-arm64.o aesni-arm64.o aesni-sha1-arm64.o::md5-arm64.o:sha1-arm64.o sha256-arm64.o sha512-arm64.o::rc4-arm64.o rc4-md5-arm64.o:::wp-arm64.o:cmll-arm64.o cmll_misc.o:ghash-arm64.o:";
+ my $x86_64_asm="x86_64cpuid.o:x86_64-gcc.o x86_64-mont.o x86_64-mont5.o x86_64-gf2m.o rsaz_exp.o rsaz-x86_64.o rsaz-avx2.o:ecp_nistz256.o ecp_nistz256-x86_64.o::aes-x86_64.o vpaes-x86_64.o bsaes-x86_64.o aesni-x86_64.o aesni-sha1-x86_64.o aesni-sha256-x86_64.o aesni-mb-x86_64.o::md5-x86_64.o:sha1-x86_64.o sha256-x86_64.o sha512-x86_64.o sha1-mb-x86_64.o sha256-mb-x86_64.o::rc4-x86_64.o rc4-md5-x86_64.o:::wp-x86_64.o:cmll-x86_64.o cmll_misc.o:ghash-x86_64.o aesni-gcm-x86_64.o:";
+ my $ia64_asm="ia64cpuid.o:bn-ia64.o ia64-mont.o:::aes_core.o aes_cbc.o aes-ia64.o::md5-ia64.o:sha1-ia64.o sha256-ia64.o sha512-ia64.o::rc4-ia64.o rc4_skey.o:::::ghash-ia64.o::void";
+ my $sparcv9_asm="sparcv9cap.o sparccpuid.o:bn-sparcv9.o sparcv9-mont.o sparcv9a-mont.o vis3-mont.o sparct4-mont.o sparcv9-gf2m.o::des_enc-sparc.o fcrypt_b.o dest4-sparcv9.o:aes_core.o aes_cbc.o aes-sparcv9.o aest4-sparcv9.o::md5-sparcv9.o:sha1-sparcv9.o sha256-sparcv9.o sha512-sparcv9.o::::::camellia.o cmll_misc.o cmll_cbc.o cmllt4-sparcv9.o:ghash-sparcv9.o::void";
+@@ -649,6 +650,7 @@
+ "darwin64-ppc-cc","cc:-arch ppc64 -O3 -DB_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc64_asm}:osx64:dlfcn:darwin-shared:-fPIC -fno-common:-arch ppc64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "darwin-i386-cc","cc:-arch i386 -O3 -fomit-frame-pointer -DL_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:BN_LLONG RC4_INT RC4_CHUNK DES_UNROLL BF_PTR:".eval{my $asm=$x86_asm;$asm=~s/cast\-586\.o//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch i386 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "debug-darwin-i386-cc","cc:-arch i386 -g3 -DL_ENDIAN::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:BN_LLONG RC4_INT RC4_CHUNK DES_UNROLL BF_PTR:${x86_asm}:macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch i386 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
++"darwin64-arm64-cc","cc:-arch arm64 -O3 -DL_ENDIAN -Wall::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL:".eval{my $asm=$arm64_asm;$asm=~s/rc4\-[^:]+//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch arm64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "darwin64-x86_64-cc","cc:-arch x86_64 -O3 -DL_ENDIAN -Wall::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:".eval{my $asm=$x86_64_asm;$asm=~s/rc4\-[^:]+//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch x86_64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "debug-darwin64-x86_64-cc","cc:-arch x86_64 -ggdb -g2 -O0 -DL_ENDIAN -Wall::-D_REENTRANT:MACOSX:-Wl,-search_paths_first%:SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:".eval{my $asm=$x86_64_asm;$asm=~s/rc4\-[^:]+//;$asm}.":macosx:dlfcn:darwin-shared:-fPIC -fno-common:-arch x86_64 -dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+ "debug-darwin-ppc-cc","cc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DB_ENDIAN -g -Wall -O::-D_REENTRANT:MACOSX::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc32_asm}:osx32:dlfcn:darwin-shared:-fPIC:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
+diff -ur openssl-1.0.2x/config openssl-1.0.2x.new/config
+--- openssl-1.0.2x/config	2020-12-08 13:23:12.000000000 +0000
++++ openssl-1.0.2x.new/config	2021-01-12 08:39:17.000000000 +0000
+@@ -274,6 +274,9 @@
+ 
+     Darwin:*)
+ 	case "$MACHINE" in
++	    arm*)
++		echo "arm-apple-darwin${VERSION}"
++		;;
+ 	    Power*)
+ 		echo "ppc-apple-darwin${VERSION}"
+ 		;;
+@@ -560,6 +563,21 @@
+ 	else
+ 	    OUT="darwin-ppc-cc"
+ 	fi ;;
++  arm-apple-darwin*)
++        ISA64=`(sysctl -n hw.optional.arm64) 2>/dev/null`
++        if [ "$ISA64" = "1" -a -z "$KERNEL_BITS" ]; then
++            echo "WARNING! If you wish to build M1 ARM 64-bit library, then you have to"
++            echo "         invoke './Configure darwin64-arm64-cc' *manually*."
++            if [ "$TEST" = "false" -a -t 1 ]; then
++              echo "         You have about 5 seconds to press Ctrl-C to abort."
++              (trap "stty `stty -g`" 2 0; stty -icanon min 0 time 50; read waste) <&1
++            fi
++        fi
++        if [ "$ISA64" = "1" -a "$KERNEL_BITS" = "64" ]; then
++            OUT="darwin64-arm64-cc"
++        else
++            OUT="darwin-arm64-cc"
++        fi ;;
+   i?86-apple-darwin*)
+ 	ISA64=`(sysctl -n hw.optional.x86_64) 2>/dev/null`
+ 	if [ "$ISA64" = "1" -a -z "$KERNEL_BITS" ]; then

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -44,6 +44,8 @@ build do
     # disable multi-os-directory via configure flag (don't use /lib64)
     # Works on all platforms, and is compatible on 32bit platforms as well
     configure_command << "--disable-multi-os-directory"
+    # Workaround issue on Apple M1 https://github.com/libffi/libffi/issues/571
+    configure_command << "--build=aarch64-apple-darwin20.2.0" if mac_os_x? && arm?
 
     # add the --disable-multi-os-directory flag to 3.2.1
     if version == "3.2.1"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -64,6 +64,8 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
+  elsif mac_os_x? && arm?
+    env["CFLAGS"] << " -Qunused-arguments"
   elsif freebsd?
     # Should this just be in standard_compiler_flags?
     env["LDFLAGS"] += " -Wl,-rpath,#{install_dir}/embedded/lib"
@@ -97,7 +99,7 @@ build do
     if aix?
       "perl ./Configure aix64-cc"
     elsif mac_os_x?
-      "./Configure darwin64-x86_64-cc"
+      intel? ? "./Configure darwin64-x86_64-cc" : "./Configure darwin64-arm64-cc no-asm"
     elsif smartos?
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif omnios?
@@ -137,6 +139,10 @@ build do
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
   elsif version.start_with? "1.1"
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
+  end
+
+  if mac_os_x? && arm?
+    patch source: "openssl-1.0.2x-darwin-arm64.patch"
   end
 
   if windows?

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -65,8 +65,9 @@ if mac_os_x?
   # would be harmless, except that autoconf treats any output to stderr as
   # a failure when it makes a test program to check your CFLAGS (regardless
   # of the actual exit code from the compiler).
-  env["CFLAGS"] << " -I#{install_dir}/embedded/include/ncurses -arch x86_64 -m64 -O3 -g -pipe -Qunused-arguments"
-  env["LDFLAGS"] << " -arch x86_64"
+  arch = intel? ? "x86_64" : "arm64"
+  env["CFLAGS"] << " -I#{install_dir}/embedded/include/ncurses -arch #{arch} -m64 -O3 -g -pipe -Qunused-arguments"
+  env["LDFLAGS"] << " -arch #{arch}"
 elsif freebsd?
   # Stops "libtinfo.so.5.9: could not read symbols: Bad value" error when
   # compiling ext/readline. See the following for more info:


### PR DESCRIPTION
This is a work in progress pull request for adding support to building various components on Apple M1 hardware. Right now I'm mostly targeting trying to build omnibus-toolchain and eventually chef and other projects.

- Set platform on MacOS M1 for libffi until upstream fixes it
- WIP fixes for openssl on M1
- Apple M1 fixes for ruby

Right now the major blocker is trying to build openssl 1.0.2x on M1. Please look at the commit for more information on where I'm at with it. It might be a good idea to just move to building openssl 1.1.x for MacOS M1 since that seems to have upstream support at least. AFAIK we don't have FIPS enabled on MacOS builds anyway.
