### PR TITLE
Upgrade Erlang to 24.3.2

### DIFF
--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -64,7 +64,6 @@ build do
 
   update_config_guess(target: "erts/autoconf")
   update_config_guess(target: "lib/common_test/priv/auxdir")
-  update_config_guess(target: "lib/erl_interface/src/auxdir")
   update_config_guess(target: "lib/wx/autoconf")
 
   if version.satisfies?(">= 19.0")

--- a/config/software/erlang.rb
+++ b/config/software/erlang.rb
@@ -15,7 +15,7 @@
 #
 
 name "erlang"
-default_version "25.0"
+default_version "24.3.2"
 
 license "Apache-2.0"
 license_file "LICENSE.txt"
@@ -35,6 +35,7 @@ relative_path "otp-OTP-#{version}"
 version("25.0")      { source sha256: "5988e3bca208486494446e885ca2149fe487ee115cbc3770535fd22a795af5d2" }
 version("24.3.4")    { source sha256: "e59bedbb871af52244ca5284fd0a572d52128abd4decf4347fe2aef047b65c58" }
 version("24.3.3")    { source sha256: "a5f4d83426fd3dc2f08c0c823ae29bcf72b69008a2baee66d27ad614ec7ab607" }
+version("24.3.2")    { source sha256: "cdc9cf788d28a492eb6b24881fbd06a0a5c785dc374ad415b3be1db96326583c" }
 version("24.2")      { source sha256: "0b9c9ba7d8b40f6c77d529e07561b10f0914d2bfe9023294d7eda85b62936792" }
 version("24.1.7")    { source sha256: "a1dd1a238f1f3e79784b902f3cd00e06f35a630191eaf73324a07a26a2c93af3" }
 version("24.1.3")    { source sha256: "7ccfa8372995fc7895baeb3729f679aff87781d1b7c734acd22740bc41ee2eed" }


### PR DESCRIPTION
- Adds new Erlang versions.
- Fixes compilation errors encountered during build.

Adhocs:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/4511
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/4549

Umbrella:
https://buildkite.com/chef/chef-umbrella-main-chef-server-full/builds/173