### PR TITLE
Configure Patch to fix  ruby-3.1.4 compilation issue

### DIFF
--- a/config/patches/ruby/ruby-3.1.4-configure.patch
+++ b/config/patches/ruby/ruby-3.1.4-configure.patch
@@ -1,0 +1,26 @@
+--- ruby-3.1.4/configure.ac.org	2024-05-28 14:20:02
++++ ruby-3.1.4/configure.ac	2024-05-28 14:21:35
+@@ -363,6 +363,12 @@
+     icc_version=`echo =__ICC | $CC -E -xc - | sed '/^=/!d;s///;/^__ICC/d'`
+     test -n "$icc_version" || icc_version=0
+     # RUBY_APPEND_OPTIONS(XCFLAGS, ["-include ruby/config.h" "-include ruby/missing.h"])
++    AC_CACHE_CHECK([if thread-local storage is supported], [rb_cv_tls_supported],
++        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[int __thread conftest;]])],
++            [rb_cv_tls_supported=yes],
++            [rb_cv_tls_supported=no])])
++    AS_IF([test x"$rb_cv_tls_supported" != xyes],
++        [AC_DEFINE(RB_THREAD_LOCAL_SPECIFIER_IS_UNSUPPORTED)])
+ ], [
+     linker_flag=
+ ])
+--- ruby-3.1.4/thread_pthread.h.org	2024-05-28 14:27:35
++++ ruby-3.1.4/thread_pthread.h	2024-05-28 14:28:30
+@@ -72,7 +72,7 @@
+ 
+ #if __STDC_VERSION__ >= 201112
+   #define RB_THREAD_LOCAL_SPECIFIER _Thread_local
+-#elif defined(__GNUC__)
++#elif defined(__GNUC__) && !defined(RB_THREAD_LOCAL_SPECIFIER_IS_UNSUPPORTED)
+   /* note that ICC (linux) and Clang are covered by __GNUC__ */
+   #define RB_THREAD_LOCAL_SPECIFIER __thread
+ #else

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -191,6 +191,10 @@ build do
     patch source: "ruby-fast-load_26.patch", plevel: 1, env: patch_env
   else
     patch source: "ruby-fast-load_31.patch", plevel: 1, env: patch_env
+
+    if version.satisfies?("= 3.1.4")
+      patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
+    end
   end
 
   # this removes a checks for windows nano in the win32-ole files.

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -178,6 +178,10 @@ build do
   #
   if rhel? && platform_version.satisfies?("< 7")
     patch source: "ruby-no-stack-protector-strong.patch", plevel: 1, env: patch_env
+  else
+    if version.satisfies?("= 3.1.4")
+      patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
+    end
   end
 
   # accelerate requires of c-extension.
@@ -191,10 +195,6 @@ build do
     patch source: "ruby-fast-load_26.patch", plevel: 1, env: patch_env
   else
     patch source: "ruby-fast-load_31.patch", plevel: 1, env: patch_env
-
-    if version.satisfies?("= 3.1.4")
-      patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
-    end
   end
 
   # this removes a checks for windows nano in the win32-ole files.

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -59,17 +59,6 @@ version("3.0.3")      { source sha256: "3586861cb2df56970287f0fd83f274bd92058872
 version("3.0.2")      { source sha256: "5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" }
 version("3.0.1")      { source sha256: "369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" }
 
-version("2.7.7")      { source sha256: "e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90" }
-version("2.7.6")      { source sha256: "e7203b0cc09442ed2c08936d483f8ac140ec1c72e37bb5c401646b7866cb5d10" }
-version("2.7.5")      { source sha256: "2755b900a21235b443bb16dadd9032f784d4a88f143d852bc5d154f22b8781f1" }
-version("2.7.4")      { source sha256: "3043099089608859fc8cce7f9fdccaa1f53a462457e3838ec3b25a7d609fbc5b" }
-version("2.7.3")      { source sha256: "8925a95e31d8f2c81749025a52a544ea1d05dad18794e6828709268b92e55338" }
-
-version("2.6.10")     { source sha256: "0dc609f263d49c4176d5725deefc337273676395985b5e017789373e8cadf16e" }
-version("2.6.9")      { source sha256: "eb7bae7aac64bf9eb2153710a4cafae450ccbb62ae6f63d573e1786178b0efbb" }
-version("2.6.8")      { source sha256: "1807b78577bc08596a390e8a41aede37b8512190e05c133b17d0501791a8ca6d" }
-version("2.6.7")      { source sha256: "e4227e8b7f65485ecb73397a83e0d09dcd39f25efd411c782b69424e55c7a99e" }
-
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.gz",
                 authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
@@ -179,8 +168,10 @@ build do
   if rhel? && platform_version.satisfies?("< 7")
     patch source: "ruby-no-stack-protector-strong.patch", plevel: 1, env: patch_env
   else
-    if version.satisfies?("= 3.1.4")
-      patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
+    if rhel? && platform_version.satisfies?(">=7")
+      if version.satisfies?("= 3.1.4")
+        patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
+      end
     end
   end
 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -157,7 +157,9 @@ build do
   if windows? && version.satisfies?("~> 3.0.0")
     patch source: "ruby-win32_resolv.patch", plevel: 0, env: patch_env
   end
-
+  if suse? && version.satisfies?("= 3.1.4")
+    patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
+  end
   # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we
   # cannot build modern ruby on the RHEL6 base compiler, and the configure script
   # determines that it supports that flag and so includes it and then ultimately


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
this change will add a ruby patch file where Ruby 3.1.4 is required it for el-7 and suse platforms. and removed older ruby versions from version list since those are no longer required

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
