### PR TITLE
Remove - from -enable_fips

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -74,6 +74,7 @@ relative_path "openssl-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
   elsif mac_os_x? && arm?
@@ -110,7 +111,7 @@ build do
   if version.satisfies?("< 3.0.0")
     configure_args += ["--with-fipsdir=#{install_dir}/embedded", "fips"] if fips_mode?
   else
-    configure_args += ["-enable-fips"] if fips_mode?
+    configure_args += ["enable-fips"] if fips_mode?
   end
 
   configure_cmd =


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
If you pass `-enable_fips` to `configure`, it thinks that a `-e` argument with `nable_fips` is being passed, which gets passed to `ld`, resulting in the following error:

```
                          D | 2024-03-21T12:23:06+00:00 | /usr/bin/ld: warning: cannot find entry symbol nable-fips; defaulting to 00000000000b3000
```

Per the man page for `ld`, `-e` specifies the entry point (as a symbol)

```
     -e symbol_name
             Specifies the entry point of a main executable.  By default the entry name is "start" which is found in crt1.o which contains the glue code need to set up and call main().
```

Since `nable_fips` isn't a symbol in the compiled output, it selects an arbitrary entry point, which causes a crash.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
