### PR TITLE
Switch to using the post-bundle-install hook

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -64,20 +64,7 @@ build do
 
   bundle "install --without #{bundle_excludes.join(" ")}", env: env
 
-  block do
-    # Install gems from git repos.  This makes the assumption that there is a <gemname>.gemspec and
-    # you can simply gem build + gem install the resulting gem, so nothing fancy.  This does not use
-    # rake install since we need --conservative --minimal-deps in order to not install duplicate gems.
-    #
-    Dir["#{install_dir.tr('\\', "/")}/embedded/lib/ruby/gems/*/bundler/gems/*"].each do |gempath|
-      gemname = File.basename(gempath).gsub(/-[A-Fa-f0-9]{12}$/, "")
-      # we can't use "commmand" or "bundle" or "gem" DSL methods here since those are lazy and we need to run commands immediately
-      # (this is like a shell_out inside of a ruby_block in core chef, you don't use an execute resource inside of a ruby_block or
-      # things get really weird and unexpected)
-      shellout! "gem build #{gemname}.gemspec", env: env, cwd: gempath
-      shellout! "gem install #{gemname}*.gem --conservative --minimal-deps --no-document", env: env, cwd: gempath
-    end
-  end
+  ruby "post-bundle-install.rb", env: env
 
   # use the rake install task to build/install chef-config/chef-utils
   command "rake install", env: env


### PR DESCRIPTION
This is going to require all branches of chef that we build have the post-bundle-install hook, which is work that is immediately in flight, but this is being merged first since we have circular requirements.