### PR TITLE
CHEF-1758 Make ruby-cleanup light weight

### DIFF
--- a/config/software/ruby-cleanup.rb
+++ b/config/software/ruby-cleanup.rb
@@ -26,7 +26,7 @@ default_version "1.0.0"
 license :project_license
 skip_transitive_dependency_licensing true
 
-dependency "ruby"
+dependency "zlib" # just so we clear health-check & zlib is ruby dependency
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -39,7 +39,9 @@ build do
   # except AIX which uses them at runtime.
   unless aix?
     block "Remove static libraries" do
-      gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+      gemfile = "#{install_dir}/embedded/bin/gem"
+      next unless File.exist?(gemfile)
+      gemdir = shellout!("#{gemfile} environment gemdir", env: env).stdout.chomp
 
       # find all the static *.a files and delete them
       Dir.glob("#{gemdir}/**/*.a").each do |f|
@@ -51,7 +53,9 @@ build do
 
   # Clear the now-unnecessary git caches, docs, and build information
   block "Delete bundler git cache, docs, and build info" do
-    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+    gemfile = "#{install_dir}/embedded/bin/gem"
+    next unless File.exist?(gemfile)
+    gemdir = shellout!("#{gemfile} environment gemdir", env: env).stdout.chomp
 
     remove_directory "#{gemdir}/cache"
     remove_directory "#{gemdir}/doc"
@@ -59,7 +63,9 @@ build do
   end
 
   block "Remove bundler gem caches" do
-    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+    gemfile = "#{install_dir}/embedded/bin/gem"
+    next unless File.exist?(gemfile)
+    gemdir = shellout!("#{gemfile} environment gemdir", env: env).stdout.chomp
 
     Dir.glob("#{gemdir}/bundler/gems/**").each do |f|
       puts "Deleting #{f}"
@@ -69,6 +75,7 @@ build do
 
   block "Remove leftovers from compiling gems" do
     # find the embedded ruby gems dir and clean it up for globbing
+    next unless File.directory?("#{install_dir}/embedded/lib/ruby/gems")
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/".tr("\\", "/")
 
     # find gem_make.out and mkmf.log files
@@ -89,7 +96,9 @@ build do
   delete "#{install_dir}/embedded/info"
 
   block "Remove leftovers from compiling gems" do
-    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+    gemfile = "#{install_dir}/embedded/bin/gem"
+    next unless File.exist?(gemfile)
+    gemdir = shellout!("#{gemfile} environment gemdir", env: env).stdout.chomp
 
     # find gem_make.out and mkmf.log files
     Dir.glob("#{gemdir}/extensions/**/{gem_make.out,mkmf.log}").each do |f|
@@ -99,7 +108,9 @@ build do
   end
 
   block "Removing random non-code files from installed gems" do
-    gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
+    gemfile = "#{install_dir}/embedded/bin/gem"
+    next unless File.exist?(gemfile)
+    gemdir = shellout!("#{gemfile} environment gemdir", env: env).stdout.chomp
 
     # find the embedded ruby gems dir and clean it up for globbing
     files = %w{


### PR DESCRIPTION
## Description

The `ruby` dependency in `ruby-cleanup` omnibus software is in place to satisfy isolated build-time health-checks. This is replaced with `zlib` dependency. `zlib` is a dependency of `ruby` so semantics don't change. Some cleanup pre-checks are updated so these don't fail when assumed `gem` binary is absent.

Ideally, a no-op omnibus-software that clears all health-checks, marked as dependency of `ruby-cleanup` would make sense. The approach above is a middle-path taken.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
