### PR TITLE
Remove old redis 2.4.7

### DIFF
--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -44,10 +44,6 @@ version "2.8.2" do
   source md5: "ee527b0c37e1e2cbceb497f5f6b8112b"
 end
 
-version "2.4.7" do
-  source md5: "6afffb6120724183e40f1cac324ac71c"
-end
-
 source url: "http://download.redis.io/releases/redis-#{version}.tar.gz"
 
 relative_path "redis-#{version}"


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dhsingh@progress.com>

-- Remove old redis 2.4.7

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
