### PR TITLE
Added new versions of dependencies to overcome the chef-workstation vulnerabilities

### DIFF
--- a/config/patches/openssl/openssl-3.0.0-enable-legacy-provider.patch
+++ b/config/patches/openssl/openssl-3.0.0-enable-legacy-provider.patch
@@ -1,0 +1,48 @@
+diff --git a/apps/openssl-vms.cnf b/apps/openssl-vms.cnf
+index ac858d6..d1cb967 100644
+--- a/apps/openssl-vms.cnf
++++ b/apps/openssl-vms.cnf
+@@ -56,6 +56,7 @@ providers = provider_sect
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
++legacy  = legacy_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+ # fips = fips_sect
+@@ -69,8 +70,10 @@ default = default_sect
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
+
++[legacy_sect]
++activate = 1
+
+ ####################################################################
+ [ ca ]
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 12bc408..35a4282 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -56,6 +56,7 @@ providers = provider_sect
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
++legacy  = legacy_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+ # fips = fips_sect
+@@ -69,8 +70,10 @@ default = default_sect
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
+
++[legacy_sect]
++activate = 1
+
+ ####################################################################
+ [ ca ]

--- a/config/patches/stunnel/stunnel-on-windows-new.patch
+++ b/config/patches/stunnel/stunnel-on-windows-new.patch
@@ -1,0 +1,42 @@
+diff --git a/src/mingw.mk b/src/mingw.mk
+index cf15bee..3f61f48 100644
+--- a/src/mingw.mk
++++ b/src/mingw.mk
+@@ -15,7 +15,7 @@ bindir = ../bin/$(win32_arch)
+ objdir = ../obj/$(win32_arch)
+
+ ifeq ($(win32_ssl_dir),)
+-win32_ssl_dir := /opt/openssl-$(win32_mingw)
++win32_ssl_dir = $(WIN32_SSL_DIR_PATCHED)
+ endif
+ win32_cppflags = -I$(win32_ssl_dir)/include
+ win32_cflags = -g -mthreads -O2
+@@ -59,7 +59,8 @@ win32_cli_objs = $(addsuffix .o, $(addprefix $(objdir)/, $(win32_cli)))
+
+ win32_prefix = $(win32_targetcpu)-w64-mingw32-
+ win32_cc = $(win32_prefix)gcc
+-win32_windres = $(win32_prefix)windres
++# Our build system only has windres.exe, no prefix
++win32_windres = windres
+
+ all: mkdirs $(bindir)/stunnel.exe $(bindir)/tstunnel.exe
+
+diff --git a/src/stunnel.c b/src/stunnel.c
+index e25d5a2..368cdc8 100644
+--- a/src/stunnel.c
++++ b/src/stunnel.c
+@@ -47,7 +47,13 @@
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif /* __GNUC__ */
+
+-#include <openssl/applink.c>
++/*
++ * Maybe we could remove
++ * omnibus-software/config/patches/openssl-fips/openssl-fips-fix-compiler-flags-table-for-msys.patch
++ * and leave this include here? Building applink into openssl broke some version
++ * of Ruby
++ */
++/* #include <openssl/applink.c> */
+
+ #ifdef __GNUC__
+ #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -20,6 +20,7 @@ default_version "7.85.0"
 dependency "zlib"
 dependency "openssl"
 dependency "cacerts"
+dependency "libnghttp2" if version.satisfies?(">= 8.0")
 
 license "MIT"
 license_file "COPYING"

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -26,6 +26,7 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 # version_list: url=https://curl.se/download/ filter=*.tar.gz
+version("8.4.0")  { source sha256: "816e41809c043ff285e8c0f06a75a1fa250211bbfb2dc0a037eeef39f1a9e427" }
 version("7.85.0") { source sha256: "78a06f918bd5fde3c4573ef4f9806f56372b32ec1829c9ec474799eeee641c27" }
 version("7.84.0") { source sha256: "3c6893d38d054d4e378267166858698899e9d87258e8ff1419d020c395384535" }
 version("7.83.1") { source sha256: "93fb2cd4b880656b4e8589c912a9fd092750166d555166370247f09d18f5d0c0" }

--- a/config/software/git.rb
+++ b/config/software/git.rb
@@ -32,6 +32,7 @@ relative_path "git-#{version}"
 
 # version_list: url=https://www.kernel.org/pub/software/scm/git/ filter=*.tar.gz
 
+version("2.39.3") { source sha256: "2f9aa93c548941cc5aff641cedc24add15b912ad8c9b36ff5a41b1a9dcad783e" }
 version("2.39.0") { source sha256: "d929fe67cef7ac3ca709d2b56a9920f17112d5a524bf8112af37ec045a7a5109" }
 version("2.37.3") { source sha256: "181f65587155ea48c682f63135678ec53055adf1532428752912d356e46b64a8" }
 version("2.37.2") { source sha256: "4c428908e3a2dca4174df6ef49acc995a4fdb1b45205a2c79794487a33bc06e5" }

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -29,7 +29,7 @@ if windows?
   ext = "zip"
 
   # version_list: url=https://golang.org/dl/ filter=*.windows-amd64.zip
-  version("1.20.9")  { source sha256: "76f40848a26b31df711f06a74ab41174f08415855fd2e0d6d70761c95e92c10d" }
+  version("1.21.3")  { source sha256: "27c8daf157493f288d42a6f38debc6a2cb391f6543139eba9152fceca0be2a10" }
   version("1.19.5")  { source sha256: "167db91a2e40aeb453d3e59d213ecab06f62e1c4a84d13a06ccda1d999961caa" }
   version("1.19.1")  { source sha256: "b33584c1d93b0e9c783de876b7aa99d3018bdeccd396aeb6d516a74e9d88d55f" }
   version("1.19")    { source sha256: "bcaaf966f91980d35ae93c37a8fe890e4ddfca19448c0d9f66c027d287e2823a" }
@@ -47,7 +47,7 @@ elsif mac_os_x?
   platform = "darwin"
 
   # version_list: url=https://golang.org/dl/ filter=*.darwin-amd64.tar.gz
-  version("1.20.9")  { source sha256: "265b40cc1ff99e24774525af66c65cc60e1576b03e3de21e1ea536ee318ef4fb" }
+  version("1.21.3")  { source sha256: "27014fc69e301d7588a169ca239b3cc609f0aa1abf38528bf0d20d3b259211eb" }
   version("1.19.5")  { source sha256: "23d22bb6571bbd60197bee8aaa10e702f9802786c2e2ddce5c84527e86b66aa0" }
   version("1.19.1")  { source sha256: "b2828a2b05f0d2169afc74c11ed010775bf7cf0061822b275697b2f470495fb7" }
   version("1.19")    { source sha256: "df6509885f65f0d7a4eaf3dfbe7dda327569787e8a0a31cbf99ae3a6e23e9ea8" }
@@ -65,7 +65,7 @@ elsif mac_os_x?
 elsif armhf?
   platform = "armv6l"
   # version_list: url=https://golang.org/dl/ filter=*.linux-armv6l.tar.gz
-  version("1.20.9")  { source sha256: "285c10d21172e6a249cef69bff69385b7ddf01ce674b584af73ad2dfa1d467c4" }
+  version("1.21.3")  { source sha256: "a1ddcaaf0821a12a800884c14cb4268ce1c1f5a0301e9060646f1e15e611c6c7" }
   version("1.19.5")  { source sha256: "ec14f04bdaf4a62bdcf8b55b9b6434cc27c2df7d214d0bb7076a7597283b026a" }
   version("1.19.1")  { source sha256: "efe93f5671621ee84ce5e262e1e21acbc72acefbaba360f21778abd083d4ad16" }
   version("1.19")    { source sha256: "25197c7d70c6bf2b34d7d7c29a2ff92ba1c393f0fb395218f1147aac2948fb93" }
@@ -81,7 +81,7 @@ elsif armhf?
 elsif arm?
   platform = "arm64"
   # version_list: url=https://golang.org/dl/ filter=*.linux-arm64.tar.gz
-  version("1.20.9")  { source sha256: "da7fca78f85b90b495382cd74b2d0a1c0b6aaa200e7feb27ae7198352b2317fa" }
+  version("1.21.3")  { source sha256: "fc90fa48ae97ba6368eecb914343590bbb61b388089510d0c56c2dde52987ef3" }
   version("1.19.5")  { source sha256: "fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3" }
   version("1.19.1")  { source sha256: "49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f" }
   version("1.19")    { source sha256: "efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8" }
@@ -96,7 +96,7 @@ elsif arm?
   version("1.16.3")  { source sha256: "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d" }
 else
   # version_list: url=https://golang.org/dl/ filter=*.linux-amd64.tar.gz
-  version("1.20.9")  { source sha256: "8921369701afa749b07232d2c34d514510c32dbfd79c65adb379451b5f0d7216" }
+  version("1.21.3")  { source sha256: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8" }
   version("1.19.5")  { source sha256: "36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95" }
   version("1.19.1")  { source sha256: "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde" }
   version("1.19")    { source sha256: "464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6" }

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -29,7 +29,7 @@ if windows?
   ext = "zip"
 
   # version_list: url=https://golang.org/dl/ filter=*.windows-amd64.zip
-  version("1.20.7")  { source sha256: "736dc6c7fcab1c96b682c8c93e38d7e371e62a17d34cb2c37d451a1147f66af9" }
+  version("1.20.9")  { source sha256: "76f40848a26b31df711f06a74ab41174f08415855fd2e0d6d70761c95e92c10d" }
   version("1.19.5")  { source sha256: "167db91a2e40aeb453d3e59d213ecab06f62e1c4a84d13a06ccda1d999961caa" }
   version("1.19.1")  { source sha256: "b33584c1d93b0e9c783de876b7aa99d3018bdeccd396aeb6d516a74e9d88d55f" }
   version("1.19")    { source sha256: "bcaaf966f91980d35ae93c37a8fe890e4ddfca19448c0d9f66c027d287e2823a" }
@@ -47,7 +47,7 @@ elsif mac_os_x?
   platform = "darwin"
 
   # version_list: url=https://golang.org/dl/ filter=*.darwin-amd64.tar.gz
-  version("1.20.7")  { source sha256: "785170eab380a8985d53896808b0a71336d0ea60e0a26099b4ccec77798b1cf4" }
+  version("1.20.9")  { source sha256: "265b40cc1ff99e24774525af66c65cc60e1576b03e3de21e1ea536ee318ef4fb" }
   version("1.19.5")  { source sha256: "23d22bb6571bbd60197bee8aaa10e702f9802786c2e2ddce5c84527e86b66aa0" }
   version("1.19.1")  { source sha256: "b2828a2b05f0d2169afc74c11ed010775bf7cf0061822b275697b2f470495fb7" }
   version("1.19")    { source sha256: "df6509885f65f0d7a4eaf3dfbe7dda327569787e8a0a31cbf99ae3a6e23e9ea8" }
@@ -65,7 +65,7 @@ elsif mac_os_x?
 elsif armhf?
   platform = "armv6l"
   # version_list: url=https://golang.org/dl/ filter=*.linux-armv6l.tar.gz
-  version("1.20.7")  { source sha256: "7cc231b415b94f2f7065870a73f67dd2b0ec12b5a98052b7ee0121c42bc04f8d" }
+  version("1.20.9")  { source sha256: "285c10d21172e6a249cef69bff69385b7ddf01ce674b584af73ad2dfa1d467c4" }
   version("1.19.5")  { source sha256: "ec14f04bdaf4a62bdcf8b55b9b6434cc27c2df7d214d0bb7076a7597283b026a" }
   version("1.19.1")  { source sha256: "efe93f5671621ee84ce5e262e1e21acbc72acefbaba360f21778abd083d4ad16" }
   version("1.19")    { source sha256: "25197c7d70c6bf2b34d7d7c29a2ff92ba1c393f0fb395218f1147aac2948fb93" }
@@ -81,7 +81,7 @@ elsif armhf?
 elsif arm?
   platform = "arm64"
   # version_list: url=https://golang.org/dl/ filter=*.linux-arm64.tar.gz
-  version("1.20.7")  { source sha256: "44781ae3b153c3b07651d93b6bc554e835a36e2d72a696281c1e4dad9efffe43" }
+  version("1.20.9")  { source sha256: "da7fca78f85b90b495382cd74b2d0a1c0b6aaa200e7feb27ae7198352b2317fa" }
   version("1.19.5")  { source sha256: "fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3" }
   version("1.19.1")  { source sha256: "49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f" }
   version("1.19")    { source sha256: "efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8" }
@@ -96,7 +96,7 @@ elsif arm?
   version("1.16.3")  { source sha256: "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d" }
 else
   # version_list: url=https://golang.org/dl/ filter=*.linux-amd64.tar.gz
-  version("1.20.7")  { source sha256: "f0a87f1bcae91c4b69f8dc2bc6d7e6bfcd7524fceec130af525058c0c17b1b44" }
+  version("1.20.9")  { source sha256: "8921369701afa749b07232d2c34d514510c32dbfd79c65adb379451b5f0d7216" }
   version("1.19.5")  { source sha256: "36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95" }
   version("1.19.1")  { source sha256: "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde" }
   version("1.19")    { source sha256: "464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6" }

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -29,6 +29,7 @@ if windows?
   ext = "zip"
 
   # version_list: url=https://golang.org/dl/ filter=*.windows-amd64.zip
+  version("1.20.7")  { source sha256: "736dc6c7fcab1c96b682c8c93e38d7e371e62a17d34cb2c37d451a1147f66af9" }
   version("1.19.5")  { source sha256: "167db91a2e40aeb453d3e59d213ecab06f62e1c4a84d13a06ccda1d999961caa" }
   version("1.19.1")  { source sha256: "b33584c1d93b0e9c783de876b7aa99d3018bdeccd396aeb6d516a74e9d88d55f" }
   version("1.19")    { source sha256: "bcaaf966f91980d35ae93c37a8fe890e4ddfca19448c0d9f66c027d287e2823a" }
@@ -46,6 +47,7 @@ elsif mac_os_x?
   platform = "darwin"
 
   # version_list: url=https://golang.org/dl/ filter=*.darwin-amd64.tar.gz
+  version("1.20.7")  { source sha256: "785170eab380a8985d53896808b0a71336d0ea60e0a26099b4ccec77798b1cf4" }
   version("1.19.5")  { source sha256: "23d22bb6571bbd60197bee8aaa10e702f9802786c2e2ddce5c84527e86b66aa0" }
   version("1.19.1")  { source sha256: "b2828a2b05f0d2169afc74c11ed010775bf7cf0061822b275697b2f470495fb7" }
   version("1.19")    { source sha256: "df6509885f65f0d7a4eaf3dfbe7dda327569787e8a0a31cbf99ae3a6e23e9ea8" }
@@ -63,6 +65,7 @@ elsif mac_os_x?
 elsif armhf?
   platform = "armv6l"
   # version_list: url=https://golang.org/dl/ filter=*.linux-armv6l.tar.gz
+  version("1.20.7")  { source sha256: "7cc231b415b94f2f7065870a73f67dd2b0ec12b5a98052b7ee0121c42bc04f8d" }
   version("1.19.5")  { source sha256: "ec14f04bdaf4a62bdcf8b55b9b6434cc27c2df7d214d0bb7076a7597283b026a" }
   version("1.19.1")  { source sha256: "efe93f5671621ee84ce5e262e1e21acbc72acefbaba360f21778abd083d4ad16" }
   version("1.19")    { source sha256: "25197c7d70c6bf2b34d7d7c29a2ff92ba1c393f0fb395218f1147aac2948fb93" }
@@ -78,6 +81,7 @@ elsif armhf?
 elsif arm?
   platform = "arm64"
   # version_list: url=https://golang.org/dl/ filter=*.linux-arm64.tar.gz
+  version("1.20.7")  { source sha256: "44781ae3b153c3b07651d93b6bc554e835a36e2d72a696281c1e4dad9efffe43" }
   version("1.19.5")  { source sha256: "fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3" }
   version("1.19.1")  { source sha256: "49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f" }
   version("1.19")    { source sha256: "efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8" }
@@ -92,6 +96,7 @@ elsif arm?
   version("1.16.3")  { source sha256: "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d" }
 else
   # version_list: url=https://golang.org/dl/ filter=*.linux-amd64.tar.gz
+  version("1.20.7")  { source sha256: "f0a87f1bcae91c4b69f8dc2bc6d7e6bfcd7524fceec130af525058c0c17b1b44" }
   version("1.19.5")  { source sha256: "36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95" }
   version("1.19.1")  { source sha256: "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde" }
   version("1.19")    { source sha256: "464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6" }

--- a/config/software/libnghttp2.rb
+++ b/config/software/libnghttp2.rb
@@ -36,7 +36,7 @@ build do
 
   configure_options = [
     "--prefix=#{install_dir}/embedded",
-    "--with-openssl"
+    "--with-openssl",
   ]
 
   configure(*configure_options, env: env)

--- a/config/software/libnghttp2.rb
+++ b/config/software/libnghttp2.rb
@@ -17,11 +17,13 @@
 name "libnghttp2"
 default_version "1.58.0"
 
+dependency "openssl"
+
 license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version("1.58.0")  { source sha256: "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb" }
+version("1.58.0") { source sha256: "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb" }
 
 source url: "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/nghttp2-#{version}.tar.gz"
 internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.gz",

--- a/config/software/libnghttp2.rb
+++ b/config/software/libnghttp2.rb
@@ -32,8 +32,12 @@ relative_path "libnghttp2-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded --openssldir=#{install_dir}/embedded", env: env
+  configure_options = [
+    "--prefix=#{install_dir}/embedded",
+    "--openssldir=#{install_dir}/embedded",
+  ]
+
+  configure(*configure_options, env: env)
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/config/software/libnghttp2.rb
+++ b/config/software/libnghttp2.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libnghttp2"
+default_version "1.58.0"
+
+license "MIT"
+license_file "COPYING"
+skip_transitive_dependency_licensing true
+
+version("1.58.0")  { source sha256: "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb" }
+
+source url: "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/nghttp2-#{version}.tar.gz"
+internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.gz",
+                authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
+
+relative_path "libnghttp2-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded --openssldir=#{install_dir}/embedded", env: env
+
+  make "-j #{workers}", env: env
+  make "install", env: env
+end

--- a/config/software/libnghttp2.rb
+++ b/config/software/libnghttp2.rb
@@ -29,14 +29,14 @@ source url: "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/ng
 internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.gz",
                 authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 
-relative_path "libnghttp2-#{version}"
+relative_path "nghttp2-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   configure_options = [
     "--prefix=#{install_dir}/embedded",
-    "--openssldir=#{install_dir}/embedded",
+    "--with-openssl"
   ]
 
   configure(*configure_options, env: env)

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -101,7 +101,7 @@ build do
     "shared",
   ]
 
-  configure_args += ["--libdir=#{install_dir}/embedded/lib", "enable-md4"] if version.satisfies?(">=3.0.1")
+  configure_args += ["--libdir=#{install_dir}/embedded/lib", "enable-legacy"] if version.satisfies?(">=3.0.1")
 
   # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
   configure_args += [ "-DOPENSSL_TRUSTED_FIRST_DEFAULT" ] if version.satisfies?(">= 1.0.2zb") && version.satisfies?("< 1.1.0")

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -166,8 +166,8 @@ build do
     # Some of the algorithms are deprecated in OpenSSL3 and moved to legacy provider
     # We need those algorithms for the working of chef-workstation
     # This patch will enable the legacy providers
-    configure_args << "enable-legacy"
-    patch source: "openssl-3.0.0-enable-legacy-provider.patch", env: patch_env
+    # configure_args << "enable-legacy"
+    # patch source: "openssl-3.0.0-enable-legacy-provider.patch", env: patch_env
   end
 
   if version.start_with?("1.0.2") && mac_os_x? && arm?

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -101,7 +101,7 @@ build do
     "shared",
   ]
 
-  configure_args += ["--libdir=#{install_dir}/embedded/lib"] if version.satisfies?(">=3.0.1")
+  configure_args += ["--libdir=#{install_dir}/embedded/lib", "enable-md4"] if version.satisfies?(">=3.0.1")
 
   # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
   configure_args += [ "-DOPENSSL_TRUSTED_FIRST_DEFAULT" ] if version.satisfies?(">= 1.0.2zb") && version.satisfies?("< 1.1.0")

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -101,7 +101,7 @@ build do
     "shared",
   ]
 
-  configure_args += ["--libdir=#{install_dir}/embedded/lib", "enable-legacy"] if version.satisfies?(">=3.0.1")
+  configure_args += ["--libdir=#{install_dir}/embedded/lib"] if version.satisfies?(">=3.0.1")
 
   # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
   configure_args += [ "-DOPENSSL_TRUSTED_FIRST_DEFAULT" ] if version.satisfies?(">= 1.0.2zb") && version.satisfies?("< 1.1.0")
@@ -162,6 +162,12 @@ build do
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
   elsif version.start_with? "3.0"
     patch source: "openssl-3.0.1-do-not-install-docs.patch", env: patch_env
+
+    # Some of the algorithms are deprecated in OpenSSL3 and moved to legacy provider
+    # We need those algorithms for the working of chef-workstation
+    # This patch will enable the legacy providers
+    configure_args << "enable-legacy"
+    patch source: "openssl-3.0.0-enable-legacy-provider.patch", env: patch_env
   end
 
   if version.start_with?("1.0.2") && mac_os_x? && arm?

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -48,6 +48,7 @@ else
                   authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 end
 
+version("3.0.11")  { source sha256: "b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55" }
 version("3.0.5")   { source sha256: "aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" }
 version("3.0.4")   { source sha256: "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f" }
 version("3.0.3")   { source sha256: "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b" }

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -32,6 +32,7 @@ internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.
 
 relative_path "stunnel-#{version}"
 
+version("5.71") { source sha256: "f023aae837c2d32deb920831a5ee1081e11c78a5d57340f8e6f0829f031017f5" }
 version("5.67") { source sha256: "3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456" }
 version("5.66") { source sha256: "558178704d1aa5f6883aac6cc5d6bbf2a5714c8a0d2e91da0392468cee9f579c" }
 version("5.65") { source sha256: "60c500063bd1feff2877f5726e38278c086f96c178f03f09d264a2012d6bf7fc" }

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -45,7 +45,13 @@ version("5.39") { source sha256: "288c087a50465390d05508068ac76c8418a21fae7275fe
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  patch source: "stunnel-on-windows.patch", plevel: 1, env: env if windows?
+  # Across different versions the files have been changed and a single patch cannot be applied successfully
+  # We have two different patches:
+  #  * stunnel-on-windows.patch working from 5.39 to 5.60
+  #  * stunnel-on-windows-new.patch working from 5.61 to the latest for the time being.
+  #
+  # TODO: Find a way to patch by version
+  patch source: "stunnel-on-windows#{'-new' if version.satisfies?("> 5.60")}.patch", plevel: 1, env: env if windows?
 
   configure_args = [
     "--with-ssl=#{install_dir}/embedded",

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -51,7 +51,7 @@ build do
   #  * stunnel-on-windows-new.patch working from 5.61 to the latest for the time being.
   #
   # TODO: Find a way to patch by version
-  patch source: "stunnel-on-windows#{'-new' if version.satisfies?("> 5.60")}.patch", plevel: 1, env: env if windows?
+  patch source: "stunnel-on-windows#{"-new" if version.satisfies?("> 5.60")}.patch", plevel: 1, env: env if windows?
 
   configure_args = [
     "--with-ssl=#{install_dir}/embedded",

--- a/config/software/stunnel.rb
+++ b/config/software/stunnel.rb
@@ -84,10 +84,10 @@ build do
     make target, env: env, cwd: "#{project_dir}/src"
 
     block "copy required windows files" do
-      copy_files = %W[
+      copy_files = %W{
         #{project_dir}/bin/#{bin_dir}/stunnel.exe
         #{project_dir}/bin/#{bin_dir}/tstunnel.exe
-        #{msys_path}/#{mingw}/bin/libssp-0.dll]
+        #{msys_path}/#{mingw}/bin/libssp-0.dll}
 
       copy_files.each do |file|
         if File.exist?(file)

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -19,6 +19,7 @@ default_version "1.2.13"
 
 # version_list: url=https://zlib.net/fossils/ filter=*.tar.gz
 
+version("1.3")    { source sha256: "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e" }
 version("1.2.13") { source sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30" }
 version("1.2.12") { source sha256: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9" }
 version("1.2.11") { source sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1" }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
To overcome the CVEs identified in the chef-workstation, we need the following version of the packages. Creating this PR to add them to the omnibus

- Curl - 8.4.0
- Git - v2.39.3
- Go - v1.20.9
- Libxml2 - v2.10.4
- OpenSSL - 3.0.11
- Stunnel - 5.71
- Zlib - 1.3

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
