### PR TITLE
Modify spec file - unpin train-core

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_dependency "omnibus", ">= 9.0.0"
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
     s.add_dependency "ffi", "< 1.17.0"
-    s.add_dependency "train-core", "<3.12.5"
   elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
     s.add_dependency "ffi", ">= 1.17.0"
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The latest version of the `train-core` gem (3.12.6) includes a fix for the issue present in version 3.12.5. We need to revert the changes made to pin the version for Ruby <= 3.1 in the `omnibus` and `omnibus-software` repositories.
Current Configuration:
if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
    s.add_dependency "train-core", "<3.12.5"

- `train-core` version 3.12.6 requires Ruby version >= 2.7.
- `train-core` version 3.12.5 required Ruby version >= 3.1.
Hence Revert the pinned  train-core version changes for Ruby <= 3.1   `omnibus-software` 
---
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
