### PR TITLE
Remove with-bundled-md5 flag introduced in PR 534

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -207,7 +207,6 @@ build do
                        "--without-tk",
                        "--disable-dtrace",
                        "--disable-jit-support"]
-  configure_command << "--with-bundled-md5" if fips_mode?
 
   # resolve C99 code accidentally introduced in Ruby 2.6.7 and it's still in 2.6.8 :(
   patch source: "ruby-2.6.7_c99.patch", plevel: 1, env: patch_env if version.satisfies?("~> 2.6.7", "< 2.6.10")


### PR DESCRIPTION
## Description

As this flag was removed in Ruby 2.3.0 at https://github.com/ruby/ruby/commit/b632ca436c5d06defc87df8b2a4774680e9cf6ef, adding this option does not change the build results.

This flag is only valid for Ruby 1.8.0 through Ruby 2.2.x (2.2.10).

Reverts #534

## Related Issue
n/a

## Types of changes
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
