### PR TITLE
The resolv.rb patch is not applying and leading to failures inwin32/r…

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -165,7 +165,7 @@ build do
   # UTF-16LE format and we need UTF-8.
   # Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class
   # conditional and therefore prevent the monkeypatch from being overwritten.
-  if windows? && version.satisfies?("~> 3.0.0")
+  if windows? && version.satisfies?("~> 3.0")
     patch source: "ruby-win32_resolv.patch", plevel: 0, env: patch_env
   end
 


### PR DESCRIPTION
…egistry code

<!--- Provide a short summary of your changes in the Title above -->

## Description
We previously patched the resolv.rb file to overcome an issue where another patch was being overwritten. This patch is no longer applying correctly. We are correcting that here.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
