### PR TITLE
Reverted default version to 1.1.35

### DIFF
--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -15,7 +15,7 @@
 #
 
 name "libxslt"
-default_version "1.1.37"
+default_version "1.1.35"
 
 license "MIT"
 license_file "COPYING"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On Solaris2-5.11, libxslt-1.1.37 fails to apply a patch .
Error :
patching file configure
  | Hunk 1 FAILED at 12849.
  | 1 out of 1 hunk FAILED -- saving rejects to file configure.rej
  |  

 update the default version to 1.1.35 to unblock chef-17 build.
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
