### PR TITLE
Make it easy to reproduce verify pipeline builds locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .bundle
 Gemfile.lock
 pkg/*
+test/pkg/*
 /binstubs
 /bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,3 @@
 FROM chefes/releng-base
 
-ARG SOFTWARE
-ARG VERSION
-
-COPY ./ /omnibus-software
-COPY ./test /test
-
-WORKDIR /test
-
 RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P omnibus-toolchain
-
-RUN . /opt/omnibus-toolchain/bin/load-omnibus-toolchain \
-    && DEBUG=1 bundle config set --local without development \
-    && DEBUG=1 bundle install \
-    && bundle exec omnibus build test

--- a/README.md
+++ b/README.md
@@ -30,13 +30,35 @@ This repository is versioned and tagged using the `YY.MM.BUILD` to allow folks t
 
 For information on contributing to this project please see our [Contributing Documentation](https://github.com/chef/chef/blob/main/CONTRIBUTING.md)
 
-### Testing via Docker
+### Testing On Ubuntu 18.04 via Docker
 
-We provide a sample Dockerfile you can use to ensure that your software definitions are able to compile on Ubuntu 18.04.
+#### Interactive Testing
+
+If you want to enter an interactive shell in a dockerized omnibus build environment on Ubuntu 18.04 you can run the following command.
 
 ```
-bundle exec rake test_build <SOFTWARE> (<VERSION>)
+docker-compose run --rm -e SOFTWARE=<SOFTWARE> -e VERSION=<VERSION> builder
 ```
+
+Now you should be in a shell in the container ready to explore, modify or build.
+
+You can start the build by running the following command in your shell.
+
+```
+bundle exec omnibus build test
+```
+
+The container will automatically be destroyed when you exit it without requiring any further cleanup.
+
+#### Non-Interactive Testing
+
+If you only want to run a build without an interactive shell you can set the `CI` environment variable as you see in the following command.
+
+```
+docker-compose run --rm -e SOFTWARE=<SOFTWARE> -e VERSION=<VERSION> -e CI=true builder
+```
+
+The container will automatically be destroyed when you exit it without requiring any further cleanup.
 
 ## License & Copyright
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,9 +27,9 @@ task :test_build do
 
   raise "\nERROR: You must specify a software name\n\n" if software.nil?
 
-  command = "docker build --build-arg SOFTWARE=#{software}"
-  command += " --build-arg VERSION=#{version}" unless version == "default"
-  command += " --tag localhost:5000/omnibus-#{software}:#{version} ."
+  command = "docker-compose run --rm -e CI=true -e SOFTWARE=#{software}"
+  command += " -e VERSION=#{version}" unless version == "default"
+  command += " builder"
 
   sh command
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  builder:
+    build: .
+    volumes:
+      - ./:/omnibus-software
+      - ./test:/test
+    working_dir: /test
+    command: bash --init-file omnibus-build.sh
+
+    # Multiple concurrent "docker-compose run" commands on the same system in the CI pipeline caused intermittent failures
+    # while creating the network.
+    # Using "network_mode: bridge" forces compose to use docker's legacy default bridge network instead.
+    # We considered namespacing the network using COMPOSE_PROJECT_NAME=$BUILDKITE_JOB_ID but using the legacy bridge network
+    # means we can avoid worrying about any impact and management overhead that multiple networks might create.
+    network_mode: bridge

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -2,3 +2,9 @@ source "https://rubygems.org"
 
 gem "omnibus", github: "chef/omnibus", branch: "main"
 gem "omnibus-software", path: "/omnibus-software"
+
+group :development do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+end

--- a/test/generate_steps.rb
+++ b/test/generate_steps.rb
@@ -41,7 +41,7 @@ files.each do |file|
   $versions.compact.uniq.each do |version|
     puts <<~EOH
       - label: "test-build (#{software} #{version})"
-        command: docker build --build-arg SOFTWARE=#{software} --build-arg VERSION=#{version} .
+        command: docker-compose run --rm -e SOFTWARE=#{software} -e VERSION=#{version} -e CI builder
         timeout_in_minutes: 30
         expeditor:
           executor:

--- a/test/omnibus-build.sh
+++ b/test/omnibus-build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# shellcheck disable=SC1090
+. ~/.bashrc
+
+# shellcheck disable=SC1091
+. /opt/omnibus-toolchain/bin/load-omnibus-toolchain
+
+if [[ $CI == true ]]; then
+  DEBUG=1 bundle config set --local without development
+fi
+
+rm -f Gemfile.lock
+
+DEBUG=1 bundle install
+
+if [[ $CI == true ]]; then
+  bundle exec omnibus build test
+  exit $?
+fi


### PR DESCRIPTION
[IPACK-31]

This makes it easy to reproduce failing builds locally as well as provide a local environment for debugging, training and exploring the omnibus build process.

[IPACK-31]: https://chefio.atlassian.net/browse/IPACK-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ