### PR TITLE
Updating openssl versions to add 3.1.4 support

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -48,7 +48,7 @@ else
                   authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 end
 
-version("3.1.4")   { source sha256: "840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"}
+version("3.1.4")   { source sha256: "840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" }
 
 version("3.0.5")   { source sha256: "aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" }
 version("3.0.4")   { source sha256: "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -48,6 +48,8 @@ else
                   authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 end
 
+version("3.1.4")   { source sha256: "840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3"}
+
 version("3.0.5")   { source sha256: "aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" }
 version("3.0.4")   { source sha256: "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f" }
 version("3.0.3")   { source sha256: "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b" }

--- a/test/generate_steps.rb
+++ b/test/generate_steps.rb
@@ -17,6 +17,8 @@ end
 # Get a list of all the config/software definitions that have been added or modified
 _, status = Open3.capture2e("git config --global --add safe.directory /workdir")
 exit 1 if status != 0
+_, status = Open3.capture2e("git config --global --add safe.directory /omnibus-software")
+exit 1 if status != 0
 _, status = Open3.capture2e("git fetch origin #{BRANCH}")
 exit 1 if status != 0
 stdout, status = Open3.capture2("git diff --name-status origin/#{BRANCH}...HEAD config/software | awk 'match($1, \"A\"){print $2; next} match($1, \"M\"){print $2}'")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef 18 is moving to Openssl 3.1. We need to get the version and sha into the tools

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
