### PR TITLE
Update cacerts to 9-30

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,18 +20,15 @@ license "MPL-2.0"
 license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 skip_transitive_dependency_licensing true
 
-default_version "2021-07-05"
+default_version "2021-09-30"
 
 source url: "https://curl.se/ca/cacert-#{version}.pem"
 
 # versions_list: https://curl.se/docs/caextract.html
+version("2021-09-30") { source sha256: "f524fc21859b776e18df01a87880efa198112214e13494275dbcbd9bcb71d976" }
 version("2021-07-05") { source sha256: "a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a" }
 version("2021-05-25") { source sha256: "3a32ad57e7f5556e36ede625b854057ac51f996d59e0952c207040077cbe48a9" }
 version("2021-01-19") { source sha256: "e010c0c071a2c79a76aa3c289dc7e4ac4ed38492bfda06d766a80b707ebd2f29" }
-version("2020-12-08") { source sha256: "313d562594ebd07846ad6b840dd18993f22e0f8b3f275d9aacfae118f4f00fb7" }
-version("2020-10-14") { source sha256: "bb28d145ed1a4ee67253d8ddb11268069c9dafe3db25a9eee654974c4e43eee5" }
-version("2020-07-22") { source sha256: "2782f0f8e89c786f40240fc1916677be660fb8d8e25dede50c9f6f7b0c2c2178" }
-version("2020-06-24") { source sha256: "726889705b00f736200ed7999f7a50021b8735d53228d679c4e6665aa3b44987" }
 
 relative_path "cacerts-#{version}"
 


### PR DESCRIPTION
This should fix the issues with lets encrypt certs

Signed-off-by: Tim Smith <tsmith@chef.io>