### PR TITLE
Updating go version from 1.17 to 1.17.2

### DIFF
--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -15,7 +15,7 @@
 #
 
 name "go"
-default_version "1.17"
+default_version "1.17.2"
 license "BSD-3-Clause"
 license_file "https://raw.githubusercontent.com/golang/go/master/LICENSE"
 
@@ -29,6 +29,7 @@ if windows?
   ext = "zip"
 
   # version_list: url=https://golang.org/dl/ filter=*.windows-amd64.zip
+  version("1.17.2")  { source sha256: "fa6da0b829a66f5fab7e4e312fd6aa1b2d8f045c7ecee83b3d00f6fe5306759a" }
   version("1.17")    { source sha256: "2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151" }
   version("1.16.3")  { source sha256: "a4400345135b36cb7942e52bbaf978b66814738b855eeff8de879a09fd99de7f" }
   version("1.15.11") { source sha256: "56f63de17cd739287de6d9f3cfdad3b781ad3e4a18aae20ece994ee97c1819fd" }
@@ -39,6 +40,7 @@ elsif mac_os_x?
   platform = "darwin"
 
   # version_list: url=https://golang.org/dl/ filter=*.darwin-amd64.tar.gz
+  version("1.17.2")  { source sha256: "7914497a302a132a465d33f5ee044ce05568bacdb390ab805cb75a3435a23f94" }
   version("1.17")    { source sha256: "355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1" }
   version("1.16.3")  { source sha256: "6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac" }
   version("1.15.11") { source sha256: "651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671" }
@@ -47,6 +49,7 @@ elsif mac_os_x?
   version("1.13.1")  { source sha256: "f3985fced3adecb62dd1e636cfa5eb9fea8f3e98101d9fcc4964d8f1ec255b7f" }
 else
   # version_list: url=https://golang.org/dl/ filter=*.linux-amd64.tar.gz
+  version("1.17.2")  { source sha256: "f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676" }
   version("1.17")    { source sha256: "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d" }
   version("1.16.3")  { source sha256: "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2" }
   version("1.15.11") { source sha256: "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec" }

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -62,7 +62,10 @@ source url: "https://dl.google.com/go/go#{version}.%{platform}-%{arch}.%{ext}" %
 
 build do
   # We do not use 'sync' since we've found multiple errors with other software definitions
-  copy "#{project_dir}/go", "#{install_dir}/embedded/go"
+  mkdir "#{install_dir}/embedded/go"
+  copy "#{project_dir}/go/*", "#{install_dir}/embedded/go"
+
+  mkdir "#{install_dir}/embedded/bin"
   %w{go gofmt}.each do |bin|
     link "#{install_dir}/embedded/go/bin/#{bin}", "#{install_dir}/embedded/bin/#{bin}"
   end


### PR DESCRIPTION
Updating go version from 1.17 to 1.17.2
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
