### PR TITLE
Use smaller docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 .bundle
 Gemfile.lock
+vendor
 pkg/*
 test/pkg/*
 /binstubs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
-FROM chefes/releng-base
+FROM ubuntu:18.04
+
+RUN apt-get update -y -q && apt-get install -y \
+      autoconf \
+      binutils \
+      binutils-doc \
+      bison \
+      build-essential \
+      curl \
+      devscripts \
+      dpkg-dev \
+      fakeroot \
+      flex \
+      gettext \
+      gnupg \
+      ncurses-dev \
+      ncurses-dev \
+      wget \
+      zlib1g-dev
 
 RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P omnibus-toolchain

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This repository is versioned and tagged using the `YY.MM.BUILD` to allow folks t
 
 For information on contributing to this project please see our [Contributing Documentation](https://github.com/chef/chef/blob/main/CONTRIBUTING.md)
 
+### Run Linux Tests in Docker
+
+Run `.expeditor/run_linux_tests.sh rake` in the ruby image of your choice.
+
+```
+docker run -it --rm -v $PWD:/src -w /src ruby:2.7-buster .expeditor/run_linux_tests.sh rake
+```
+
 ### Testing On Ubuntu 18.04 via Docker
 
 #### Interactive Testing


### PR DESCRIPTION
Use smaller docker image

chefes/releng-base docker image is more than 8GB uncompressed.
There is far more in that image than we need for testing omnibus-software. This wastes time downloading the image and disk space. We can use Ubuntu:18.04 instead which is about 56MB uncompressed.