### PR TITLE
Updating logrotate from 3.18.1 to 3.19.0 

### DIFF
--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -15,7 +15,7 @@
 #
 
 name "logrotate"
-default_version "3.18.1"
+default_version "3.19.0"
 
 license "GPL-2.0"
 license_file "COPYING"
@@ -27,6 +27,7 @@ source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
 # versions_list: https://github.com/logrotate/logrotate/tags filter=*.tar.gz
 
+version("3.19.0") { source sha256: "7de1796cb99ce4ed21770b5dae0b4e6f81de0b4df310a58a1617d8061b1e0930" }
 version("3.18.1") { source sha256: "18e9c9b85dd185e79f097f4e7982bc5b8c137300756a7878e8fa24731f2f8e21" }
 version("3.9.2")  { source sha256: "2de00c65e23fa9d7909cae6594e550b9abe9a7eb1553669ddeaca92d30f97009" }
 

--- a/config/software/logrotate.rb
+++ b/config/software/logrotate.rb
@@ -15,7 +15,7 @@
 #
 
 name "logrotate"
-default_version "3.9.2"
+default_version "3.18.1"
 
 license "GPL-2.0"
 license_file "COPYING"
@@ -27,7 +27,8 @@ source url: "https://github.com/logrotate/logrotate/archive/#{version}.tar.gz"
 
 # versions_list: https://github.com/logrotate/logrotate/tags filter=*.tar.gz
 
-version("3.9.2") { source sha256: "2de00c65e23fa9d7909cae6594e550b9abe9a7eb1553669ddeaca92d30f97009" }
+version("3.18.1") { source sha256: "18e9c9b85dd185e79f097f4e7982bc5b8c137300756a7878e8fa24731f2f8e21" }
+version("3.9.2")  { source sha256: "2de00c65e23fa9d7909cae6594e550b9abe9a7eb1553669ddeaca92d30f97009" }
 
 relative_path "logrotate-#{version}"
 
@@ -42,7 +43,12 @@ build do
   env["EXTRA_LDFLAGS"] = env["LDFLAGS"]
   env["EXTRA_CFLAGS"]  = env["CFLAGS"]
 
-  patch source: "logrotate_basedir_override.patch", plevel: 0, env: env
+  if version == "3.9.2"
+    patch source: "logrotate_basedir_override.patch", plevel: 0, env: env
+  else
+    command   "autoreconf -fiv", env: env
+    command   "./configure --prefix=#{install_dir}/embedded", env: env
+  end
 
   make "-j #{workers}", env: env
 


### PR DESCRIPTION
now logorotate 3.19.0 is also available so updating PR to update it from 3.18.1 to 3.19.0

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
