### PR TITLE
Update openssl build config

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -98,8 +98,8 @@ build do
   if mac_os_x? && arm?
     configure_options << "LT_SYS_LIBRARY_PATH=#{install_dir}/embedded/lib"
     configure_options << "CMAKE_FIND_DEBUG_MODE=TRUE"
-    env["CPPFLAGS"] << " --nostdinc++"
-    env["CFLAGS"] << " --nostdinc"
+    env["CPPFLAGS"] << " -nostdinc++"
+    env["CFLAGS"] << " -nostdinc"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -62,6 +62,10 @@ build do
   elsif solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
+
+  elsif mac_os_x? && arm?
+    env["CMAKE_FIND_ROOT_PATH_MODE_INCLUDE"] = "ONLY"
+    env["CMAKE_FIND_ROOT_PATH"] = "#{install_dir}/embedded"
   end
 
   configure_options = [

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -94,9 +94,9 @@ build do
   ]
 
   if mac_os_x? && arm?
-    configure_options << "CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
-    configure_options << "CMAKE_FIND_ROOT_PATH=#{install_dir}/embedded"
-    configure_options << "CMAKE_IGNORE_PREFIX_PATH=/usr/local"
+    configure_options << "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE:STRING=ONLY"
+    configure_options << "-DCMAKE_FIND_ROOT_PATH:STRING=#{install_dir}/embedded"
+    configure_options << "-DCMAKE_IGNORE_PREFIX_PATH:STRING=/usr/local"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -62,6 +62,8 @@ build do
   elsif solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
+  elsif mac_os_x? && arm?
+    env["OPENSSL_VERSION_MAJOR"] = "1"
   end
 
   configure_options = [

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -97,9 +97,7 @@ build do
 
   if mac_os_x? && arm?
     configure_options << "LT_SYS_LIBRARY_PATH=#{install_dir}/embedded/lib"
-    configure_options << "CMAKE_FIND_DEBUG_MODE=TRUE"
     env["CPPFLAGS"] << " -nostdinc++"
-    env["CFLAGS"] << " -nostdinc"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -96,8 +96,8 @@ build do
   ]
 
   if mac_os_x? && arm?
-    configure_options << "PKG_CONFIG_PATH=#{install_dir}/embedded"
     configure_options << "LT_SYS_LIBRARY_PATH=#{install_dir}/embedded/lib"
+    configure_options << "CMAKE_FIND_DEBUG_MODE=TRUE"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -64,8 +64,9 @@ build do
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
 
   elsif mac_os_x? && arm?
-    env["CMAKE_FIND_ROOT_PATH_MODE_INCLUDE"] = "ONLY"
-    env["CMAKE_FIND_ROOT_PATH"] = "#{install_dir}/embedded"
+    #env["CMAKE_FIND_ROOT_PATH_MODE_INCLUDE"] = "ONLY"
+    #env["CMAKE_FIND_ROOT_PATH"] = "#{install_dir}/embedded"
+    env["CMAKE_IGNORE_PREFIX_PATH"] = "/usr/local"
   end
 
   configure_options = [

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -87,7 +87,7 @@ build do
     "--without-zsh-functions-dir",
     "--without-fish-functions-dir",
     "--disable-mqtt",
-    "--with-ssl=#{install_dir}/embedded",
+    "--with-openssl=#{install_dir}/embedded",
     "--with-zlib=#{install_dir}/embedded",
     "--with-ca-bundle=#{install_dir}/embedded/ssl/certs/cacert.pem",
     "--without-zstd",

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -62,11 +62,6 @@ build do
   elsif solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
-
-  elsif mac_os_x? && arm?
-    #env["CMAKE_FIND_ROOT_PATH_MODE_INCLUDE"] = "ONLY"
-    #env["CMAKE_FIND_ROOT_PATH"] = "#{install_dir}/embedded"
-    env["CMAKE_IGNORE_PREFIX_PATH"] = "/usr/local"
   end
 
   configure_options = [
@@ -97,6 +92,12 @@ build do
     "--with-ca-bundle=#{install_dir}/embedded/ssl/certs/cacert.pem",
     "--without-zstd",
   ]
+
+  if mac_os_x? && arm?
+    configure_options << "CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
+    configure_options << "CMAKE_FIND_ROOT_PATH=#{install_dir}/embedded"
+    configure_options << "CMAKE_IGNORE_PREFIX_PATH=/usr/local"
+  end
 
   configure(*configure_options, env: env)
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -94,9 +94,8 @@ build do
   ]
 
   if mac_os_x? && arm?
-    configure_options << "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE:STRING=ONLY"
-    configure_options << "-DCMAKE_FIND_ROOT_PATH:STRING=#{install_dir}/embedded"
-    configure_options << "-DCMAKE_IGNORE_PREFIX_PATH:STRING=/usr/local"
+    configure_options << "PKG_CONFIG_PATH=#{install_dir}/embedded"
+    configure_options << "LT_SYS_LIBRARY_PATH=#{install_dir}/embedded/lib"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -98,6 +98,8 @@ build do
   if mac_os_x? && arm?
     configure_options << "LT_SYS_LIBRARY_PATH=#{install_dir}/embedded/lib"
     configure_options << "CMAKE_FIND_DEBUG_MODE=TRUE"
+    env["CPPFLAGS"] << " --nostdinc++"
+    env["CFLAGS"] << " --nostdinc"
   end
 
   configure(*configure_options, env: env)

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -96,7 +96,7 @@ build do
     if aix?
       "perl ./Configure aix64-cc"
     elsif mac_os_x?
-      intel? ? "./Configure darwin64-x86_64-cc" : "./Configure darwin64-arm64-cc no-asm"
+      intel? ? "./Configure darwin64-x86_64-cc" : "./Configure shared enable-rc5 zlib darwin64-arm64-cc"
     elsif smartos?
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif omnios?


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Updated openssl build configuration parameters as described in https://github.com/openssl/openssl/issues/12254

## Related Issue
when attempting to run `git clone` from Chef Workstation on MacOS ARM64, a dyld error shows up. 

```
dyld: lazy symbol binding failed: Symbol not found: _SSL_CTX_load_verify_file
  Referenced from: /opt/chef-workstation/embedded/lib/libcurl.4.dylib
  Expected in: flat namespace
 
dyld: Symbol not found: _SSL_CTX_load_verify_file
  Referenced from: /opt/chef-workstation/embedded/lib/libcurl.4.dylib
  Expected in: flat namespace
 
error: git-remote-https died of signal 6
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
