### PR TITLE
Update gcc version from 4.9.2 to 4.9.4

### DIFF
--- a/config/software/gcc.rb
+++ b/config/software/gcc.rb
@@ -16,7 +16,7 @@
 
 # do_not_auto_update
 name "gcc"
-default_version "4.9.2"
+default_version "4.9.4"
 
 dependency "gmp"
 dependency "mpfr"
@@ -24,6 +24,7 @@ dependency "mpc"
 dependency "libiconv"
 
 # version_list: url=https://ftp.gnu.org/gnu/gcc/ filter=*.tar.gz
+version("4.9.4") { source sha256: "1680f92781b92cbdb57d7e4f647c650678c594154cb0d707fd9a994424a9860d" }
 version("4.9.2") { source sha256: "3e573826ec8b0d62d47821408fbc58721cd020df3e594cd492508de487a43b5e" }
 version("4.9.3") { source sha256: "e6c63b40877bc756cc7cfe6ca98013eb15f02ec6c8c2cf68e24533ad1203aaba" }
 version("4.9.4") { source sha256: "1680f92781b92cbdb57d7e4f647c650678c594154cb0d707fd9a994424a9860d" }


### PR DESCRIPTION
Signed-off-by: poornima <poorndm@progress.com>
gcc 4.9.4 includes a large number of regression fixes, particularly for those running O3 like we do in many places. update from 4.9.2 to 4.9.4 to get these fixes.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
