### PR TITLE
Set the libxml2 default back to 2.9.10

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxml2"
-default_version "2.9.12"
+default_version "2.9.10" # 2.9.12 is not properly building as of 5.20.21
 
 license "MIT"
 license_file "COPYING"


### PR DESCRIPTION
2.9.12 is pretty broken right now and it looks like they may have an upstream release to resolve some problems.

Signed-off-by: Tim Smith <tsmith@chef.io>