### PR TITLE
update mingw to fix build issue on windows

### DIFF
--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -29,7 +29,9 @@ dependency "openssl"
 source url: "https://www.stunnel.org/archive/5.x/stunnel-#{version}.tar.gz"
 
 relative_path "stunnel-#{version}"
+
 version("5.67") { source sha256: "3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456" }
+version("5.66") { source sha256: "558178704d1aa5f6883aac6cc5d6bbf2a5714c8a0d2e91da0392468cee9f579c" }
 version("5.65") { source sha256: "60c500063bd1feff2877f5726e38278c086f96c178f03f09d264a2012d6bf7fc" }
 version("5.64") { source sha256: "eebe53ed116ba43b2e786762b0c2b91511e7b74857ad4765824e7199e6faf883" }
 version("5.63") { source sha256: "c74c4e15144a3ae34b8b890bb31c909207301490bd1e51bfaaa5ffeb0a994617" }
@@ -56,7 +58,8 @@ build do
     env["WIN32_SSL_DIR_PATCHED"] = "#{install_dir}/embedded"
 
     mingw = ENV["MSYSTEM"].downcase
-    target = (mingw == "mingw32" ? "mingw" : mingw)
+    target = (mingw == "mingw32" ? "mingw" : "mingw64")
+  
     # Starting omnibus-toolchain version 1.1.115 we do not build msys2 as a part of omnibus-toolchain anymore, but pre install it in image
     # so here we set the path to default install of msys2 first and default to OMNIBUS_TOOLCHAIN_INSTALL_DIR for backward compatibility
     msys_path = ENV["MSYS2_INSTALL_DIR"] ? "#{ENV["MSYS2_INSTALL_DIR"]}" : "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin"

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -59,7 +59,6 @@ build do
 
     mingw = ENV["MSYSTEM"].downcase
     target = (mingw == "mingw32" ? "mingw" : "mingw64")
-  
     # Starting omnibus-toolchain version 1.1.115 we do not build msys2 as a part of omnibus-toolchain anymore, but pre install it in image
     # so here we set the path to default install of msys2 first and default to OMNIBUS_TOOLCHAIN_INSTALL_DIR for backward compatibility
     msys_path = ENV["MSYS2_INSTALL_DIR"] ? "#{ENV["MSYS2_INSTALL_DIR"]}" : "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin"


### PR DESCRIPTION
Signed-off-by: poorndm <poorndm@progress.com>
This PR is to fix the build issue on windows. 
The stunnel build is failing for workstation  -   with changes - Ruby 3.1  update and  windows-64-msystem: UCRT64  in  release.omnibus.yml .
[Build Log ](https://buildkite.com/chef/chef-chef-workstation-main-omnibus-adhoc/builds/1314#0185c70c-dece-4752-b458-497364490f84)
Error :

```

[Builder: stunnel] I \| 2023-01-18T23:40:38+00:00 \| $ bash -c 'make ucrt64'
--
  | D \| 2023-01-18T23:40:38+00:00 \| make: *** No rule to make target 'ucrt64'.  Stop.
  | [Builder: stunnel] I \| 2023-01-18T23:40:38+00:00 \| Execute: `make ucrt64': 0.0447s
  | [Builder: stunnel] I \| 2023-01-18T23:40:38+00:00 \| Build stunnel: 27.3041s
  | The following shell command exited with status 2:

 make: *** No rule to make target 'ucrt64'.  Stop.
```


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
