### PR TITLE
Adding libxml2 2.12.7,  libarchive 3.7.5 and git-windows 2.47.0 as the current have CVEs

### DIFF
--- a/config/software/git-windows.rb
+++ b/config/software/git-windows.rb
@@ -39,6 +39,7 @@ internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}-
 
 if windows_arch_i386?
   # version_list: url=https://github.com/git-for-windows/git/releases filter=PortableGit-*-32-bit.7z.exe
+  version("2.47.0") { source sha256: "b2def285b907ce1d47abd2df8df83df629b768defe08c1fcd4ad91582fc6606b" }
   version("2.41.0") { source sha256: "e1360e94cb292862fb023018578a1029022a09278b160f7264c6dc444f65c9ca" }
   version("2.33.0") { source sha256: "c3b6f1a8f8c1b5be2175b7190d35926dce07a58294780291326a437ef0694676" }
   version("2.31.1") { source sha256: "d6d48e16e3f0ecbc0a45d410ad3ebae15e5618202855ebe72cd9757e4d35b880" }
@@ -48,6 +49,7 @@ if windows_arch_i386?
   version("2.27.0") { source sha256: "8cbe1e3b57eb9d02e92cff12089454f2cf090c02958080d62e199ef8764542d3" }
 else
   # version_list: url=https://github.com/git-for-windows/git/releases filter=PortableGit-*-64-bit.7z.exe
+  version("2.47.0") { source sha256: "0b7fcd76902ebde5b4c00ebae597d7f65dff8c3dd0ae59f5059e1aaa3adace87" }
   version("2.41.0") { source sha256: "fcbaeffd24fdf435a1f7844825253509136377915e6720aa66aa256ec1f83c30" }
   version("2.33.0") { source sha256: "12c10fad2c2db17d9867dbbacff1adc8be50868b793a73d451c2b878914bb32d" }
   version("2.31.1") { source sha256: "fce2161a8891c4deefdb8d215ab76498c245072f269843ef1a489c4312baef52" }

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -26,6 +26,7 @@ skip_transitive_dependency_licensing true
 
 # versions_list: https://github.com/libarchive/libarchive/releases/ filter=*.tar.gz
 
+version("3.7.5") { source sha256: "37556113fe44d77a7988f1ef88bf86ab68f53d11e85066ffd3c70157cc5110f1" }
 version("3.7.4") { source sha256: "7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8" }
 version("3.6.2") { source sha256: "ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3" }
 version("3.6.1") { source sha256: "c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2" }

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -26,6 +26,7 @@ dependency "liblzma"
 dependency "config_guess"
 
 # version_list: url=https://download.gnome.org/sources/libxml2/ filter=*.tar.xz
+version("2.12.7") { source sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56" }
 version("2.12.5") { source sha256: "a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21" }
 version("2.11.7") { source sha256: "fb27720e25eaf457f94fd3d7189bcf2626c6dccf4201553bc8874d50e3560162" }
 version("2.10.4") { source sha256: "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45" }

--- a/scripts/internal_sources.yml
+++ b/scripts/internal_sources.yml
@@ -1,6 +1,8 @@
 software:
 - name: libarchive
   sources:
+  - url: https://github.com/libarchive/libarchive/releases/download/v3.7.5/libarchive-3.7.5.tar.gz
+    sha256: 37556113fe44d77a7988f1ef88bf86ab68f53d11e85066ffd3c70157cc5110f1
   - url: https://github.com/libarchive/libarchive/releases/download/v3.6.1/libarchive-3.6.1.tar.gz
     sha256: c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2
   - url: https://github.com/libarchive/libarchive/releases/download/v3.6.0/libarchive-3.6.0.tar.gz
@@ -70,6 +72,8 @@ software:
 
 - name: libxml2
   sources:
+  - url: https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz
+    sha256: 24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56
   - url: https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.5.tar.xz
     sha256: a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21
   - url: https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.7.tar.xz
@@ -363,6 +367,10 @@ software:
 
 - name: git-windows
   sources:
+  - url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/PortableGit-2.47.0-32-bit.7z.exe
+    sha256: b2def285b907ce1d47abd2df8df83df629b768defe08c1fcd4ad91582fc6606b
+  - url: https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.1/PortableGit-2.47.0-64-bit.7z.exe
+    sha256: 0b7fcd76902ebde5b4c00ebae597d7f65dff8c3dd0ae59f5059e1aaa3adace87
   - url: https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.1/PortableGit-2.33.0-32-bit.7z.exe
     sha256: c3b6f1a8f8c1b5be2175b7190d35926dce07a58294780291326a437ef0694676
   - url: https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/PortableGit-2.31.1-32-bit.7z.exe


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Adding the libxml2 v2.12.7 as v2.12.5 have high CVE - https://www.cvedetails.com/vulnerability-list/vendor_id-1962/product_id-3311/version_id-1777449/Xmlsoft-Libxml2-2.12.5.html

Adding the libarchive v3.7.5 as v3.7.4 have high and critical CVEs - https://www.cvedetails.com/vulnerability-list/vendor_id-12872/product_id-26168/version_id-1807154/Libarchive-Libarchive-3.7.4.html

Adding the git-windows v2.47.0 as v2.41.0 is bundled with curl v8.1 which is having high/critical vulnerability


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
