### PR TITLE
Add libxml2 2.9.12 as default

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxml2"
-default_version "2.9.10"
+default_version "2.9.12"
 
 license "MIT"
 license_file "COPYING"
@@ -26,7 +26,7 @@ dependency "liblzma"
 dependency "config_guess"
 
 # version_list: url=ftp://xmlsoft.org/libxml2/ filter=libxml2-*.tar.gz
-
+version("2.9.12") { source sha256: "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92" }
 version("2.9.10") { source sha256: "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f" }
 version("2.9.9")  { source sha256: "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871" }
 


### PR DESCRIPTION
This resolves a HUGE list of bugs and a pile of CVEs

Signed-off-by: Tim Smith <tsmith@chef.io>