### PR TITLE
Update default version of make

### DIFF
--- a/config/software/make.rb
+++ b/config/software/make.rb
@@ -15,7 +15,7 @@
 #
 
 name "make"
-default_version "4.4"
+default_version "4.3"
 
 license "GPL-3.0"
 license_file "COPYING"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
AIX build with make version 4.4 failed on omnibus-toolchain. Hence updating the default version to 4.3.
[Failed log](https://buildkite.com/chef/chef-omnibus-toolchain-main-omnibus-release/builds/4#0188fdbd-fb15-4379-9162-7ccae3d0be14) 
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
