### PR TITLE
MacOS 15 support fixes

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -23,6 +23,7 @@ skip_transitive_dependency_licensing true
 
 # version_list: url=https://github.com/libffi/libffi/releases filter=*.tar.gz
 
+version("3.4.7") { source sha256: "138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d" }
 version("3.4.4") { source sha256: "d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676" }
 version("3.4.2") { source sha256: "540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620" }
 version("3.3")   { source sha256: "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056" }

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -15,7 +15,12 @@
 #
 
 name "zlib"
-default_version "1.2.13"
+# MacOS 15 requires newer zlib due to compilation issues
+if macos? && platform_version.satisfies?(">=15")
+  default_version "1.3.1"
+else
+  default_version "1.2.13"
+end
 
 # version_list: url=https://zlib.net/fossils/ filter=*.tar.gz
 


### PR DESCRIPTION
This contains a few fixes needed to build on MacOS 15.

- **Update libffi to 3.4.7**
- **Fix default zlib version on MacOS 15**

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
