### PR TITLE
Add "safe-mode" fallback to gem-permissions

### DIFF
--- a/config/software/gem-permissions.rb
+++ b/config/software/gem-permissions.rb
@@ -29,7 +29,15 @@ skip_transitive_dependency_licensing true
 build do
   unless windows?
     block "Fix gem permissions" do
-      FileUtils.chmod_R "a+rX", "#{install_dir}/embedded/lib/ruby/gems/"
+      FileUtils.chmod_R("a+rX", "#{install_dir}/embedded/lib/ruby/gems/")
+    rescue Errno::ENOENT
+      # It is possible that the above method will fail for a variety of reasons, including:
+      #   * there is a symlink to a file that does not exist.
+      #
+      # If that happens we "retry" with a slower, but safer approach.
+      Dir["#{install_dir}/embedded/lib/ruby/gems/**/**"].each do |entry|
+        FileUtils.chmod("a+rX", entry) if File.exist?(entry)
+      end
     end
   end
 end


### PR DESCRIPTION
It is possible that gem-permissions will fail if a rubygem includes a symlink to a file that is not included in the distribution. If so, we want to "retry" with a slower but "safer" chmod approach.

Confirmed that this fixes the issue we're seeing in the InSpec builds that are facing this issue with the `mongo` gem. 

Signed-off-by: Tom Duffield <github@tomduffield.com>