### PR TITLE
gem openssl 3.0.0 install to be consistent with ruby 3.1.2

### DIFF
--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -48,6 +48,9 @@ build do
     end
 
     embedded_ruby_lib_dir = get_sanitized_rbconfig("rubylibdir")
+
+    # use the value from the else clause here and remove the if/else once Ruby < 3.1
+    # is not supported in combination with OpenSSL >= 3.0
     source_openssl_rb = if project.overrides[:openssl] && project.overrides[:ruby] &&
         ChefUtils::VersionString.new(project.overrides[:ruby][:version]).satisfies?("< 3.1") &&
         ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -286,8 +286,9 @@ build do
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
       ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
-    command "curl https://rubygems.org/downloads/openssl-3.2.0.gem --output openssl-3.2.0.gem"
-    command "#{install_dir}/embedded/bin/gem install openssl-3.2.0.gem --no-document"
+    # use the same version as ruby 3.1.3 version has as default, so that the chef gemfile is just redundant
+    command "curl https://rubygems.org/downloads/openssl-3.0.1.gem --output openssl-3.0.1.gem"
+    command "#{install_dir}/embedded/bin/gem install openssl-3.0.1.gem --no-document"
   end
 
   if windows?

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -286,9 +286,11 @@ build do
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
       ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
-    # use the same version as ruby 3.1.3 version has as default, so that the chef gemfile is just redundant
-    command "curl https://rubygems.org/downloads/openssl-3.0.1.gem --output openssl-3.0.1.gem"
-    command "#{install_dir}/embedded/bin/gem install openssl-3.0.1.gem --no-document"
+
+    # use the same version as ruby 3.1.2 version has as default, so that the chef gemfile is just redundant
+    openssl_gem_version = project.overrides.dig(:ruby, :openssl_gem) || "3.0.0"
+    command "curl https://rubygems.org/downloads/openssl-#{openssl_gem_version}.gem --output openssl-#{openssl_gem_version}.gem"
+    command "#{install_dir}/embedded/bin/gem install openssl-#{openssl_gem_version}.gem --no-document"
   end
 
   if windows?

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -267,6 +267,8 @@ build do
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end
 
+  # Remove this if clause once Ruby < 3.1 is not supported in combination with
+  # OpenSSL >= 3.0
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
       ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
@@ -283,11 +285,14 @@ build do
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env
 
+  # Remove this if clause once Ruby < 3.1 is not supported in combination with
+  # OpenSSL >= 3.0
   if version.satisfies?("< 3.1") &&
       project.overrides[:openssl] &&
       ChefUtils::VersionString.new(project.overrides[:openssl][:version]).satisfies?(">= 3.0")
 
-    # use the same version as ruby 3.1.2 version has as default, so that the chef gemfile is just redundant
+    # use the same version as ruby 3.1.2 version has as default, so that the chef gemfile inclusion of the
+    # same openssl gem version is redundant for ruby 3.1[.2] projects
     openssl_gem_version = project.overrides.dig(:ruby, :openssl_gem) || "3.0.0"
     command "curl https://rubygems.org/downloads/openssl-#{openssl_gem_version}.gem --output openssl-#{openssl_gem_version}.gem"
     command "#{install_dir}/embedded/bin/gem install openssl-#{openssl_gem_version}.gem --no-document"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
- Add logic to install a version of the `openssl` gem that can be consistent with the ruby version in use. Default is `3.0.0`, which is the `openssl` gem in use for Ruby 3.1.2 (caution: Ruby 3.1.3 uses `3.0.1`)
- Look for a hash key on the `:ruby` override named `:openssl_gem`, so that `omnibus_overrides.rb` can set this value.

Usage in `omnibus_overrides.rb`

```ruby
override :ruby, version: aix? ? "3.0.3" : "3.1.2", openssl_gem: "3.0.0"
```

Note: the `gem install openssl` is so that the `--without-openssl` ruby builds work. A side effect is that for Ruby 3.0.x, you will also need your Gemfile to include `openssl` version `3.0.0` (or whatever override you choose), because the built ruby will no longer include a default gem. The `openssl_gem` option is to allow some flexibility for projects that both build for a ruby 3.0 and a later ruby, so that the openssl gem used can be made to match the default gem for the >= 3.1 version of Ruby, which will vary by minor and patch version (e.g., Ruby 3.1.3 has `openssl` 3.0.1, Ruby 3.2 has `openssl` 3.1.x, Ruby 3.3 has `openssl` 3.2.x). Avoiding gems newer than the default may be unnecessary, but I've observed conflicts with a few core default gems and especially gems removed from the default gem set in later rubies that this is a safety measure against further conflicts.

I have also added comments that the manual gem install of openssl and other 3.0 vs. 3.1 code should be removed once ruby 3.0 is retired from omnibus-software dependent projects that support OpenSSL >= 3.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
