### PR TITLE
Fix bash on freebsd

### DIFF
--- a/config/software/bash.rb
+++ b/config/software/bash.rb
@@ -39,9 +39,13 @@ relative_path "bash-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # Fix bash race condition
-  # https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00051.html
-  patch source: "race-condition.patch", plevel: 1, env: env
+  # FreeBSD can build bash with this patch but it doesn't work properly
+  # Things like command substitution will throw syntax errors even though the syntax is correct
+  unless freebsd?
+    # Fix bash race condition
+    # https://lists.gnu.org/archive/html/bug-bash/2020-12/msg00051.html
+    patch source: "race-condition.patch", plevel: 1, env: env
+  end
 
   configure_command = ["./configure",
                        "--prefix=#{install_dir}/embedded"]


### PR DESCRIPTION
FreeBSD can build bash with the race condition patch but
it doesn't work properly.
Things like command substitution will throw syntax errors even
though the syntax is correct.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>