### PR TITLE
Ignore certain errors in generate_steps.rb

### DIFF
--- a/test/generate_steps.rb
+++ b/test/generate_steps.rb
@@ -36,7 +36,12 @@ files.each do |file|
   software = File.basename(file, ".rb")
   $versions = []
 
-  load file
+  begin
+    load file
+  rescue => e
+    # Ignore errors from methods such as `_64_bit?` and `armhf?` returning `nil` to conditional logic
+    raise unless e.message.match?(/ can only be installed on /)
+  end
 
   $versions.compact.uniq.each do |version|
     puts <<~EOH


### PR DESCRIPTION
Ignore certain errors from methods such as `_64_bit?` and `armhf?` returning `nil` to conditional logic.

Fixes [IPACK-45]

[IPACK-45]: https://chefio.atlassian.net/browse/IPACK-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ