### PR TITLE
Skip the configure patch on Ruby 3.0.2+

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -116,7 +116,7 @@ build do
   patch_env = env.dup
   patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
 
-  if version.satisfies?("~> 3.0")
+  if version.satisfies?("~> 3.0") && version.satisfies?("< 3.0.2")
     patch source: "ruby-3.0.1-configure.patch", plevel: 1, env: patch_env
   end
 


### PR DESCRIPTION
This patch doesn't apply

Signed-off-by: Tim Smith <tsmith@chef.io>