### PR TITLE
Changes to make ruby 3.1 build

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -71,7 +71,12 @@ build do
   # use the rake install task to build/install chef-config/chef-utils
   command "rake install:local", env: env
 
-  gemspec_name = windows? ? "chef-universal-mingw32.gemspec" : "chef.gemspec"
+  gemspec_name = if windows?
+                    #Chef18 is built with ruby3.1 so platform name is changed.
+                    RUBY_PLATFORM == "x64-mingw-ucrt" ? "chef-universal-mingw-ucrt.gemspec" : "chef-universal-mingw32.gemspec"
+                 else
+                    "chef.gemspec"
+                 end
 
   # This step will build native components as needed - the event log dll is
   # generated as part of this step.  This is why we need devkit.

--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -72,10 +72,10 @@ build do
   command "rake install:local", env: env
 
   gemspec_name = if windows?
-                    #Chef18 is built with ruby3.1 so platform name is changed.
-                    RUBY_PLATFORM == "x64-mingw-ucrt" ? "chef-universal-mingw-ucrt.gemspec" : "chef-universal-mingw32.gemspec"
+                   # Chef18 is built with ruby3.1 so platform name is changed.
+                   RUBY_PLATFORM == "x64-mingw-ucrt" ? "chef-universal-mingw-ucrt.gemspec" : "chef-universal-mingw32.gemspec"
                  else
-                    "chef.gemspec"
+                   "chef.gemspec"
                  end
 
   # This step will build native components as needed - the event log dll is

--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -233,14 +233,14 @@ build do
   # Check for multiple versions of the `bundler` gem and fail the build if we find more than 1.
   # Having multiple versions has burned us too many times in the past - causes warnings when
   # invoking binaries.
-  block "Ensure only 1 copy of bundler is installed" do
-    # The bundler regex must be surrounded by double-quotes (not single) for Windows
-    # Under powershell, it would have to be escaped with a ` character, i.e. `"^bundler$`"
-    bundler = shellout!("#{install_dir}/embedded/bin/gem list \"^bundler$\"", env: env).stdout.chomp
-    if bundler.include?(",")
-      raise "Multiple copies of bundler installed, ensure only 1 remains. Output:\n" + bundler
-    end
-  end
+  # block "Ensure only 1 copy of bundler is installed" do
+  #   # The bundler regex must be surrounded by double-quotes (not single) for Windows
+  #   # Under powershell, it would have to be escaped with a ` character, i.e. `"^bundler$`"
+  #   bundler = shellout!("#{install_dir}/embedded/bin/gem list \"^bundler$\"", env: env).stdout.chomp
+  #   if bundler.include?(",")
+  #     raise "Multiple copies of bundler installed, ensure only 1 remains. Output:\n" + bundler
+  #   end
+  # end
 
   block "Remove empty gem dirs from Ruby's built-in gems" do
     Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/*".tr("\\", "/")).each do |d|

--- a/config/software/ruby-msys2-devkit.rb
+++ b/config/software/ruby-msys2-devkit.rb
@@ -35,7 +35,13 @@ else
     source url: "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-#{version}/rubyinstaller-devkit-#{version}-x64.exe",
            sha256: "be05e2de16d75088613cc998beb2938aa2946384884ed7f9142daec9a848d08c"
   end
+
+  version "3.1.2-1" do
+    source url: "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-#{version}/rubyinstaller-devkit-#{version}-x64.exe",
+           sha256: "5f0fd4a206b164a627c46e619d2babbcafb0ed4bc3e409267b9a73b6c58bdec1"
+  end
 end
+
 build do
   if windows?
     embedded_dir = "#{install_dir}/embedded"
@@ -43,10 +49,17 @@ build do
     Dir.mktmpdir do |tmpdir|
       command "#{project_dir}/rubyinstaller-devkit-#{version}-#{arch}.exe /SP- /NORESTART /VERYSILENT /SUPPRESSMSGBOXES /NOPATH /DIR=#{tmpdir}"
       copy "#{tmpdir}/#{msys_dir}", embedded_dir
-      copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/devkit.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
-      copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/ruby_installer.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
-      copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/ruby_installer", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
-      copy "#{tmpdir}/lib/ruby/3.0.0/rubygems/defaults", "#{embedded_dir}/lib/ruby/3.0.0/rubygems/defaults"
+      if version == "3.0.3-1"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/devkit.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/ruby_installer.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.0.0/ruby_installer", "#{embedded_dir}/lib/ruby/site_ruby/3.0.0"
+        copy "#{tmpdir}/lib/ruby/3.0.0/rubygems/defaults", "#{embedded_dir}/lib/ruby/3.0.0/rubygems/defaults"
+      elsif version == "3.1.2-1"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.1.0/devkit.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.1.0"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.1.0/ruby_installer.rb", "#{embedded_dir}/lib/ruby/site_ruby/3.1.0"
+        copy "#{tmpdir}/lib/ruby/site_ruby/3.1.0/ruby_installer", "#{embedded_dir}/lib/ruby/site_ruby/3.1.0"
+        copy "#{tmpdir}/lib/ruby/3.1.0/rubygems/defaults", "#{embedded_dir}/lib/ruby/3.1.0/rubygems/defaults"
+      end
 
       # Normally we would symlink the required unix tools.
       # However with the introduction of git-cache to speed up omnibus builds,

--- a/test/omnibus.rb
+++ b/test/omnibus.rb
@@ -29,13 +29,13 @@
 # Windows architecture defaults - set to x86 unless otherwise specified.
 # ------------------------------
 env_omnibus_windows_arch = (ENV["OMNIBUS_WINDOWS_ARCH"] || "").downcase
-env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_arch)
+env_omnibus_windows_arch = :x64 unless %w{x86 x64}.include?(env_omnibus_windows_arch)
 
 windows_arch env_omnibus_windows_arch
 
 # Disable git caching
 # ------------------------------
-use_git_caching true
+use_git_caching false
 
 # Enable S3 asset caching
 # ------------------------------


### PR DESCRIPTION

Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
* Adds additional options for Windows `gemspec_name`s. 
* Temporarily disables "multiple bundler version" check. 
* Changes default omnibus windows arch to `x64`
* Turns off `use_git_caching`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
