### PR TITLE
Update config.guess when building xproto

### DIFF
--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -17,6 +17,8 @@
 name "xproto"
 default_version "7.0.31"
 
+dependency "config_guess"
+
 # version_list: url=https://www.x.org/releases/individual/proto/ filter=xproto-*.tar.gz
 
 version("7.0.31") { source sha256: "6d755eaae27b45c5cc75529a12855fed5de5969b367ed05003944cf901ed43c7" }
@@ -34,6 +36,8 @@ relative_path "xproto-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
+  update_config_guess
 
   command "./configure" \
           " --prefix=#{install_dir}/embedded", env: env


### PR DESCRIPTION
This will fix build failures on non-x86 architectures (such as ppc64le). This should likely fix the issue mentioned in https://github.com/chef/omnibus-toolchain/pull/204.

I ran into this trying to build omnibus-toolchain with Ubuntu on ppc64le.

Signed-off-by: Lance Albertson <lance@osuosl.org>
