### PR TITLE
Add sqitch version 0.9999

### DIFF
--- a/config/software/cpanminus.rb
+++ b/config/software/cpanminus.rb
@@ -40,3 +40,11 @@ build do
 
   command "cat cpanm | perl - App::cpanminus", env: env
 end
+
+# Perl after 5.18 does not come with this by default
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "cpanm Module::Build", env: env
+end
+

--- a/config/software/sqitch.rb
+++ b/config/software/sqitch.rb
@@ -26,6 +26,10 @@ dependency "cpanminus"
 # install a LGPL-licensed version of libintl-perl:
 dependency "libintl-perl"
 
+version "0.9999" do
+  source md5: "f203d4ac02c83b5e1214d92f090acef2"
+end
+
 version "0.9994" do
   source md5: "7227dfcd141440f23d99f01a2b01e0f2"
 end


### PR DESCRIPTION
## Description
This PR adds sqitch version `0.9999` which is the first version to support Perl `5.30.0` as noted here:

http://www.cpantesters.org/distro/A/App-Sqitch.html

chef-server is looking to modernize the version of Perl that it ships with and requires a version of sqitch that is compatible with Perl `5.30.0`.

## Related Issue
https://github.com/chef/chef-server/issues/2166

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
