### PR TITLE
Update URL for Omnibus blog by Chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is managed by the CHEF Release Engineering team. For more informati
 
 ## Using Your Own Software Definitions
 
-This repository is the collection of Chef Software's software definitions. We like that others get utility out of them, but they are not meant to be comprehensive collection of all software on the planet. For more information, please read [Omnibus, a look forward](http://www.getchef.com/blog/2014/06/30/omnibus-a-look-forward/) on the Chef blog.
+This repository is the collection of Chef Software's software definitions. We like that others get utility out of them, but they are not meant to be comprehensive collection of all software on the planet. For more information, please read [Omnibus, a look forward](https://blog.chef.io/omnibus-a-look-forward) on the Chef blog.
 
 For more information on writing your own software definitions, please see [the Omnibus README](https://github.com/chef/omnibus#sharing-software-definitions).
 


### PR DESCRIPTION
## Description
The URL `http://www.getchef.com/blog/2014/06/30/omnibus-a-look-forward/` for the article entitled as "Omnibus, a look forward" is now dead, so should be fixed.

Redirection structure:

- http://www.getchef.com/blog/2014/06/30/omnibus-a-look-forward/
   - https://www.chef.io/blog/2014/06/30/omnibus-a-look-forward/
      - https://blog.chef.io2014/06/30/omnibus-a-look-forward/
         - 404
            - https://blog.chef.io2014/06/30/omnibus-a-look-forward/
               - https://blog.chef.io/omnibus-a-look-forward/
                  - https://blog.chef.io/omnibus-a-look-forward
                     - 200

## Related Issue
Part of #1288 

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
