### PR TITLE
Fix the URL for server-open-jre

### DIFF
--- a/config/software/server-open-jre.rb
+++ b/config/software/server-open-jre.rb
@@ -25,7 +25,7 @@ end
 
 license "GPL-2.0 (with the Classpath Exception)"
 
-license_file "http://openjdk.java.net/legal/gplv2+ce.html"
+license_file "https://openjdk.org/legal/gplv2+ce.html"
 skip_transitive_dependency_licensing true
 
 whitelist_file "jre/bin/javaws"


### PR DESCRIPTION
The URL has changed; I'm hoping that this is the reason we're seeing every request to fetch it timeout (resulting in  ~24 minutes extra build time for every build that includes this)

```
[Builder: server-open-jre] I | 2025-06-24T06:37:42+00:00 | Finished build
[Licensing] I | 2025-06-24T06:41:42+00:00 | Retrying failed download due to Net::ReadTimeout (5 retries left)...
[Licensing] I | 2025-06-24T06:45:42+00:00 | Retrying failed download due to Net::ReadTimeout (4 retries left)...
[Licensing] I | 2025-06-24T06:49:43+00:00 | Retrying failed download due to Net::ReadTimeout (3 retries left)...
[Licensing] I | 2025-06-24T06:53:43+00:00 | Retrying failed download due to Net::ReadTimeout (2 retries left)...
[Licensing] I | 2025-06-24T06:57:43+00:00 | Retrying failed download due to Net::ReadTimeout (1 retries left)...
[Licensing] E | 2025-06-24T07:01:44+00:00 | Download failed - Net::ReadTimeout!
[Licensing] W | 2025-06-24T07:01:44+00:00 | Can not download license file 'http://openjdk.java.net/legal/gplv2+ce.html' for software 'server-open-jre'.
```
