### PR TITLE
use ruby 3.0.3 patch file for freebsd-13 to fix chef-17 build error

### DIFF
--- a/config/patches/ruby/ruby-3.0.3-freebsd_13.patch
+++ b/config/patches/ruby/ruby-3.0.3-freebsd_13.patch
@@ -1,0 +1,11 @@
+--- "a/include/ruby/internal/attr/maybe_unused.h"
++++ "b/include/ruby/internal/attr/maybe_unused.h"
+@@ -27,7 +27,7 @@
+ /** Wraps  (or simulates)  `[[maybe_unused]]` */
+ #if RBIMPL_HAS_CPP_ATTRIBUTE(maybe_unused)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
+-#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused)
++#elif RBIMPL_HAS_C_ATTRIBUTE(maybe_unused) && (__STDC_VERSION__ >= 202000L)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() [[maybe_unused]]
+ #elif RBIMPL_HAS_ATTRIBUTE(unused)
+ # define RBIMPL_ATTR_MAYBE_UNUSED() __attribute__((__unused__))

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -223,7 +223,9 @@ build do
       patch source: "ruby-faster-load_27.patch", plevel: 1, env: patch_env
     end
   end
-
+  if freebsd? && version.satisfies?("~> 3.0.3")
+    patch source: "ruby-3.0.3-freebsd_13.patch", plevel: 1, env: patch_env
+  end
   # disable libpath in mkmf across all platforms, it trolls omnibus and
   # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
   # this was a good idea, but it breaks our use case hard.  AIX cannot even


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
there is an issue on chef-17 build on freebsd which is 
```
bigdecimal.c:1407:5: error: 'maybe_unused' attribute cannot be applied to types
--
  | 1407 \|     ENTER(5);
```
https://buildkite.com/chef/chef-chef-chef-17-omnibus-adhoc/builds/813#0190e8c6-06b2-4347-a266-cdf5a9a6857c/6-12100
this patch file will help to resolve this issue
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
