### PR TITLE
Patching resolv.rb to conditionally load

### DIFF
--- a/config/patches/ruby/ruby-win32_resolv.patch
+++ b/config/patches/ruby/ruby-win32_resolv.patch
@@ -1,5 +1,5 @@
---- C:\Ruby30-x64\lib\ruby\3.0.0\win32\resolv-orig.rb	2021-11-27 14:46:20 -0800
-+++ c:\Ruby30-x64\lib\ruby\3.0.0\win32\resolv.rb	2024-03-24 19:33:40 -0700
+--- ext/win32/lib/win32/resolv.rb.org 2024-03-25 19:48:15
++++ ext/win32/lib/win32/resolv.rb 2024-03-25 19:49:01
 @@ -4,7 +4,7 @@
  
  =end

--- a/config/patches/ruby/ruby-win32_resolv.patch
+++ b/config/patches/ruby/ruby-win32_resolv.patch
@@ -1,0 +1,11 @@
+--- C:\Ruby30-x64\lib\ruby\3.0.0\win32\resolv-orig.rb	2021-11-27 14:46:20 -0800
++++ c:\Ruby30-x64\lib\ruby\3.0.0\win32\resolv.rb	2024-03-24 19:33:40 -0700
+@@ -4,7 +4,7 @@
+ 
+ =end
+ 
+-require 'win32/registry'
++require 'win32/registry' unless defined?(Win32::Registry)
+ 
+ module Win32
+   module Resolv

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -153,15 +153,15 @@ build do
     patch source: "ruby-win32_warning_removal.patch", plevel: 1, env: patch_env
   end
 
-  # We fixed a bug regarding Windows fqdn resolution in Ohai on the 17-stable branch. 
-  # That Ohai update requires the Resolv class. The 'resolv' class unconditionally 
-  # loads the Win32::Registry class as a dependency. 
-  # Chef Infra already loads Win32::Registry and has a monkeypatch for the export_string method. 
-  # When the Resolv class loads again in Ohai, it overwrites the monkeypatch and that 
-  # leads to registry encoding/decoding errors - Base Ruby classes return text encoded in 
+  # We fixed a bug regarding Windows fqdn resolution in Ohai on the 17-stable branch.
+  # That Ohai update requires the Resolv class. The 'resolv' class unconditionally
+  # loads the Win32::Registry class as a dependency.
+  # Chef Infra already loads Win32::Registry and has a monkeypatch for the export_string method.
+  # When the Resolv class loads again in Ohai, it overwrites the monkeypatch and that
+  # leads to registry encoding/decoding errors - Base Ruby classes return text encoded in
   # UTF-16LE format and we need UTF-8.
-  # Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class 
-  # conditional and therefore prevent the monkeypatch from being overwritten. 
+  # Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class
+  # conditional and therefore prevent the monkeypatch from being overwritten.
   if windows? && version.satisfies?("~> 3.0.0")
     patch source: "ruby-win32_resolv.patch", plevel: 1, env: patch_env
   end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -153,6 +153,19 @@ build do
     patch source: "ruby-win32_warning_removal.patch", plevel: 1, env: patch_env
   end
 
+  # We fixed a bug regarding Windows fqdn resolution in Ohai on the 17-stable branch. 
+  # That Ohai update requires the Resolv class. The 'resolv' class unconditionally 
+  # loads the Win32::Registry class as a dependency. 
+  # Chef Infra already loads Win32::Registry and has a monkeypatch for the export_string method. 
+  # When the Resolv class loads again in Ohai, it overwrites the monkeypatch and that 
+  # leads to registry encoding/decoding errors - Base Ruby classes return text encoded in 
+  # UTF-16LE format and we need UTF-8.
+  # Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class 
+  # conditional and therefore prevent the monkeypatch from being overwritten. 
+  if windows? && version.satisfies?("~> 3.0.0")
+    patch source: "ruby-win32_resolv.patch", plevel: 1, env: patch_env
+  end
+
   # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we
   # cannot build modern ruby on the RHEL6 base compiler, and the configure script
   # determines that it supports that flag and so includes it and then ultimately


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We fixed a bug regarding Windows fqdn resolution in Ohai on the 17-stable branch. That Ohai update requires the Resolv class. The 'resolv' class unconditionally loads the Win32::Registry class as a dependency. Chef Infra already loads Win32::Registry and has a monkeypatch for the export_string method. When the Resolv class loads again in Ohai, it overwrites the monkeypatch and that 
leads to registry encoding/decoding errors - Base Ruby classes return text encoded in UTF-16LE format and we need UTF-8.
Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class conditional and therefore prevent the monkeypatch from being overwritten. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
