### PR TITLE
Updating freebsd to omit the devcrypto engine which is breaking

### DIFF
--- a/config/patches/openssl/openssl-1.0.2zi-freebsd-nocryptodev.patch
+++ b/config/patches/openssl/openssl-1.0.2zi-freebsd-nocryptodev.patch
@@ -1,0 +1,11 @@
+--- openssl-1.0.2zi/crypto/engine/eng_cryptodev.c.orig	2017-07-06 01:00:00 UTC
++++ openssl-1.0.2zi/crypto/engine/eng_cryptodev.c
+@@ -35,7 +35,7 @@
+ #if (defined(__unix__) || defined(unix)) && !defined(USG) && \
+         (defined(OpenBSD) || defined(__FreeBSD__))
+ # include <sys/param.h>
+-# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041)
++# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || (__FreeBSD_version >= 500041 && __FreeBSD_version < 1300000))
+ #  define HAVE_CRYPTODEV
+ # endif
+ # if (OpenBSD >= 200110)

--- a/config/patches/ruby/ruby-3.0.3-maybe_unused.h.patch
+++ b/config/patches/ruby/ruby-3.0.3-maybe_unused.h.patch
@@ -1,0 +1,11 @@
+--- "a/include/ruby/internal/attr/maybe_unused.h"
++++ "b/include/ruby/internal/attr/maybe_unused.h"
+@@ -27,7 +27,7 @@
+ /** Wraps  (or simulates)  `[[maybe_unused]]` */
+ #if RBIMPL_HAS_CPP_ATTRIBUTE(maybe_unused)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
+-#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused)
++#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused) && (__STDC_VERSION__ >= 202000L)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
+ #elif RBIMPL_HAS_ATTRIBUTE(unused)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() __attribute__((__unused__))

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -161,6 +161,7 @@ build do
 
   if version.start_with? "1.0"
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
+    patch source: "openssl-1.0.2zi-freebsd-nocryptodev.patch", env: patch_env
   elsif version.start_with? "1.1"
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
   elsif version.start_with? "3.0"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -224,6 +224,10 @@ build do
     end
   end
 
+  if freebsd? && version.satisfies?("~> 3.0.3")
+    patch source: "ruby-3.0.3-maybe_unused.h.patch", plevel: 1, env: patch_env
+  end
+
   # disable libpath in mkmf across all platforms, it trolls omnibus and
   # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
   # this was a good idea, but it breaks our use case hard.  AIX cannot even


### PR DESCRIPTION
In compiling Ruby 3.0.4 out for an updated Chef 17.0.149 build we encountered a couple of issues. First, compilation for openssl was dying and causing the builder to spit this error message out:

```
gmake[2]: Leaving directory '/var/cache/omnibus/chef/src/openssl/openssl-1.0.2zi/crypto/engine'
--
  | gmake[1]: Leaving directory '/var/cache/omnibus/chef/src/openssl/openssl-1.0.2zi/crypto'
  |  
  | Error:
  |  
  | eng_cryptodev.c:250:19: error: use of undeclared identifier 'CRIOGET'
  | 250 \|     if (ioctl(fd, CRIOGET, &retfd) == -1)
  | \|                   ^
  | 1 error generated.
```

if you search on the "eng_cryptodev.c... " in the error output above you get exactly 1 hit from Google which is the patch put out by Freebsd.org that tells you how to fix this:[ Go Here](https://cgit.freebsd.org/ports/commit/?id=11b77b717cb1765a3eae5730d81823e0597d985a)

The only issue with that patch is that it adds a version constraint limiting devcrypto to Freebsd 13 or less. The workaround for that moving forward is to simply add dev crypto to your modules list and voila!




## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
