### PR TITLE
Add support for Ruby 3.1.7

### DIFF
--- a/config/software/ruby-msys2-devkit.rb
+++ b/config/software/ruby-msys2-devkit.rb
@@ -72,6 +72,13 @@ version "3.1.6-1" do
                   authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 end
 
+version "3.1.7-1" do
+  source url: "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-#{version}/rubyinstaller-devkit-#{version}-x64.exe",
+          sha256: "c643bf00680aa21f20b34587aa0613e9970d9b63adaef2c0228925a7f9cdfc7a"
+  internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/rubyinstaller-devkit-#{version}-x64.exe",
+                  authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
+end
+
 version "3.2.2-1" do
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-#{version}/rubyinstaller-devkit-#{version}-x64.exe",
           sha256: "678619631c7e0e9b06bd53fd50689b47770fb577a8e49a35f615d2c8691aa6b7"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -46,6 +46,7 @@ version("3.3.1") { source sha256: "8dc2af2802cc700cd182d5430726388ccf885b3f0a14f
 version("3.3.0") { source sha256: "96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d" }
 version("3.2.2") { source sha256: "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" }
 version("3.2.0") { source sha256: "daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" }
+version("3.1.7") { source sha256: "0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b" }
 version("3.1.6") { source sha256: "0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" }
 version("3.1.5") { source sha256: "3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" }
 version("3.1.4") { source sha256: "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" }
@@ -155,6 +156,7 @@ build do
   # UTF-16LE format and we need UTF-8.
   # Here we patch the Ruby Win32/Reolv.rb file to make reloading the Win32::Registry class
   # conditional and therefore prevent the monkeypatch from being overwritten.
+
   if windows? && version.satisfies?("~> 3.0.0")
     patch source: "ruby-win32_resolv.patch", plevel: 0, env: patch_env
   end
@@ -169,7 +171,7 @@ build do
   if suse? && version.satisfies?("= 3.1.4")
     patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
   end
-  if suse? && version.satisfies?("= 3.1.6")
+  if suse? && version.satisfies?(">= 3.1.6")
     patch source: "ruby-3.1.6-configure.patch", plevel: 1, env: patch_env
   end
 
@@ -186,7 +188,7 @@ build do
     if rhel? && platform_version.satisfies?(">=7")
       if version.satisfies?("= 3.1.4")
         patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
-      elsif version.satisfies?("= 3.1.6")
+      elsif version.satisfies?(">= 3.1.6")
         patch source: "ruby-3.1.6-configure.patch", plevel: 1, env: patch_env
       end
     end

--- a/scripts/internal_sources.yml
+++ b/scripts/internal_sources.yml
@@ -39,6 +39,8 @@ software:
     sha256: 5f0fd4a206b164a627c46e619d2babbcafb0ed4bc3e409267b9a73b6c58bdec1
   - url: https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.6-1/rubyinstaller-devkit-3.1.6-1-x64.exe
     sha256: 42f71849f0ae053df8d40182e00ee82a98ac5faa69d815fa850566f2d3711174
+  - url: https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.7-1/rubyinstaller-devkit-3.1.7-1-x64.exe
+    sha256: c643bf00680aa21f20b34587aa0613e9970d9b63adaef2c0228925a7f9cdfc7a
 
 - name: ruby
   sources:
@@ -48,6 +50,8 @@ software:
     sha256: 96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz
     sha256: 0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22
+  - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz
+    sha256: 0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz
     sha256: 61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request adds Ruby version 3.1.7 support .
Key changes:
- Added Ruby 3.1.7  to config/software/ruby.rb and config/software/ruby-msys2-devkit.rb.
- Updated corresponding SHA256 checksums and source URLs for Ruby 3.1.7.
- Included Ruby 3.1.7 sources in scripts/internal_sources.yml.
- Updated patch logic to apply correct patches for Ruby 3.1.7  on SLSE to fix build issue.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
