### PR TITLE
Use HTTPS connection to get RubyGems source

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -33,7 +33,7 @@ if version && !source
   }
   known_tarballs.each do |vsn, md5|
     version vsn do
-      source md5: md5, url: "http://production.cf.rubygems.org/rubygems/rubygems-#{vsn}.tgz"
+      source md5: md5, url: "https://rubygems.org/rubygems/rubygems-#{vsn}.tgz"
       relative_path "rubygems-#{vsn}"
     end
   end


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Use HTTPS connection to get RubyGems source.

`http://production.cf.rubygems.org` has been insecure since:

1. using HTTP instead of HTTPS
2. `production.cf.rubygems.org` does not use [a valid cert](https://www.ssllabs.com/ssltest/analyze.html?d=production.cf.rubygems.org&hideResults=on) (looks hosting `j.sni.global.fastly.net`)

The upstream project currently suggests to use tarballs hosted on `rubygems.org` according to the instruction on `https://rubygems.org/pages/download`.

## Related Issue
Part of #1288 

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [n/a] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
