### PR TITLE
Update Openresty to 1.19.3.2 for a CVE fix

### DIFF
--- a/config/software/openresty.rb
+++ b/config/software/openresty.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ name "openresty"
 license "BSD-2-Clause"
 license_file "README.markdown"
 skip_transitive_dependency_licensing true
-default_version "1.19.3.1"
+default_version "1.19.3.2"
 
 dependency "pcre"
 dependency "openssl"
@@ -29,6 +29,7 @@ source_package_name = "openresty"
 
 # Versions above 1.11.2.2 require SSE4.2 CPU support
 # versions_list: https://openresty.org/download/ filter=*.tar.gz
+version("1.19.3.2") { source sha256: "ce40e764990fbbeb782e496eb63e214bf19b6f301a453d13f70c4f363d1e5bb9" }
 version("1.19.3.1") { source sha256: "f36fcd9c51f4f9eb8aaab8c7f9e21018d5ce97694315b19cacd6ccf53ab03d5d" }
 version("1.17.8.2") { source sha256: "2f321ab11cb228117c840168f37094ee97f8f0316eac413766305409c7e023a0" }
 version("1.15.8.1") { source sha256: "89a1238ca177692d6903c0adbea5bdf2a0b82c383662a73c03ebf5ef9f570842" }
@@ -36,7 +37,6 @@ version("1.13.6.2") { source sha256: "946e1958273032db43833982e2cec0766154a9b5cb
 version("1.11.2.5") { source sha256: "f8cc203e8c0fcd69676f65506a3417097fc445f57820aa8e92d7888d8ad657b9" }
 version("1.11.2.2") { source sha256: "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01" }
 version("1.11.2.1") { source sha256: "0e55b52bf6d77ac2d499ae2b05055f421acde6bb937e650ed8f482d11cbeeb5c" }
-version("1.9.7.3")  { source sha256: "3e4422576d11773a03264021ff7985cd2eeac3382b511ae3052e835210a9a69a" }
 
 source url: "https://openresty.org/download/#{source_package_name}-#{version}.tar.gz"
 


### PR DESCRIPTION
https://openresty.org/en/ann-1019003002.html

This resolves CVE-2021-23017

Signed-off-by: Tim Smith <tsmith@chef.io>