### PR TITLE
Correcitng the tar installation

### DIFF
--- a/config/software/ruby-msys2-devkit.rb
+++ b/config/software/ruby-msys2-devkit.rb
@@ -117,6 +117,11 @@ build do
         copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-bz2-1.dll", "#{install_dir}/bin/msys-bz2-1.dll"
         copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-iconv-2.dll", "#{install_dir}/bin/msys-iconv-2.dll"
         copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-expat-1.dll", "#{install_dir}/bin/msys-expat-1.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-lzma-5.dll", "#{install_dir}/bin/msys-lzma-5.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-lz4-1.dll", "#{install_dir}/bin/msys-lz4-1.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-2.0.dll", "#{install_dir}/bin/msys-2.0.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-z.dll", "#{install_dir}/bin/msys-z.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-zstd-1.dll", "#{install_dir}/bin/msys-zstd-1.dll"
       end
     end
 

--- a/config/software/ruby-msys2-devkit.rb
+++ b/config/software/ruby-msys2-devkit.rb
@@ -112,6 +112,12 @@ build do
       # many gems that ship with native extensions assume tar will be available
       # in the PATH.
       copy "#{tmpdir}/#{msys_dir}/usr/bin/bsdtar.exe", "#{install_dir}/bin/tar.exe"
+      if version >= "3.1.6-1" do
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-crypto-3.dll", "#{install_dir}/bin/msys-crypto-3.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-bz2-1.dll", "#{install_dir}/bin/msys-bz2-1.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-iconv-2.dll", "#{install_dir}/bin/msys-iconv-2.dll"
+        copy "#{tmpdir}/#{msys_dir}/usr/bin/msys-expat-1.dll", "#{install_dir}/bin/msys-expat-1.dll"
+      end
     end
 
     command "#{embedded_dir}/#{msys_dir}/msys2_shell.cmd -defterm -no-start -c exit", env: { "CONFIG" => "" }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[CHEF-13143](https://progresssoftware.atlassian.net/browse/CHEF-13143). Per that bug, 'tar.exe' does not work on Windows Server. I tested it out on Windows 11 and it doesn't work there either. When I run it interactively, I get a series of dialog boxes telling me that 4 dll's are missing. Those files ARE shipped with the ruby devkit and with chef but are located in the \msys64\usr\bin directory and are not immediately available to chef. 

If I expand the path to include that folder the errors go away but the correct thing to do is to update the builder to put the dll's in the correct spot to begin with. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
