### PR TITLE
[WIP] Update gemspec to pull ffi >=1.17.0 irrespective of ruby version

### DIFF
--- a/omnibus-software.gemspec
+++ b/omnibus-software.gemspec
@@ -14,11 +14,15 @@ Gem::Specification.new do |s|
   # Software definitions in this bundle require at least this version of
   # omnibus because of the dsl methods they are using.
   s.add_dependency "omnibus", ">= 9.0.0"
-  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
-    s.add_dependency "ffi", "< 1.17.0"
-  elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
-    s.add_dependency "ffi", ">= 1.17.0"
-  end
+
+  # Need ffi 1.17.0 for Infra Client
+  s.add_dependency "ffi", ">= 1.17.0"
+  
+  # if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
+  #   s.add_dependency "ffi", "< 1.17.0"
+  # elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
+  #   s.add_dependency "ffi", ">= 1.17.0"
+  # end
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Update gemspec to pull ffi >=1.17.0 irrespective of ruby version as Infra Client 18 needs it at 1.17.0

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
