### PR TITLE
Add OpenJDK 11.0.13+8

### DIFF
--- a/config/software/server-open-jre.rb
+++ b/config/software/server-open-jre.rb
@@ -17,7 +17,7 @@ dependency "zlib"
 dependency "patchelf"
 
 name "server-open-jre"
-default_version "11.0.12+7"
+default_version "11.0.13+8"
 
 unless _64_bit?
   raise "Server-open-jre can only be installed on x86_64 systems."
@@ -36,6 +36,13 @@ whitelist_file "jre/bin/appletviewer"
 
 license_warning = "By including the JRE, you accept the terms of AdoptOpenJRE."
 
+version "11.0.13+8" do
+  source url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jre_x64_linux_hotspot_11.0.13_8.tar.gz",
+  sha256: "fb0a27e6e1f26a1ee79daa92e4cfe3ec0d676acfe114d99dd84b3414f056e8a0",
+  warning: license_warning,
+  unsafe: true
+end
+
 version "11.0.12+7" do
   source url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.12_7.tar.gz",
   sha256: "e813e270b7ea0a13f9c400ce5abd4cb811aacbd536b8909e6c7f0e346f78348c",
@@ -53,20 +60,6 @@ end
 version "11.0.10+9" do
   source url: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz",
   sha256: "25fdcf9427095ac27c8bdfc82096ad2e615693a3f6ea06c700fca7ffb271131a",
-  warning: license_warning,
-  unsafe: true
-end
-
-version "11.0.9.1+1" do
-  source url: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jre_x64_linux_hotspot_11.0.9.1_1.tar.gz",
-  sha256: "73ce5ce03d2efb097b561ae894903cdab06b8d58fbc2697a5abe44ccd8ecc2e5",
-  warning: license_warning,
-  unsafe: true
-end
-
-version "11.0.7+1" do
-  source url: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.7_10.tar.gz",
-  sha256: "74b493dd8a884dcbee29682ead51b182d9d3e52b40c3d4cbb3167c2fd0063503",
   warning: license_warning,
   unsafe: true
 end


### PR DESCRIPTION
* Security fixes
  - JDK-8163326, CVE-2021-35550: Update the default enabled cipher suites preference
  - JDK-8254967, CVE-2021-35565: com.sun.net.HttpsServer spins on TLS session close
  - JDK-8263314: Enhance XML Dsig modes
  - JDK-8265167, CVE-2021-35556: Richer Text Editors
  - JDK-8265574: Improve handling of sheets
  - JDK-8265580, CVE-2021-35559: Enhanced style for RTF kit
  - JDK-8265776: Improve Stream handling for SSL
  - JDK-8266097, CVE-2021-35561: Better hashing support
  - JDK-8266103: Better specified spec values
  - JDK-8266109: More Resilient Classloading
  - JDK-8266115: More Manifest Jar Loading
  - JDK-8266137, CVE-2021-35564: Improve Keystore integrity
  - JDK-8266689, CVE-2021-35567: More Constrained Delegation
  - JDK-8267086: ArrayIndexOutOfBoundsException in java.security.KeyFactory.generatePublic
  - JDK-8267712: Better LDAP reference processing
  - JDK-8267729, CVE-2021-35578: Improve TLS client handshaking
  - JDK-8267735, CVE-2021-35586: Better BMP support
  - JDK-8268193: Improve requests of certificates
  - JDK-8268199: Correct certificate requests
  - JDK-8268205: Enhance DTLS client handshake
  - JDK-8268506: More Manifest Digests
  - JDK-8269618, CVE-2021-35603: Better session identification
  - JDK-8269624: Enhance method selection support
  - JDK-8270398: Enhance canonicalization
  - JDK-8270404: Better canonicalization

I also nuked 2 super old releases.

Signed-off-by: Tim Smith <tsmith@chef.io>