### PR TITLE
Updating openssl to 1.0.2zi

### DIFF
--- a/scripts/internal_sources.yml
+++ b/scripts/internal_sources.yml
@@ -142,6 +142,8 @@ software:
     sha256: 86ec5d2ecb53839e9ec999db7f8715d0eb7e534d8a1d8688ef25280fbeee2ff8
   - url: https://s3.amazonaws.com/chef-releng/openssl/openssl-1.0.2zf.tar.gz
     sha256: 85d2242b7d11a33d5f239f1f34a1ff7eb37431a554b7df99c52c646b70b14b2e
+  - url: https://s3.amazonaws.com/chef-releng/openssl/openssl-1.0.2zi.tar.gz
+    sha256: 80b6c07995fc92456e31c61cf1b2a18f75e314063189bb183af6ae66d0261d84
 
 - name: openssl-fips
   sources:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Needed by chef-foundation to get chef-18 to 1.0.2zi until we can finally migrate to openssl 3.x

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
