### PR TITLE
remove libatomic dependency for keydb

### DIFF
--- a/config/patches/keydb/remove-libatomic-dep
+++ b/config/patches/keydb/remove-libatomic-dep
@@ -1,45 +1,9 @@
 --- KeyDB-6.3.4-original/src/Makefile	2024-08-23 16:20:47.182590590 -0400
 +++ KeyDB-6.3.4/src/Makefile	2024-08-23 16:21:13.045995002 -0400
-@@ -25,7 +25,7 @@
- 
- # Default settings
- STD=-pedantic -DREDIS_STATIC=''
--CXX_STD=-std=c++17 -pedantic -fno-rtti -D__STDC_FORMAT_MACROS  
-+CXX_STD=-std=c++17 -pedantic -fno-rtti -D__STDC_FORMAT_MACROS
- ifneq (,$(findstring clang,$(CC)))
-   STD+=-Wno-c11-extensions
- else
-@@ -76,7 +76,7 @@
- 	FINAL_LIBS+= -lz -lcrypto -lbz2 -lzstd -llz4 -lsnappy
- 	CXXFLAGS+= -I../deps/rocksdb/include/ -DENABLE_ROCKSDB
- 	STORAGE_OBJ+= storage/rocksdb.o storage/rocksdbfactory.o
--	FINAL_LIBS+= ../deps/rocksdb/librocksdb.a 
-+	FINAL_LIBS+= ../deps/rocksdb/librocksdb.a
- 	DEPENDENCY_TARGETS+= rocksdb
- endif
- 
-@@ -99,7 +99,7 @@
- endif
- 
- ifeq ($(COMPILER_NAME),clang)
--	CXXFLAGS+= -stdlib=libc++ 
-+	CXXFLAGS+= -stdlib=libc++
- endif
- 
- # To get ARM stack traces if KeyDB crashes we need a special C flag.
-@@ -133,7 +133,7 @@
- 
- ifeq ($(NO_LICENSE_CHECK),yes)
- 	CXXFLAGS+=-DNO_LICENSE_CHECK=1
--endif	
-+endif
- 
- # Override default settings if possible
- -include .make-settings
 @@ -144,16 +144,6 @@
  FINAL_LDFLAGS=$(LDFLAGS) $(KEYDB_LDFLAGS) $(DEBUG)
  FINAL_LIBS+=-lm -lz -lcrypto
- 
+
 -ifneq ($(uname_S),Darwin)
 -    ifneq ($(uname_S),FreeBSD)
 -	FINAL_LIBS+=-latomic
@@ -50,6 +14,6 @@
 -	FINAL_LIBS+=-latomic
 -endif
 -
- 
+
  ifeq ($(uname_S),SunOS)
  	# SunOS

--- a/config/patches/keydb/remove-libatomic-dep
+++ b/config/patches/keydb/remove-libatomic-dep
@@ -1,0 +1,55 @@
+--- KeyDB-6.3.4-original/src/Makefile	2024-08-23 16:20:47.182590590 -0400
++++ KeyDB-6.3.4/src/Makefile	2024-08-23 16:21:13.045995002 -0400
+@@ -25,7 +25,7 @@
+ 
+ # Default settings
+ STD=-pedantic -DREDIS_STATIC=''
+-CXX_STD=-std=c++17 -pedantic -fno-rtti -D__STDC_FORMAT_MACROS  
++CXX_STD=-std=c++17 -pedantic -fno-rtti -D__STDC_FORMAT_MACROS
+ ifneq (,$(findstring clang,$(CC)))
+   STD+=-Wno-c11-extensions
+ else
+@@ -76,7 +76,7 @@
+ 	FINAL_LIBS+= -lz -lcrypto -lbz2 -lzstd -llz4 -lsnappy
+ 	CXXFLAGS+= -I../deps/rocksdb/include/ -DENABLE_ROCKSDB
+ 	STORAGE_OBJ+= storage/rocksdb.o storage/rocksdbfactory.o
+-	FINAL_LIBS+= ../deps/rocksdb/librocksdb.a 
++	FINAL_LIBS+= ../deps/rocksdb/librocksdb.a
+ 	DEPENDENCY_TARGETS+= rocksdb
+ endif
+ 
+@@ -99,7 +99,7 @@
+ endif
+ 
+ ifeq ($(COMPILER_NAME),clang)
+-	CXXFLAGS+= -stdlib=libc++ 
++	CXXFLAGS+= -stdlib=libc++
+ endif
+ 
+ # To get ARM stack traces if KeyDB crashes we need a special C flag.
+@@ -133,7 +133,7 @@
+ 
+ ifeq ($(NO_LICENSE_CHECK),yes)
+ 	CXXFLAGS+=-DNO_LICENSE_CHECK=1
+-endif	
++endif
+ 
+ # Override default settings if possible
+ -include .make-settings
+@@ -144,16 +144,6 @@
+ FINAL_LDFLAGS=$(LDFLAGS) $(KEYDB_LDFLAGS) $(DEBUG)
+ FINAL_LIBS+=-lm -lz -lcrypto
+ 
+-ifneq ($(uname_S),Darwin)
+-    ifneq ($(uname_S),FreeBSD)
+-	FINAL_LIBS+=-latomic
+-    endif
+-endif
+-# Linux ARM32 needs -latomic at linking time
+-ifneq (,$(findstring armv,$(uname_M)))
+-	FINAL_LIBS+=-latomic
+-endif
+-
+ 
+ ifeq ($(uname_S),SunOS)
+ 	# SunOS

--- a/config/software/keydb.rb
+++ b/config/software/keydb.rb
@@ -43,6 +43,7 @@ build do
   env["CFLAGS"] << " -I#{install_dir}/embedded/include"
   env["LDFLAGS"] << " -L#{install_dir}/embedded/lib"
 
+  patch source: "remove-libatomic-dep", env: env
   if suse?
     env["CFLAGS"] << " -fno-lto"
     env["CXXFLAGS"] << " -fno-lto"

--- a/config/software/keydb.rb
+++ b/config/software/keydb.rb
@@ -34,7 +34,6 @@ relative_path "KeyDB-#{version}"
 
 # version_list: url=https://github.com/Snapchat/KeyDB/archive/refs/tags/ filter=*.tar.gz
 version("6.3.4") { source sha256: "229190b251f921e05aff7b0d2f04b5676c198131e2abbec1e2cfb2e61215e2f3" }
-version("6.3.1") { source sha256: "851b91e14dc3e9c973a1870acdc5f2938ad51a12877e64e7716d9e9ae91ce389" }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path).merge(
@@ -42,8 +41,9 @@ build do
   )
   env["CFLAGS"] << " -I#{install_dir}/embedded/include"
   env["LDFLAGS"] << " -L#{install_dir}/embedded/lib"
-
-  patch source: "remove-libatomic-dep", env: env
+  if version.satisfies?(">=6.3.4")
+    patch source: "remove-libatomic-dep", env: env
+  end
   if suse?
     env["CFLAGS"] << " -fno-lto"
     env["CXXFLAGS"] << " -fno-lto"


### PR DESCRIPTION
libatomic  is not easily buildable for all platforms because it was only made separately installable in later versions of GCC than we're using. Since keydb will work without this (it does not use it on darwin), we're attempting to exclude the dependency entirely to work around this issue.
