### PR TITLE
Fix Aix Build issue -libpsl and libgsasl

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -50,19 +50,6 @@ build do
 
   delete "#{project_dir}/src/tool_hugehelp.c"
 
-  # if aix?
-  # alpn doesn't appear to work on AIX when connecting to certain sites, most
-  # importantly for us https://www.github.com Since git uses libcurl under
-  # the covers, this functionality breaks the handshake on connection, giving
-  # a cryptic error. This patch essentially forces disabling of ALPN on AIX,
-  # which is not really what we want in a http/2 world, but we're not there
-  # yet.
-  # patch_env = env.dup
-  # patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
-  # patch source: "curl-aix-disable-alpn.patch", plevel: 0, env: patch_env
-  # otherwise gawk will die during ./configure with variations on the theme of:
-  # "/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded"
-  # env["LIBPATH"] = "/usr/lib:/lib"
   if solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -50,21 +50,20 @@ build do
 
   delete "#{project_dir}/src/tool_hugehelp.c"
 
-  if aix?
-    # alpn doesn't appear to work on AIX when connecting to certain sites, most
-    # importantly for us https://www.github.com Since git uses libcurl under
-    # the covers, this functionality breaks the handshake on connection, giving
-    # a cryptic error. This patch essentially forces disabling of ALPN on AIX,
-    # which is not really what we want in a http/2 world, but we're not there
-    # yet.
-    patch_env = env.dup
-    patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
-    patch source: "curl-aix-disable-alpn.patch", plevel: 0, env: patch_env
-
-    # otherwise gawk will die during ./configure with variations on the theme of:
-    # "/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded"
-    env["LIBPATH"] = "/usr/lib:/lib"
-  elsif solaris2?
+  # if aix?
+  # alpn doesn't appear to work on AIX when connecting to certain sites, most
+  # importantly for us https://www.github.com Since git uses libcurl under
+  # the covers, this functionality breaks the handshake on connection, giving
+  # a cryptic error. This patch essentially forces disabling of ALPN on AIX,
+  # which is not really what we want in a http/2 world, but we're not there
+  # yet.
+  # patch_env = env.dup
+  # patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
+  # patch source: "curl-aix-disable-alpn.patch", plevel: 0, env: patch_env
+  # otherwise gawk will die during ./configure with variations on the theme of:
+  # "/opt/omnibus-toolchain/embedded/lib/libiconv.a(shr4.o) could not be loaded"
+  # env["LIBPATH"] = "/usr/lib:/lib"
+  if solaris2?
     # Without /usr/gnu/bin first in PATH the libtool fails during make on Solaris
     env["PATH"] = "/usr/gnu/bin:#{env["PATH"]}"
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fix omnibus-toolchain build on AIX
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Error :
configure: WARNING: libpsl was not found
configure: WARNING: libgsasl was not found
configure: WARNING: Continuing even with errors mentioned immediately above this line.
Could not load program gawk_64:
Symbol resolution failed for gawk_64 because:
	Symbol _GLOBAL__AIXI_libintl_so (number 176) is not exported from dependent
	  module /usr/lib/libintl.a[libintl.so.8].
	  
	  aix patch file - curl-aix-disable-alpn.patch causing the issue.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
