### PR TITLE
add libatomic as dependency to fix keydb buils issue

### DIFF
--- a/config/software/keydb.rb
+++ b/config/software/keydb.rb
@@ -24,6 +24,8 @@ dependency "config_guess"
 dependency "openssl"
 dependency "libuuid"
 dependency "curl"
+dependency "gcc"
+dependency "libatomic"
 
 default_version "6.3.4"
 

--- a/config/software/libatomic.rb
+++ b/config/software/libatomic.rb
@@ -1,0 +1,7 @@
+name "libatomic"
+default_version "7.5.0"
+dependency "gcc"
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  command "cd #{install_dir}/embedded/lib && ln -s libatomic.so.1.2.0 libatomic.so", env: env
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
