### PR TITLE
Updating stunnel default to 5.49

### DIFF
--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -15,7 +15,7 @@
 #
 
 name "stunnel"
-default_version "5.39"
+default_version "5.49" # Pin stunnel to 5.49 as it's the last version that supports FIPS with standard builds.
 
 license "GPL-2.0"
 license_file "COPYING"
@@ -25,11 +25,15 @@ dependency "openssl"
 
 # version_list: url=https://www.stunnel.org/downloads/ filter=*.tar.gz
 
-source url:
-"https://www.stunnel.org/downloads/stunnel-#{version}.tar.gz"
+if version <= "5.58"
+  source url: "ftp://ftp.stunnel.org/stunnel/archive/5.x/stunnel-#{version}.tar.gz"
+else
+  source url: "https://www.stunnel.org/downloads/stunnel-#{version}.tar.gz"
+end
 relative_path "stunnel-#{version}"
 
 version("5.59") { source sha256: "137776df6be8f1701f1cd590b7779932e123479fb91e5192171c16798815ce9f" }
+version("5.49") { source sha256: "3d6641213a82175c19f23fde1c3d1c841738385289eb7ca1554f4a58b96d955e" }
 version("5.39") { source sha256: "288c087a50465390d05508068ac76c8418a21fae7275febcc63f041ec5b04dee" }
 
 build do


### PR DESCRIPTION
The following version is also now available:

- 5.59

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

 Stunnel versions >=50 have stopped FIPS supports with standard builds and this is the reason stunnel release 5.59 had started breaking workstation code base https://buildkite.com/chef/chef-chef-workstation-master-omnibus-adhoc/builds/499#75a13289-de88-4b00-bbcf-53ea41f99cea. So pinning stunnel default to 5.49 .

Verified workstation build for stunnel-5.49 -https://buildkite.com/chef/chef-chef-workstation-master-omnibus-adhoc/builds/542#_



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
