### PR TITLE
Chef-Server currently uses 5.0.7 version of redis.

### DIFF
--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -28,6 +28,10 @@ version "6.2.5" do
   source sha256: "4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae"
 end
 
+version "5.0.7" do
+  source sha256: "61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b"
+end
+
 version "3.0.7" do
   source md5: "84ed3f486e7a6f0ebada6917370f3532"
 end


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>