### PR TITLE
Fix builds on Solaris

### DIFF
--- a/config/patches/bash/race-condition.patch
+++ b/config/patches/bash/race-condition.patch
@@ -1,0 +1,15 @@
+bashline.c:65:10: fatal error: builtins/builtext.h: No such file or directory
+   65 | #include "builtins/builtext.h"  /* for read_builtin */
+      |          ^~~~~~~~~~~~~~~~~~~~~
+
+--- bash-5.1/Makefile.in
++++ bash-5.1/Makefile.in
+@@ -584,6 +584,8 @@
+ 	ls -l $(Program)
+ 	-$(SIZE) $(Program)
+ 
++$(CSOURCES): $(DEFDIR)/builtext.h
++
+ .build:	$(SOURCES) config.h Makefile version.h $(VERSPROG)
+ 	@echo
+ 	@echo "	  ***********************************************************"

--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -39,6 +39,10 @@ relative_path "bash-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Fix bash race condition
+  # https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00051.html
+  patch source: "race-condition.patch", plevel: 1, env: env
+
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded"]
 

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -25,7 +25,7 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 # version_list: url=https://github.com/libexpat/libexpat/releases filter=*.tar.gz
-source url: "http://downloads.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz"
+source url: "https://github.com/libexpat/libexpat/releases/download/R_#{version.gsub(".", "_")}/expat-#{version}.tar.gz"
 
 version("2.3.0") { source sha256: "89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987" }
 version("2.1.0") { source sha256: "823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86" }

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -15,7 +15,7 @@
 #
 
 name "expat"
-default_version "2.3.0"
+default_version "2.4.1"
 
 relative_path "expat-#{version}"
 dependency "config_guess"
@@ -27,6 +27,7 @@ skip_transitive_dependency_licensing true
 # version_list: url=https://github.com/libexpat/libexpat/releases filter=*.tar.gz
 source url: "https://github.com/libexpat/libexpat/releases/download/R_#{version.gsub(".", "_")}/expat-#{version}.tar.gz"
 
+version("2.4.1") { source sha256: "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b" }
 version("2.3.0") { source sha256: "89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987" }
 version("2.1.0") { source sha256: "823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86" }
 

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -39,6 +39,9 @@ version("2.29.2") { source sha256: "869a121e1d75e4c28213df03d204156a17f02fce2dc7
 version("2.28.0") { source sha256: "f914c60a874d466c1e18467c864a910dd4ea22281ba6d4d58077cb0c3f115170" }
 version("2.26.2") { source sha256: "e1c17777528f55696815ef33587b1d20f5eec246669f3b839d15dbfffad9c121" }
 
+# we need to keep 2.24.1 until we can remove the version pin in omnibus-toolchain Solaris builds
+version("2.24.1") { source sha256: "ad5334956301c86841eb1e5b1bb20884a6bad89a10a6762c958220c7cf64da02" }
+
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
 # git builds git-core as binaries into a special directory. We need to include

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -98,7 +98,11 @@ build do
       "/bin/bash ./Configure solaris-x86-gcc"
     elsif solaris2?
       platform = sparc? ? "solaris64-sparcv9-gcc" : "solaris64-x86_64-gcc"
-      "/bin/bash ./Configure #{platform} -static-libgcc"
+      if version.satisfies?("< 1.1.0")
+        "/bin/bash ./Configure #{platform} -static-libgcc"
+      else
+        "./Configure #{platform} -static-libgcc"
+      end
     elsif windows?
       platform = windows_arch_i386? ? "mingw" : "mingw64"
       "perl.exe ./Configure #{platform}"

--- a/test/generate_steps.rb
+++ b/test/generate_steps.rb
@@ -46,6 +46,7 @@ files.each do |file|
         expeditor:
           executor:
             linux:
+              privileged: true
     EOH
   end
 end


### PR DESCRIPTION
Fix openssl for solaris

Fix bash race condition
https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00051.html

Add git 2.24.1 back to accommodate omnibus-toolchain Solaris builds

Update expat source url since it is moving to GitHub

Update expat default_version to 2.4.1 which fixes vulnerabilities

