### PR TITLE
Revert "Use smaller docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,3 @@
-FROM ubuntu:18.04
-
-RUN apt-get update -y -q && apt-get install -y \
-      autoconf \
-      binutils \
-      binutils-doc \
-      bison \
-      build-essential \
-      curl \
-      devscripts \
-      dpkg-dev \
-      fakeroot \
-      flex \
-      gettext \
-      gnupg \
-      ncurses-dev \
-      ncurses-dev \
-      wget \
-      zlib1g-dev
+FROM chefes/releng-base
 
 RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P omnibus-toolchain


### PR DESCRIPTION
This reverts commit ea9ff306ec154e6372454ae69048e75ad361397b.

We deployed new AMIs to the buildkite queues that run the verify
pipeline and unfortunately they have an issue that is preventing us from
using the ubuntu:18.04 docker image.
We have a fix ready but we need some time
to resolve some deployment issues so in the meantime we are going to use
chefes/releng-base again.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>