### PR TITLE
Remove EOL nodejs release + PPC releases

### DIFF
--- a/config/software/nodejs.rb
+++ b/config/software/nodejs.rb
@@ -20,11 +20,7 @@ license "MIT"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-if ppc64? || ppc64le? || s390x?
-  default_version "0.10.38-release-ppc"
-else
-  default_version "0.10.48"
-end
+default_version "0.10.48"
 
 dependency "python"
 
@@ -32,26 +28,6 @@ default_src_url = "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
 
 version "0.10.48" do
   source url: default_src_url, sha256: "27a1765b86bf4ec9833e2f89e8421ba4bc01a326b883f125de2f0b3494bd5549"
-end
-
-version "0.10.35" do
-  source url: default_src_url, sha256: "0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03"
-end
-
-version "0.10.38-release-ppc" do
-  # This release is sourced from https://github.com/andrewlow/node but is packaged as
-  #  a tarball here for consistency between builds and to enable omnibus caching.
-  source url: "https://s3.amazonaws.com/chef-releng/node-v0.10.38-release-ppc.tar.gz",
-         md5: "1ca1a2179b4b255e8fac839a92985cf5"
-end
-
-version "4.1.2" do
-  source url: default_src_url, md5: "31a3ee2f51bb2018501048f543ea31c7"
-end
-
-# Warning: NodeJS 5.6.0 requires GCC >= 4.8
-version "5.6.0" do
-  source url: default_src_url, md5: "6f7c2cec289a20bcd970240dd63c1395"
 end
 
 relative_path "node-v#{version}"


### PR DESCRIPTION
We don't need a PPC build at this point and we don't need all these
unused / super EOL releases

Signed-off-by: Tim Smith <tsmith@chef.io>