### PR TITLE
Better version constraint for Ruby 2.6 patch

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -202,7 +202,7 @@ build do
   configure_command << "--with-bundled-md5" if fips_mode?
 
   # resolve C99 code accidentally introduced in Ruby 2.6.7 and it's still in 2.6.8 :(
-  patch source: "ruby-2.6.7_c99.patch", plevel: 1, env: patch_env if version >= "2.6.7"
+  patch source: "ruby-2.6.7_c99.patch", plevel: 1, env: patch_env if version.satisfies?("~> 2.6.7")
 
   if aix?
     # need to patch ruby's configure file so it knows how to find shared libraries


### PR DESCRIPTION
Make sure this only applies to 2.6

Signed-off-by: Tim Smith <tsmith@chef.io>