### PR TITLE
Fix  git-windows checksum mismatch error

### DIFF
--- a/config/software/git-windows.rb
+++ b/config/software/git-windows.rb
@@ -43,7 +43,7 @@ if windows_arch_i386?
   version("2.27.0") { source sha256: "8cbe1e3b57eb9d02e92cff12089454f2cf090c02958080d62e199ef8764542d3" }
 else
   # version_list: url=https://github.com/git-for-windows/git/releases filter=PortableGit-*-64-bit.7z.exe
-  version("2.33.0") { source sha256: "bc030848e282d49e562ae2392a72501cf539322ad06ffe4cea8cf766f148dfe8" }
+  version("2.33.0") { source sha256: "12c10fad2c2db17d9867dbbacff1adc8be50868b793a73d451c2b878914bb32d" }
   version("2.31.1") { source sha256: "fce2161a8891c4deefdb8d215ab76498c245072f269843ef1a489c4312baef52" }
   version("2.30.2") { source sha256: "f719f248de3dd7ef234331f8da95762594a388f6aa62f4c0260df18068e5a447" }
   version("2.29.2") { source sha256: "7d114e81a541536b025313efcdf6feea1e973323f2b8f53995721bfd511139bd" }


### PR DESCRIPTION
Chef-workstation is failing with below error-

```
Verification for git-windows failed due to a checksum mismatch:
     expected: bc030848e282d49e562ae2392a72501cf539322ad06ffe4cea8cf766f148dfe8
     actual:   12c10fad2c2db17d9867dbbacff1adc8be50868b793a73d451c2b878914bb32d

```

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
https://buildkite.com/chef/chef-chef-workstation-main-omnibus-adhoc/builds/679

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
