### PR TITLE
Remove ancient elasticsearch release

### DIFF
--- a/config/software/elasticsearch.rb
+++ b/config/software/elasticsearch.rb
@@ -15,7 +15,7 @@
 #
 
 name "elasticsearch"
-default_version "5.4.1"
+default_version "5.6.16"
 
 dependency "server-open-jre"
 
@@ -25,10 +25,6 @@ skip_transitive_dependency_licensing true
 
 source url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{version}.tar.gz"
 relative_path "elasticsearch-#{version}"
-
-version "5.4.1" do
-  source sha256: "09d6422bd33b82f065760cd49a31f2fec504f2a5255e497c81050fd3dceec485"
-end
 
 version "5.6.16" do
   source sha256: "6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f"


### PR DESCRIPTION
No need for this. Chef-back now uses 5.6

Signed-off-by: Tim Smith <tsmith@chef.io>