### PR TITLE
Use disable-dynamicbase and fixed DLL locations

### DIFF
--- a/config/patches/openssl/openssl-1.0.1j-windows-relocate-dll.patch
+++ b/config/patches/openssl/openssl-1.0.1j-windows-relocate-dll.patch
@@ -1,20 +1,44 @@
 diff --git a/Makefile.shared b/Makefile.shared
-index e8d222a..02ec85b 100644
+index e8d222a..f723803 100644
 --- a/Makefile.shared
 +++ b/Makefile.shared
-@@ -283,13 +283,12 @@ link_a.cygwin:
+@@ -267,6 +267,12 @@ link_o.cygwin:
+ 			deffile=$(LIBNAME)eay32.def; \
+ 		fi; \
+ 	fi; \
++	if expr $(PLATFORM) : 'mingw64' > /dev/null; then \
++		SHLIB=$(LIBNAME)eay32; base=; \
++		if test -f $(LIBNAME)eay32.def; then \
++			deffile=$(LIBNAME)eay32.def; \
++		fi; \
++	fi; \
+ 	SHLIB_SUFFIX=.dll; \
+ 	LIBVERSION="$(LIBVERSION)"; \
+ 	SHLIB_SOVER=${LIBVERSION:+"-$(LIBVERSION)"}; \
+@@ -283,13 +289,23 @@ link_a.cygwin:
  	base=-Wl,--enable-auto-image-base; \
  	if expr $(PLATFORM) : 'mingw' > /dev/null; then \
  		case $(LIBNAME) in \
 -			crypto) SHLIB=libeay;; \
 -			ssl) SHLIB=ssleay;; \
-+			crypto) SHLIB=libeay; base=-Wl,--image-base,0x64000000;; \
-+			ssl) SHLIB=ssleay; base=-Wl,--image-base,0x65000000;; \
++			crypto) SHLIB=libeay; base=-Wl,--disable-dynamicbase,--image-base,0x64000000;; \
++			ssl) SHLIB=ssleay; base=-Wl,--disable-dynamicbase,--image-base,0x65000000;; \
++		esac; \
++		SHLIB_SOVER=32; \
++		extras="$(LIBNAME).def"; \
++		$(PERL) util/mkdef.pl 32 $$SHLIB > $$extras; \
++		base=; [ $(LIBNAME) = "crypto" -a -n "$(FIPSCANLIB)" ] && base=-Wl,--disable-dynamicbase,--image-base,0x63000000; \
++	fi; \
++	if expr $(PLATFORM) : 'mingw64' > /dev/null; then \
++		case $(LIBNAME) in \
++			crypto) SHLIB=libeay; base=-Wl,--disable-dynamicbase,--image-base,0x64000000;; \
++			ssl) SHLIB=ssleay; base=-Wl,--disable-dynamicbase,--image-base,0x65000000;; \
  		esac; \
  		SHLIB_SOVER=32; \
  		extras="$(LIBNAME).def"; \
  		$(PERL) util/mkdef.pl 32 $$SHLIB > $$extras; \
 -		base=; [ $(LIBNAME) = "crypto" -a -n "$(FIPSCANLIB)" ] && base=-Wl,--image-base,0x63000000; \
++		base=; [ $(LIBNAME) = "crypto" -a -n "$(FIPSCANLIB)" ] && base=-Wl,--disable-dynamicbase,--image-base,0x63000000; \
  	fi; \
  	dll_name=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX; \
  	$(PERL) util/mkrc.pl $$dll_name | \


### PR DESCRIPTION
## Description
Issue with Chef Infra Client 18.0.155 and FIPS mode on Windows Server 2016.

Enable OS setting for FIPS mode to be enabled.

Chef 18 errors out with:

```
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-config-18.0.155/lib/chef-config/config.rb:1292:in `fips_mode=': Turning on FIPS mode failed: fingerprint does not match (OpenSSL::OpenSSLError)
```

FIPS Mode enabling in the registry:

`HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy\Enabled and set Enabled to 1`

## Related Issue
INFC-289

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
