### PR TITLE
Update cacerts to 07-05-2021

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,11 +20,13 @@ license "MPL-2.0"
 license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
-default_version "2021-01-19"
+default_version "2021-07-05"
 
-source url: "https://curl.haxx.se/ca/cacert-#{version}.pem"
+source url: "https://curl.se/ca/cacert-#{version}.pem"
 
 # versions_list: https://curl.se/docs/caextract.html
+version("2021-07-05") { source sha256: "a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a" }
+version("2021-05-25") { source sha256: "3a32ad57e7f5556e36ede625b854057ac51f996d59e0952c207040077cbe48a9" }
 version("2021-01-19") { source sha256: "e010c0c071a2c79a76aa3c289dc7e4ac4ed38492bfda06d766a80b707ebd2f29" }
 version("2020-12-08") { source sha256: "313d562594ebd07846ad6b840dd18993f22e0f8b3f275d9aacfae118f4f00fb7" }
 version("2020-10-14") { source sha256: "bb28d145ed1a4ee67253d8ddb11268069c9dafe3db25a9eee654974c4e43eee5" }


### PR DESCRIPTION
Removes:

- QuoVadis Root CA
- Sonera Class 2 Root CA
- GeoTrust Primary Certification Authority - G2
- VeriSign Universal Root Certification Authority
- Chambers of Commerce Root - 2008
- Global Chambersign Root - 2008
- Trustis FPS Root CA
- Staat der Nederlanden Root CA - G3

Adds:

- AC RAIZ FNMT-RCM SERVIDORES SEGUROS
- GlobalSign Root R46
- GlobalSign Root E46
- GLOBALTRUST 2020
- ANF Secure Server Root CA
- Certum EC-384 CA
- Certum Trusted Root CA

Signed-off-by: Tim Smith <tsmith@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
