### PR TITLE
Use smaller docker image again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
-FROM chefes/releng-base
+FROM ubuntu:18.04
+
+RUN apt-get update -y -q && apt-get install -y \
+      autoconf \
+      binutils \
+      binutils-doc \
+      bison \
+      build-essential \
+      curl \
+      devscripts \
+      dpkg-dev \
+      fakeroot \
+      flex \
+      gettext \
+      gnupg \
+      ncurses-dev \
+      ncurses-dev \
+      wget \
+      zlib1g-dev
 
 RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -P omnibus-toolchain


### PR DESCRIPTION
We resolved the issue that forced us to revert to using the larger image so now we can start using the smaller image again.