### PR TITLE
IPACK-46 Fix some pipeline and docker container issues

### DIFF
--- a/test/generate_steps.rb
+++ b/test/generate_steps.rb
@@ -25,7 +25,7 @@ end
 # Get a list of all the config/software definitions that have been added or modified
 _, status = Open3.capture2e("git fetch origin #{BRANCH}")
 exit 1 if status != 0
-stdout, status = Open3.capture2("git diff --name-status HEAD origin/#{BRANCH} config/software | awk 'match($1, \"A\"){print $2; next} match($1, \"M\"){print $2}'")
+stdout, status = Open3.capture2("git diff --name-status origin/#{BRANCH}...HEAD config/software | awk 'match($1, \"A\"){print $2; next} match($1, \"M\"){print $2}'")
 exit 1 if status != 0
 
 files = stdout.lines.compact.uniq.map(&:chomp)

--- a/test/omnibus-build.sh
+++ b/test/omnibus-build.sh
@@ -6,11 +6,12 @@
 # shellcheck disable=SC1091
 . /opt/omnibus-toolchain/bin/load-omnibus-toolchain
 
+rm -f Gemfile.lock
+rm -rf .bundle
+
 if [[ $CI == true ]]; then
   DEBUG=1 bundle config set --local without development
 fi
-
-rm -f Gemfile.lock
 
 DEBUG=1 bundle install
 


### PR DESCRIPTION
Ensure .bundle directory is deleted when docker container is created. This ensures potentially leftover configuration from prior usage doesn't impact subsequent usage of the container.

Fix the `git diff` in generate_steps.rb script. This ensures that only files modified in the development branch are listed.

Fixes [IPACK-46]

[IPACK-46]: https://chefio.atlassian.net/browse/IPACK-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ