### PR TITLE
Turn off ssl weak ciphers

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ build do
     "no-rc5",
     "no-ssl2",
     "no-ssl3",
+    "no-weak-ssl-ciphers",
     "no-zlib",
     "shared",
   ]


### PR DESCRIPTION
I'm honestly not really sure what this does, but it seems like we should turn off weak ciphers.

I developed this while investigating https://github.com/chef/customer-bugs/issues/485 and it builds fine, but it doesn't turn off many/any ciphers as far as I can tell.

This does not close that issue.