### PR TITLE
force gcc on windows ruby builds

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -233,6 +233,7 @@ build do
     # force that API off.
     configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
+    env["CC"] = "gcc"
     configure_command << "debugflags=-g"
     configure_command << "--with-winnt-ver=0x0602" # the default is 0x0600 which is Vista. 602 is Windows 8 (2012)
   else

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -92,6 +92,10 @@ elsif aix?
 elsif solaris2?
   env["CXXFLAGS"] = "#{env["CXXFLAGS"]} -std=c++0x"
 elsif windows?
+  # this forces ruby >= 3.0 to pick up the gcc in the devkit rather than the cc in /opt/omnibus-toolchain
+  # which is necessary for mkmf.rb to be able to correctly build native gems.  in an ideal world the compilation
+  # environment in omnibus-toolchain would probably need to look a little more identical to the devkit.
+  env["CC"] = "gcc"
   env["CFLAGS"] = "-I#{install_dir}/embedded/include -DFD_SETSIZE=2048"
   if windows_arch_i386?
     env["CFLAGS"] << " -m32 -march=i686 -O3"
@@ -233,7 +237,6 @@ build do
     # force that API off.
     configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
-    env["CC"] = "gcc"
     configure_command << "debugflags=-g"
     configure_command << "--with-winnt-ver=0x0602" # the default is 0x0600 which is Vista. 602 is Windows 8 (2012)
   else


### PR DESCRIPTION
This fixes ruby-3.0 which for some reason preferentially picks up cc out of /opt/omnibus-toolchain on the build servers (where ruby-2.x did not) and results in a ruby-3.0 build which cannot build any native gems.  This also breaks builds on chef-workstation for ruby-3.0 because the cc it picks up cannot compile `dep_selector` probably due to bypassing some gcc-check in the extconf.rb of that gem.  This fixes omnibus builds of both chef and chef-workstation.