### PR TITLE
Add libxcrypt Software Definition

### DIFF
--- a/config/software/libcrypt.rb
+++ b/config/software/libcrypt.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libxcrypt"
+default_version "4.4.38" # Updated for modern .so.2 implementation
+
+license "LGPL-2.1"
+license_file "COPYING.LIB"
+skip_transitive_dependency_licensing true
+
+version("4.4.38") { source sha256: "e5e1f4cc232668769b96b11a00fbf1597e65bf3694b4e887dfa7ac6b0a90ffd0" } # Verify actual checksum
+
+source url: "https://github.com/besser82/libxcrypt/releases/download/v#{version}/libxcrypt-#{version}.tar.xz"
+
+relative_path "libxcrypt-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_command = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+    "--disable-werror",
+    "--enable-hashes=strong,glibc", # Modern hash algorithms
+    "--enable-obsolete-api=no",     # Disable legacy .so.1 symbols
+    "--disable-static",
+    "--with-pic"
+  ]
+
+  command configure_command.join(" "), env: env
+  make "-j #{workers}", env: env
+  make "install", env: env  # Sequential install for reliability
+
+  # Post-install verification
+  command "readelf -d #{install_dir}/embedded/lib/libcrypt.so | grep 'SONAME.*libcrypt.so.2'", env: env
+  command "objdump -T #{install_dir}/embedded/lib/libcrypt.so | grep 'GLIBC_2.2.5.*crypt_r'", env: env
+end
+


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request introduces a new software definition for libxcrypt . Adding libxcrypt as a managed dependency ensures that Omnibus-built packages can reliably link against libcrypt.so.2, improving compatibility with modern Linux distributions and eliminating the need for legacy compatibility libraries.
This PR updates Chef’s Omnibus build process to link Ruby against the modern libcrypt.so.2 instead of the legacy libcrypt.so.1

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
