### PR TITLE
IPACK-80 update libxslt to 1.1.35

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -16,6 +16,7 @@
 
 name "libxml2"
 default_version "2.9.13"
+
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
@@ -24,18 +25,13 @@ dependency "zlib"
 dependency "liblzma"
 dependency "config_guess"
 
-# version_list: url=https://download.gnome.org/sources/libxml2 filter=libxml2-*.tar.+z
-
+# version_list: url=https://download.gnome.org/sources/libxml2/2.9/ filter=*.tar.xz
 version("2.9.13") { source sha256: "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e" }
-version("2.9.12") { source sha256: "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92" }
-version("2.9.10") { source sha256: "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f" }
-version("2.9.9")  { source sha256: "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871" }
+version("2.9.12") { source sha256: "28a92f6ab1f311acf5e478564c49088ef0ac77090d9c719bbc5d518f1fe62eb9" }
+version("2.9.10") { source sha256: "593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813" }
+version("2.9.9")  { source sha256: "58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5" }
 
-if version.satisfies?("= 2.9.13")
-  source url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz"
-else
-  source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
-end
+source url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-#{version}.tar.xz"
 
 relative_path "libxml2-#{version}"
 

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxslt"
-default_version "1.1.34"
+default_version "1.1.35"
 
 license "MIT"
 license_file "COPYING"
@@ -25,11 +25,12 @@ dependency "libxml2"
 dependency "liblzma"
 dependency "config_guess"
 
-# versions_list: ftp://xmlsoft.org/libxml2/ filter=*.tar.gz
-version("1.1.34") { source sha256: "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f" }
-version("1.1.30") { source sha256: "ba65236116de8326d83378b2bd929879fa185195bc530b9d1aba72107910b6b3" }
+# versions_list: url=https://download.gnome.org/sources/libxslt/1.1/ filter=*.tar.xz
+version("1.1.35") { source sha256: "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79" }
+version("1.1.34") { source sha256: "28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824" }
+version("1.1.30") { source sha256: "db1e4e26eaec47d00f885bad19a8749eb1008909b817d650101365f068ee3b24" }
 
-source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+source url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-#{version}.tar.xz"
 
 relative_path "libxslt-#{version}"
 


### PR DESCRIPTION
Update libxslt to 1.1.35.

Also, use tarballs from https source url for libxslt and libxml2.

libxslt 1.1.35 fixes an xml2-config check issue in configure script that was preventing libxslt from finding libxml2.

libxslt 1.1.35 does not build successfully with libxml2 2.9.13 on Windows. We will pin windows builds to libxslt 1.1.34 and libxml2 2.9.10 for now and followup later with the work to fix that issue in [IPACK-145](https://chefio.atlassian.net/browse/IPACK-145).