### PR TITLE
Determine Chef version using build_version in software to decide gemspec

### DIFF
--- a/config/software/chef.rb
+++ b/config/software/chef.rb
@@ -71,9 +71,10 @@ build do
   # use the rake install task to build/install chef-config/chef-utils
   command "rake install:local", env: env
 
+  # NOTE: Chef18 is packaged and built with ruby31 whereas previous versions of Chef are ONLY built
+  # with ruby31,the packaged versions differ. So we use Chef's own version to determine the windows gemspec.
   gemspec_name = if windows?
-                   # Chef18 is built with ruby3.1 so platform name is changed.
-                   RUBY_PLATFORM == "x64-mingw-ucrt" ? "chef-universal-mingw-ucrt.gemspec" : "chef-universal-mingw32.gemspec"
+                   project.build_version.partition(".")[0].to_i < 18 ? "chef-universal-mingw32.gemspec" : "chef-universal-mingw-ucrt.gemspec"
                  else
                    "chef.gemspec"
                  end


### PR DESCRIPTION
## Description
The omnibus build environment in adhoc/release pipelines is using ruby31 for all versions of Chef. 
That happens from [omnibus-toolchain](https://github.com/chef/omnibus-toolchain/blob/main/config/projects/omnibus-toolchain.rb#L57), irrespective of Chef version.
To determine when to use ucrt gemspec for chef, condition `RUBY_PLATFORM==x64-mingw-ucrt` can no longer be used since that would hold true for chef16/17 as well. So we make use of build_version to decide which version of chef is getting built and pick the gemspec accordingly when running builds for windows.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/pull/13304

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
