### PR TITLE
Sync gem version with tags

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,3 +24,10 @@ subscriptions:
       - bash:.expeditor/push_git_tag.sh:
           only_if: bash:.expeditor/determine_version.sh
           post_commit: true
+      - built_in:build_gem:
+          only_if: "bash:.expeditor/push_git_tag.sh"
+
+  - workload: project_promoted:{{agent_id}}:*
+    actions:
+      - built_in:rollover_changelog
+      - built_in:publish_rubygems

--- a/lib/omnibus-software/version.rb
+++ b/lib/omnibus-software/version.rb
@@ -1,3 +1,3 @@
 module OmnibusSoftware
-  VERSION = "4.0.0".freeze
+  VERSION = File.read(File.join(__dir__, "../../VERSION")).strip.freeze
 end


### PR DESCRIPTION
## Description
omnibus-software is technically a gem but it most often gets installed via the `git:` functionality of bundler. This PR aligns the git tag with the gem version so that we can install the gem from an internal artifactory rubygems proxy at a specified version.

## Related Issue

BS-51 (JIRA)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
