### PR TITLE
Add Docker-based compilation testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM chefes/releng-base
+
+ARG SOFTWARE
+ARG VERSION
+
+COPY ./ /omnibus-software
+COPY ./test /test
+
+WORKDIR /test
+
+RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P omnibus-toolchain
+
+RUN . /opt/omnibus-toolchain/bin/load-omnibus-toolchain \
+    && DEBUG=1 bundle install --without development \
+    && bundle exec omnibus build test

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This repository is versioned and tagged using the `YY.MM.BUILD` to allow folks t
 
 For information on contributing to this project please see our [Contributing Documentation](https://github.com/chef/chef/blob/master/CONTRIBUTING.md)
 
+### Testing via Docker
+
+We provide a sample Dockerfile you can use to ensure that your software definitions are able to compile on Ubuntu 18.04.
+
+```
+bundle exec rake test_build <SOFTWARE> (<VERSION>)
+```
+
 ## License & Copyright
 
 - Copyright:: Copyright (c) 2012-2021 Chef Software, Inc.

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,20 @@ task :fetch_all do
   OmnibusSoftware.fetch_all(path)
 end
 
+task :test_build do
+  rake_fakeout
+  software = ARGV[1]
+  version = ARGV[2] || "default"
+
+  raise "\nERROR: You must specify a software name\n\n" if software.nil?
+
+  command = "docker build --build-arg SOFTWARE=#{software}"
+  command += " --build-arg VERSION=#{version}" unless version == "default"
+  command += " --tag localhost:5000/omnibus-#{software}:#{version} ."
+
+  sh command
+end
+
 def rake_fakeout
   ARGV.each { |a| task a.to_sym {} } # rubocop: disable Lint/AmbiguousBlockAssociation
 end

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "omnibus", github: "chef/omnibus", branch: "master"
+gem "omnibus-software", path: "/omnibus-software"

--- a/test/config/projects/test.rb
+++ b/test/config/projects/test.rb
@@ -1,0 +1,14 @@
+name "test"
+maintainer "Chef Software, Inc."
+homepage "https://www.chef.io"
+
+install_dir "#{default_root}/#{name}"
+
+build_version   Omnibus::BuildVersion.semver
+build_iteration 1
+
+dependency ENV["SOFTWARE"]
+
+if ENV["VERSION"]
+  override ENV["SOFTWARE"].to_sym, version: ENV["VERSION"]
+end

--- a/test/omnibus.rb
+++ b/test/omnibus.rb
@@ -1,0 +1,58 @@
+#
+# This file is used to configure the harmony project. It contains
+# some minimal configuration examples for working with Omnibus. For a full list
+# of configurable options, please see the documentation for +omnibus/config.rb+.
+#
+
+# Build internally
+# ------------------------------
+# By default, Omnibus uses system folders (like +/var+ and +/opt+) to build and
+# cache components. If you would to build everything internally, you can
+# uncomment the following options. This will prevent the need for root
+# permissions in most cases. You will also need to update the harmony
+# project configuration to build at +./local/omnibus/build+ instead of
+# +/opt/harmony+
+#
+# Uncomment this line to change the default base directory to "local"
+# -------------------------------------------------------------------
+# base_dir './local'
+#
+# Alternatively you can tune the individual values
+# ------------------------------------------------
+# cache_dir     './local/omnibus/cache'
+# git_cache_dir './local/omnibus/cache/git_cache'
+# source_dir    './local/omnibus/src'
+# build_dir     './local/omnibus/build'
+# package_dir   './local/omnibus/pkg'
+# package_tmp   './local/omnibus/pkg-tmp'
+
+# Windows architecture defaults - set to x86 unless otherwise specified.
+# ------------------------------
+env_omnibus_windows_arch = (ENV["OMNIBUS_WINDOWS_ARCH"] || "").downcase
+env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_arch)
+
+windows_arch env_omnibus_windows_arch
+
+# Disable git caching
+# ------------------------------
+use_git_caching false
+
+# Enable S3 asset caching
+# ------------------------------
+use_s3_caching true
+s3_access_key  ENV["AWS_ACCESS_KEY_ID"]
+s3_secret_key  ENV["AWS_SECRET_ACCESS_KEY"]
+s3_bucket      "opscode-omnibus-cache"
+
+# Customize compiler bits
+# ------------------------------
+# solaris_compiler 'gcc'
+
+# Do not retry builds
+# ------------------------------
+build_retries 0
+
+# Load additional software
+# ------------------------------
+# software_gems ['omnibus-software', 'my-company-software']
+# local_software_dirs ['/path/to/local/software']


### PR DESCRIPTION
This docker testing can act as a sanity test to ensure that things are
able to compile correctly. We may eventually extend this to support
Windows, and even run in a verification pipeline.

Signed-off-by: Tom Duffield <github@tomduffield.com>