### PR TITLE
Ensure that curl builds without brotli support 

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -81,6 +81,7 @@ build do
     "--disable-gopher",
     "--disable-dependency-tracking",
     "--enable-ipv6",
+    "--without-brotli",
     "--without-libidn2",
     "--without-gnutls",
     "--without-librtmp",


### PR DESCRIPTION
Ensure that curl builds without brotli support 

We want to make sure curl does not depend on the brotli library since it is not guaranteed to be installed.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>