### PR TITLE
Build OpenSSL 3.x and Ruby < 3.1

### DIFF
--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -49,8 +49,8 @@ build do
 
     embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
     source_openssl_rb = if version.satisfies?("< 3.1") &&
-      project.overrides[:openssl] &&
-      project.overrides[:openssl][:version].satisfies?(">= 3.0")
+        project.overrides[:openssl] &&
+        project.overrides[:openssl][:version].satisfies?(">= 3.0")
                           # ruby 3.0 by default is built with < OpenSSL 3.0, and we'll
                           # have an openssl gem separately installed as part of this
                           Dir["#{install_dir}/**/openssl-*/lib/openssl.rb"].last

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -61,7 +61,7 @@ build do
       # Unfortunately there is no patch on windows, but luckily we only need to append a line to the openssl.rb
       # to pick up our script which find the CA bundle in omnibus installations and points SSL_CERT_FILE to it
       # if it's not already set
-      source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
+      source_openssl_rb = Dir["#{install_dir}/**/openssl-*/lib/openssl.rb"].last
       File.open(source_openssl_rb, "r+") do |f|
         unpatched_openssl_rb = f.read
         f.rewind
@@ -70,7 +70,7 @@ build do
       end
     else
       embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
-      source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
+      source_openssl_rb = Dir["#{install_dir}/**/openssl-*/lib/openssl.rb"].last
       File.open(source_openssl_rb, "r+") do |f|
         unpatched_openssl_rb = f.read
         f.rewind

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -47,9 +47,10 @@ build do
       config_dir
     end
 
+    embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
     source_openssl_rb = if version.satisfies?("< 3.1") &&
-                            project.overrides[:openssl] &&
-                            project.overrides[:openssl][:version].satisfies?(">= 3.0")
+      project.overrides[:openssl] &&
+      project.overrides[:openssl][:version].satisfies?(">= 3.0")
                           # ruby 3.0 by default is built with < OpenSSL 3.0, and we'll
                           # have an openssl gem separately installed as part of this
                           Dir["#{install_dir}/**/openssl-*/lib/openssl.rb"].last
@@ -59,9 +60,7 @@ build do
 
     if windows?
       embedded_ruby_site_dir = get_sanitized_rbconfig("sitelibdir")
-      embedded_ruby_lib_dir  = get_sanitized_rbconfig("rubylibdir")
-
-      source_ssl_env_hack      = File.join(project_dir, "windows", "ssl_env_hack.rb")
+      source_ssl_env_hack = File.join(project_dir, "windows", "ssl_env_hack.rb")
       destination_ssl_env_hack = File.join(embedded_ruby_site_dir, "ssl_env_hack.rb")
 
       create_directory(embedded_ruby_site_dir)
@@ -78,7 +77,6 @@ build do
         f.write(unpatched_openssl_rb)
       end
     else
-      embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
       File.open(source_openssl_rb, "r+") do |f|
         unpatched_openssl_rb = f.read
         f.rewind

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -50,7 +50,7 @@ build do
     embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
     source_openssl_rb = if version.satisfies?("< 3.1") &&
         project.overrides[:openssl] &&
-        project.overrides[:openssl][:version].satisfies?(">= 3.0")
+        ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
                           # ruby 3.0 by default is built with < OpenSSL 3.0, and we'll
                           # have an openssl gem separately installed as part of this
                           Dir["#{install_dir}/**/openssl-*/lib/openssl.rb"].last

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -49,7 +49,7 @@ build do
 
     embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
     source_openssl_rb = if project.overrides[:openssl] && project.overrides[:ruby] &&
-        ChefUtils::VersionString.new(project.overrides[:ruby][:version].satisfies?("< 3.1")) &&
+        ChefUtils::VersionString.new(project.overrides[:ruby][:version]).satisfies?("< 3.1") &&
         ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
                           # ruby 3.0 by default is built with < OpenSSL 3.0, and we'll
                           # have an openssl gem separately installed as part of this

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -48,8 +48,8 @@ build do
     end
 
     embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
-    source_openssl_rb = if version.satisfies?("< 3.1") &&
-        project.overrides[:openssl] &&
+    source_openssl_rb = if project.overrides[:openssl] && project.overrides[:ruby] &&
+        ChefUtils::VersionString.new(project.overrides[:ruby][:version].satisfies?("< 3.1")) &&
         ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
                           # ruby 3.0 by default is built with < OpenSSL 3.0, and we'll
                           # have an openssl gem separately installed as part of this

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -49,6 +49,7 @@ else
 end
 
 version("3.0.11")  { source sha256: "b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55" }
+version("3.0.9")   { source sha256: "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90" }
 version("3.0.5")   { source sha256: "aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" }
 version("3.0.4")   { source sha256: "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f" }
 version("3.0.3")   { source sha256: "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b" }

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -267,6 +267,11 @@ build do
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end
 
+
+  unless version.satisfies?("> 3.0")
+    configure_command << "--without-openssl --with-openssl-dir=#{install_dir}/embedded"
+  end
+
   # FFS: works around a bug that infects AIX when it picks up our pkg-config
   # AFAIK, ruby does not need or use this pkg-config it just causes the build to fail.
   # The alternative would be to patch configure to remove all the pkg-config garbage entirely
@@ -276,6 +281,9 @@ build do
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
+
+  command "curl https://rubygems.org/downloads/openssl-3.2.0.gem --output openssl-3.2.0.gem"
+  command "#{install_dir}/embedded/bin/gem install openssl-3.2.0.gem --no-document"
 
   if windows?
     # Needed now that we switched to msys2 and have not figured out how to tell

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -267,7 +267,6 @@ build do
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end
 
-
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
       project.overrides[:openssl][:version].satisfies?(">= 3.0")

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -269,7 +269,7 @@ build do
 
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
-      project.overrides[:openssl][:version].satisfies?(">= 3.0")
+      ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
     configure_command << "--without-openssl --with-openssl-dir=#{install_dir}/embedded"
   end
 
@@ -285,7 +285,7 @@ build do
 
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
-      project.overrides[:openssl][:version].satisfies?(">= 3.0")
+      ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
     command "curl https://rubygems.org/downloads/openssl-3.2.0.gem --output openssl-3.2.0.gem"
     command "#{install_dir}/embedded/bin/gem install openssl-3.2.0.gem --no-document"
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -268,7 +268,9 @@ build do
   end
 
 
-  unless version.satisfies?("> 3.0")
+  if version.satisfies?("< 3.1") &&
+      project.overrides[:openssl] &&
+      project.overrides[:openssl][:version].satisfies?(">= 3.0")
     configure_command << "--without-openssl --with-openssl-dir=#{install_dir}/embedded"
   end
 
@@ -282,8 +284,12 @@ build do
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 
-  command "curl https://rubygems.org/downloads/openssl-3.2.0.gem --output openssl-3.2.0.gem"
-  command "#{install_dir}/embedded/bin/gem install openssl-3.2.0.gem --no-document"
+  if version.satisfies?("< 3.1") &&
+      project.overrides[:openssl] &&
+      project.overrides[:openssl][:version].satisfies?(">= 3.0")
+    command "curl https://rubygems.org/downloads/openssl-3.2.0.gem --output openssl-3.2.0.gem"
+    command "#{install_dir}/embedded/bin/gem install openssl-3.2.0.gem --no-document"
+  end
 
   if windows?
     # Needed now that we switched to msys2 and have not figured out how to tell


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The primary platform in mind for this OpenSSL 3.x (3.0.9 at this time) and Ruby < 3.1 (Ruby 3.0.4 at this time) is AIX, but the following guard should catch other similar cases.

```ruby
  if version.satisfies?("< 3.1") &&
      project.overrides[:openssl] &&
      project.overrides[:openssl][:version].satisfies?(">= 3.0")
```

[chef-foundation adhoc build 264](https://buildkite.com/chef/chef-chef-foundation-main-omnibus-adhoc/builds/264) has validated this against all platforms.

Tested this change against all dependent projects which are consuming openssl , updated the build logs below in comment section

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
