### PR TITLE
Set default version of PostgreSQL to 12.5

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.2.24" # NOTE: This version is EoL, but many downstream users take the default, and we shouldn't break them
+default_version "12.5"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"


### PR DESCRIPTION
Question: should we also remove most of the older pg versions specified here?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
