### PR TITLE
Update libxml2 - 2.13.8

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -27,6 +27,7 @@ dependency "config_guess"
 
 # version_list: url=https://download.gnome.org/sources/libxml2/ filter=*.tar.xz
 version("2.14.2")  { source sha256: "353f3c83535d4224a4e5f1e88c90b5d4563ea8fec11f6407df640fd28fc8b8c6" }
+version("2.13.8")  { source sha256: "277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a" }
 version("2.13.5")  { source sha256: "74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6" }
 version("2.12.10") { source sha256: "c3d8c0c34aa39098f66576fe51969db12a5100b956233dc56506f7a8679be995" }
 version("2.12.7")  { source sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56" }
@@ -43,7 +44,6 @@ minor_version = version.gsub(/\.\d+\z/, "")
 source url: "https://download.gnome.org/sources/libxml2/#{minor_version}/libxml2-#{version}.tar.xz"
 internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.xz",
                 authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
-
 relative_path "libxml2-#{version}"
 
 build do

--- a/scripts/internal_sources.yml
+++ b/scripts/internal_sources.yml
@@ -83,6 +83,8 @@ software:
   sources:
   - url: https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.2.tar.xz
     sha256: 353f3c83535d4224a4e5f1e88c90b5d4563ea8fec11f6407df640fd28fc8b8c6
+  - url: https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.8.tar.xz
+    sha256: 277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a
   - url: https://download.gnome.org/sources/libxml2/2.12/libxml2-2.13.5.tar.xz
     sha256: 74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6
   - url: https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.10.tar.xz


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
nokogiri 1.18.8 resolved [CVE-2025-32414](https://github.com/advisories/GHSA-mfrm-w63c-3x58) and [CVE-2025-32415](https://github.com/advisories/GHSA-w8fw-fj9q-vcjj) by updating libxml2 to 2.13.8. since we were pinning libxml2 to 2.13.5 in chef-foundation, we need to update this pin to 2.13.8
#jira - https://progresssoftware.atlassian.net/browse/CHEF-22572

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
