### PR TITLE
Fix openssl build under FreeBSD 13.x

### DIFF
--- a/config/patches/openssl-1.0.2zb-freebsd.patch
+++ b/config/patches/openssl-1.0.2zb-freebsd.patch
@@ -1,0 +1,11 @@
+--- openssl-1.0.2zb/crypto/engine/eng_cryptodev.c.orig	2023-01-26 20:50:48.586582000 +0000
++++ openssl-1.0.2zb/crypto/engine/eng_cryptodev.c	2023-01-26 20:51:26.564438000 +0000
+@@ -35,7 +35,7 @@
+ #if (defined(__unix__) || defined(unix)) && !defined(USG) && \
+         (defined(OpenBSD) || defined(__FreeBSD__))
+ # include <sys/param.h>
+-# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041)
++# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || (__FreeBSD_version >= 500041 && __FreeBSD_version < 1300000))
+ #  define HAVE_CRYPTODEV
+ # endif
+ # if (OpenBSD >= 200110)

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -66,6 +66,8 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
+elsif freebsd?
+    patch source: "openssl-1.0.2zb-freebsd.patch"
   elsif mac_os_x? && arm?
     env["CFLAGS"] << " -Qunused-arguments"
   elsif windows?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fix build of openssl under FreeBSD >=13.0
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes the build under FreeBSD 13.1
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
