### PR TITLE
Pin ohai to 16.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development, :test do
   gem "highline"
   gem "rake"
   gem "chefstyle"
+  gem "ohai", "~> 16.17"    # pin until we support ruby version 2.6
 end


### PR DESCRIPTION
Verify pipeline is failing with below error-
```
Installing ohai 17.7.8
--
  | Gem::RuntimeRequirementNotMetError: ohai requires Ruby version >= 2.7. The
  | current ruby version is 2.6.8.205.
  | An error occurred while installing ohai (17.7.8), and Bundler
  | cannot continue.
  | Make sure that `gem install ohai -v '17.7.8' --source 'https://rubygems.org/'`
  | succeeds before bundling.

```
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
(https://buildkite.com/chef-oss/chef-omnibus-software-main-verify/builds/1259#00893741-7e6d-418c-8205-0cf855e0c7b9)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
