### PR TITLE
Update curl to 7.78 and remove old versions

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -15,7 +15,7 @@
 #
 
 name "curl"
-default_version "7.77.0"
+default_version "7.78.0"
 
 dependency "zlib"
 dependency "openssl"
@@ -26,16 +26,9 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 # version_list: url=https://curl.se/download/ filter=*.tar.gz
+version("7.78.0") { source sha256: "ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7" }
 version("7.77.0") { source sha256: "b0a3428acb60fa59044c4d0baae4e4fc09ae9af1d8a3aa84b2e3fbcd99841f77" }
 version("7.76.1") { source sha256: "5f85c4d891ccb14d6c3c701da3010c91c6570c3419391d485d95235253d837d7" }
-version("7.76.0") { source sha256: "3b4378156ba09e224008e81dcce854b7ce4d182b1f9cfb97fe5ed9e9c18c6bd3" }
-version("7.75.0") { source sha256: "4d51346fe621624c3e4b9f86a8fd6f122a143820e17889f59c18f245d2d8e7a6" }
-version("7.74.0") { source sha256: "e56b3921eeb7a2951959c02db0912b5fcd5fdba5aca071da819e1accf338bbd7" }
-version("7.73.0") { source sha256: "ba98332752257b47b9dea6d8c0ad25ec1745c20424f1dd3ff2c99ab59e97cf91" }
-version("7.71.1") { source sha256: "59ef1f73070de67b87032c72ee6037cedae71dcb1d7ef2d7f59487704aec069d" }
-version("7.68.0") { source sha256: "1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358" }
-version("7.65.1") { source sha256: "821aeb78421375f70e55381c9ad2474bf279fc454b791b7e95fc83562951c690" }
-version("7.65.0") { source sha256: "2a65f4f858a1fa949c79f926ddc2204c2be353ccbad014e95cd322d4a87d82ad" }
 
 source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz"
 


### PR DESCRIPTION
This resolves 5 CVEs

Signed-off-by: Tim Smith <tsmith@chef.io>