### PR TITLE
Ensure we force lib_dirs to init properly before appending

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -27,8 +27,8 @@ default_version "1.0.2x"
 
 # Openssl builds engines as libraries into a special directory. We need to include
 # that directory in lib_dirs so omnibus can sign them during macOS deep signing.
-lib_dirs << "#{install_dir}/embedded/lib/engines"
-lib_dirs << "#{install_dir}/embedded/lib/engines-1.1" if version.start_with?("1.1")
+lib_dirs lib_dirs.concat(["#{install_dir}/embedded/lib/engines"])
+lib_dirs lib_dirs.concat(["#{install_dir}/embedded/lib/engines-1.1"]) if version.start_with?("1.1")
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # So skip error checking with `extract: :lax_tar`


### PR DESCRIPTION
Revert to the original way of concatenating to the lib path, because `lib_dirs` is not exposed in a way that would let us concat it like `lib_dirs << '/some/path'`.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
