### PR TITLE
updating the SHA for Ruby 3.1.6

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -47,7 +47,7 @@ version("3.3.0") { source sha256: "96518814d9832bece92a85415a819d4893b307db5921a
 version("3.2.2") { source sha256: "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" }
 version("3.2.0") { source sha256: "daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" }
 version("3.1.7") { source sha256: "0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b" }
-version("3.1.6") { source sha256: "0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" }
+version("3.1.6") { source sha256: "2e4db40ef3703ca9ee9d2402f48f7032400d177c936e867b926d3801f88cb3ab" }
 version("3.1.5") { source sha256: "3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" }
 version("3.1.4") { source sha256: "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" }
 version("3.1.3") { source sha256: "5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" }

--- a/scripts/internal_sources.yml
+++ b/scripts/internal_sources.yml
@@ -49,7 +49,7 @@ software:
   - url: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz
     sha256: 96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz
-    sha256: 0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22
+    sha256: 2e4db40ef3703ca9ee9d2402f48f7032400d177c936e867b926d3801f88cb3ab
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz
     sha256: 0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b
   - url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The SHA256 value changed, it needs to be updated

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
