### PR TITLE
Port chef-workstation work openssl 3.2.4 + fips 3.0.9 + validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository is versioned and tagged using the `YY.MM.BUILD` to allow folks t
 
 ## Project Configuration Overrides
 
-Omnibus projects can override software configurations by providing override values in their project configuration. The following override options are available for specific software components:
+Omnibus projects can override software configurations by providing override values in their project configuration. The following software projects defined in this repo have additional options.
 
 ### Ruby OpenSSL Configuration
 
@@ -46,6 +46,8 @@ This is particularly useful when:
 - FIPS mode is enabled
 - You need a specific OpenSSL gem version for compatibility
 
+_Warning_: You need to also be sure to install the same version via your `Gemfile`, as this option just grabs a copy of the `openssl.rb` for initial native gem building. The installed gem for you project needs to match or else there is a chance of breakage of OpenSSL functionality.
+
 ### OpenSSL Version Configuration
 
 You can override the OpenSSL version used in your project and specify an alternative to the 3.0.9 FIPS version that is the default:
@@ -55,7 +57,7 @@ You can override the OpenSSL version used in your project and specify an alterna
 override :openssl, version: "3.4.1", fips_version: "3.1.2"
 ```
 
-The Ruby software definition will automatically detect when OpenSSL >= 3.0 is being used and configure the appropriate OpenSSL gem installation for compatibility.
+The Ruby software definition will automatically detect when OpenSSL >= 3.0 is being used and configure the appropriate OpenSSL gem installation for compatibility. Specifying the `:fips_version` will indicate the OpenSSL library version from which the FIPS module should be used. Currently, only `3.0.9` and `3.1.2` in the software definition are validated. See [CVEs and the FIPS Provider](https://openssl-library.org/news/fips-cve/) for a list of 3.0.0 FIPS releases.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,36 @@ For more information on writing your own software definitions, please see [the O
 
 This repository is versioned and tagged using the `YY.MM.BUILD` to allow folks to be able to access the state of the software definition at a specific point in time. We do however encourage folks to pull in the latest whenever possible.
 
+## Project Configuration Overrides
+
+Omnibus projects can override software configurations by providing override values in their project configuration. The following override options are available for specific software components:
+
+### Ruby OpenSSL Configuration
+
+When using Ruby with OpenSSL >= 3.0 in your omnibus project, you can override the OpenSSL gem version used:
+
+```ruby
+# In your omnibus project configuration
+override :ruby, version: "3.1.3", openssl_gem: "3.2.0"
+```
+
+This is particularly useful when:
+
+- Using Ruby < 3.1 with OpenSSL >= 3.0
+- FIPS mode is enabled
+- You need a specific OpenSSL gem version for compatibility
+
+### OpenSSL Version Configuration
+
+You can override the OpenSSL version used in your project and specify an alternative to the 3.0.9 FIPS version that is the default:
+
+```ruby
+# In your omnibus project configuration  
+override :openssl, version: "3.4.1", fips_version: "3.1.2"
+```
+
+The Ruby software definition will automatically detect when OpenSSL >= 3.0 is being used and configure the appropriate OpenSSL gem installation for compatibility.
+
 ## Contributing
 
 For information on contributing to this project please see our [Contributing Documentation](https://github.com/chef/chef/blob/main/CONTRIBUTING.md)

--- a/config/patches/openssl/openssl-3.2.4-do-not-install-docs.patch
+++ b/config/patches/openssl/openssl-3.2.4-do-not-install-docs.patch
@@ -1,11 +1,21 @@
+--- openssl-3.2.4/Configurations/unix-Makefile.tmpl.org	2025-03-03 12:05:33
++++ openssl-3.2.4/Configurations/unix-Makefile.tmpl	2025-03-03 12:25:17
+@@ -625,7 +625,7 @@
+ # Install helper targets #############################################
+ ##@ Installation
+
+-install: install_sw install_ssldirs {- "install_docs" if !$disabled{docs}; -} {- $disabled{fips} ? "" : "install_fips" -} ## Install software and documentation, create OpenSSL directories
++install: install_sw install_ssldirs {- $disabled{fips} ? "" : "install_fips" -}
+
+ uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled{fips} ? "" : "uninstall_fips" -} ## Uninstall software and documentation
+
 --- openssl-3.2.4/Configurations/windows-makefile.tmpl.org	2025-03-03 12:15:23
 +++ openssl-3.2.4/Configurations/windows-makefile.tmpl	2025-03-03 12:23:04
 @@ -455,7 +455,7 @@
  	@$(ECHO) "Tests are not supported with your chosen Configure options"
  	@{- output_on() if !$disabled{tests}; "\@rem" -}
- 
+
 -install: install_sw install_ssldirs {- "install_docs" if !$disabled{docs}; -} {- $disabled{fips} ? "" : "install_fips" -}
 +install: install_sw install_ssldirs {- $disabled{fips} ? "" : "install_fips" -}
- 
+
  uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled{fips} ? "" : "uninstall_fips" -}
- 

--- a/config/patches/openssl/openssl-3.2.4-enable-legacy-provider.patch
+++ b/config/patches/openssl/openssl-3.2.4-enable-legacy-provider.patch
@@ -1,0 +1,48 @@
+diff --git a/apps/openssl-vms.cnf b/apps/openssl-vms.cnf
+index ac858d6..d1cb967 100644
+--- a/apps/openssl-vms.cnf
++++ b/apps/openssl-vms.cnf
+@@ -56,6 +56,7 @@ providers = provider_sect
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
++legacy  = legacy_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+ # fips = fips_sect
+@@ -69,8 +70,10 @@ default = default_sect
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
+
++[legacy_sect]
++activate = 1
+
+ ####################################################################
+ [ ca ]
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 12bc408..35a4282 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -56,6 +56,7 @@ providers = provider_sect
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
++legacy  = legacy_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+ # fips = fips_sect
+@@ -69,8 +70,10 @@ default = default_sect
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
+
++[legacy_sect]
++activate = 1
+
+ ####################################################################
+ [ ca ]

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -50,10 +50,13 @@ end
 version("3.2.4") { source sha256: "b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5618436a0dd2c17c3716" }
 version("3.3.3") { source sha256: "712590fd20aaa60ec75d778fe5b810d6b829ca7fb1e530577917a131f9105539" }
 version("3.4.1") { source sha256: "002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" }
+
+version("3.1.2") { source sha256: "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" } # FIPS validated
+
 version("3.0.15") { source sha256: "23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" }
 version("3.0.12") { source sha256: "f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61" }
 version("3.0.11")  { source sha256: "b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55" }
-version("3.0.9")   { source sha256: "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90" }
+version("3.0.9")   { source sha256: "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90" } # FIPS validated
 version("3.0.5")   { source sha256: "aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" }
 version("3.0.4")   { source sha256: "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f" }
 version("3.0.3")   { source sha256: "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b" }
@@ -217,8 +220,7 @@ build do
   make "install", env: env
 
   if fips_mode? && version.satisfies?(">= 3.0.0")
-
-    openssl_fips_version = "3.0.9"
+    openssl_fips_version = project.overrides(:openssl, :fips_version) || "3.0.9"
 
     # Downloading the openssl-3.0.9.tar.gz file and extracting it
     command "wget https://www.openssl.org/source/openssl-#{openssl_fips_version}.tar.gz"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -169,7 +169,7 @@ build do
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
   elsif version.start_with? "1.1"
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
-  elsif version.start_with? "3.0"
+  elsif version.start_with? "3.0" || version.start_with?("3.1")
     patch source: "openssl-3.0.1-do-not-install-docs.patch", env: patch_env
     # Some of the algorithms which are being used are deprecated in OpenSSL3 and moved to legacy provider.
     # We need those algorithms for the working of chef-workstation and other packages.

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -135,7 +135,7 @@ build do
         "./Configure #{platform} -static-libgcc"
       end
     elsif windows?
-      platform = windows_arch_i386? ? "mingw" : "mingw64"
+      platform = "mingw64"
       "perl.exe ./Configure #{platform}"
     else
       prefix =

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -220,7 +220,7 @@ build do
   make "install", env: env
 
   if fips_mode? && version.satisfies?(">= 3.0.0")
-    openssl_fips_version = project.overrides(:openssl, :fips_version) || "3.0.9"
+    openssl_fips_version = project.overrides.dig(:openssl, :fips_version) || "3.0.9"
 
     # Downloading the openssl-3.0.9.tar.gz file and extracting it
     command "wget https://www.openssl.org/source/openssl-#{openssl_fips_version}.tar.gz"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -19,8 +19,9 @@ name "openssl"
 license "OpenSSL"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
+
 # Override default version if CI_OPENSSL_VERSION is set (this is used in CI for ruby software testing)
-default_version ENV["CI_OPENSSL_VERSION"] || "3.2.4"
+default_version ENV["CI_OPENSSL_VERSION"] || "1.0.2zg" # do_not_auto_update
 
 dependency "cacerts"
 dependency "openssl-fips" if fips_mode? && !(version.satisfies?(">= 3.0.0"))

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -169,7 +169,7 @@ build do
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
   elsif version.start_with? "1.1"
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
-  elsif version.start_with? "3.0" || version.start_with?("3.1")
+  elsif version.start_with?("3.0") || version.start_with?("3.1")
     patch source: "openssl-3.0.1-do-not-install-docs.patch", env: patch_env
     # Some of the algorithms which are being used are deprecated in OpenSSL3 and moved to legacy provider.
     # We need those algorithms for the working of chef-workstation and other packages.

--- a/test/omnibus.rb
+++ b/test/omnibus.rb
@@ -53,6 +53,8 @@ if ENV["SKIP_HEALTH_CHECK"]
   health_check false
 end
 
+fips_mode ENV["OMNIBUS_FIPS_MODE"] if ENV["OMNIBUS_FIPS_MODE"]
+
 # Load additional software
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']

--- a/test/validation/build_and_validate_openssl_executable.sh
+++ b/test/validation/build_and_validate_openssl_executable.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+echo "=== OpenSSL Build and Validation Wrapper ==="
+echo "Building OpenSSL first..."
+
+# Change to the test directory where omnibus-build.sh expects to be run
+cd /test
+
+export OMNIBUS_FIPS_MODE=true
+# Run the build process first
+bash --init-file omnibus-build.sh
+
+echo ""
+echo "Build completed. Checking if OpenSSL validation should run..."
+
+# Only run validation if VERSION is >= 3.0.0
+if [ -n "$VERSION" ]; then
+    # Use version comparison - convert VERSION to comparable format
+    version_major=$(echo "$VERSION" | cut -d. -f1)
+    
+    if [ "$version_major" -ge 3 ]; then
+        echo "OpenSSL version $VERSION >= 3.0.0, running executable validation..."
+        /omnibus-software/test/validation/validate_openssl_executable.sh
+    else
+        echo "OpenSSL version $VERSION < 3.0.0, skipping executable validation"
+    fi
+else
+    echo "VERSION environment variable not set, skipping validation"
+fi

--- a/test/validation/build_and_validate_openssl_providers.sh
+++ b/test/validation/build_and_validate_openssl_providers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+echo "=== OpenSSL Build and Providers Validation Wrapper ==="
+echo "Building OpenSSL first..."
+
+# Change to the test directory where omnibus-build.sh expects to be run
+cd /test
+
+export OMNIBUS_FIPS_MODE=true
+
+# Run the build process first
+bash --init-file omnibus-build.sh
+
+echo ""
+echo "Build completed. Checking if OpenSSL providers validation should run..."
+
+# Only run validation if VERSION major is >= 3
+if [ -n "$VERSION" ]; then
+    # Extract major version number
+    version_major=$(echo "$VERSION" | cut -d. -f1)
+    
+    if [ "$version_major" -ge 3 ]; then
+        echo "OpenSSL version $VERSION (major >= 3), running providers validation..."
+        /omnibus-software/test/validation/validate_openssl_providers.sh
+    else
+        echo "OpenSSL version $VERSION (major < 3), skipping providers validation"
+    fi
+else
+    echo "VERSION environment variable not set, skipping validation"
+fi

--- a/test/validation/build_and_validate_openssl_ruby.sh
+++ b/test/validation/build_and_validate_openssl_ruby.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "=== OpenSSL Build and Ruby Validation Wrapper ==="
+echo "Building OpenSSL first..."
+
+# Change to the test directory where omnibus-build.sh expects to be run
+cd /test
+
+
+export OMNIBUS_FIPS_MODE=true
+
+# Run the build process first
+bash --init-file omnibus-build.sh
+
+echo ""
+echo "Build completed. Running OpenSSL Ruby integration validation..."
+
+
+export CI_OPENSSL_VERSION=$VERSION
+export SOFTWARE=ruby
+export VERSION=3.1.6
+
+bash --init-file omnibus-build.sh
+
+export VERSION=$CI_OPENSSL_VERSION
+
+# Now run the actual validation
+/omnibus-software/test/validation/validate_openssl_ruby.rb

--- a/test/validation/validate_openssl_executable.sh
+++ b/test/validation/validate_openssl_executable.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+
+echo "=== OpenSSL Executable Validation ==="
+
+FAILURES=()
+
+# Check for OpenSSL in multiple possible locations
+POSSIBLE_PATHS=(
+    "/opt/test/embedded/bin/openssl"
+    "/opt/omnibus-toolchain/embedded/bin/openssl"
+    "/usr/bin/openssl"
+)
+
+OPENSSL_PATH=""
+for path in "${POSSIBLE_PATHS[@]}"; do
+    if [ -f "$path" ]; then
+        OPENSSL_PATH="$path"
+        echo "Found OpenSSL at: $OPENSSL_PATH"
+        break
+    fi
+done
+
+if [ -z "$OPENSSL_PATH" ]; then
+    FAILURES+=("ERROR: OpenSSL not found in any expected location")
+    FAILURES+=("Checked locations:")
+    for path in "${POSSIBLE_PATHS[@]}"; do
+        FAILURES+=("  - $path")
+    done
+    FAILURES+=("Searching for any OpenSSL installations...")
+    find /opt -name "openssl" -type f 2>/dev/null || FAILURES+=("No OpenSSL executable found in /opt")
+else
+    # Test OpenSSL executable and providers
+    echo "--- OpenSSL Version Information ---"
+    $OPENSSL_PATH version -a
+
+    echo ""
+    echo "--- Testing OpenSSL providers ---"
+    $OPENSSL_PATH list -providers
+
+    echo ""
+    echo "--- Testing legacy provider availability ---"
+    providers_output=$($OPENSSL_PATH list -providers)
+    if echo "$providers_output" | grep -qi "openssl legacy provider"; then
+        echo "Legacy provider is available"
+    else
+        FAILURES+=("Legacy provider not available - 'OpenSSL Legacy Provider' not found in providers output")
+    fi
+
+    echo ""
+    echo "--- Testing FIPS provider availability ---"
+    if echo "$providers_output" | grep -qi "openssl fips provider"; then
+        echo "FIPS provider is available"
+    else
+        FAILURES+=("FIPS provider not available - 'OpenSSL FIPS Provider' not found in providers output")
+    fi
+fi
+
+if [ ${#FAILURES[@]} -ne 0 ]; then
+    echo ""
+    echo "=== Failures ==="
+    for msg in "${FAILURES[@]}"; do
+        echo "$msg"
+    done
+    exit 1
+fi
+
+echo ""
+echo "All OpenSSL executable tests completed!"

--- a/test/validation/validate_openssl_providers.sh
+++ b/test/validation/validate_openssl_providers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+echo "=== OpenSSL Providers Configuration Validation ==="
+
+# Check if OpenSSL is installed - the test project installs to /opt/test
+OPENSSL_PATH="/opt/test/embedded/bin/openssl"
+if [ ! -f "$OPENSSL_PATH" ]; then
+    echo "ERROR: OpenSSL not found at $OPENSSL_PATH"
+    echo "Build may not have completed successfully or OpenSSL installation failed"
+    echo "Checking alternative locations..."
+    find /opt -name "openssl" -type f 2>/dev/null || echo "No OpenSSL executable found in /opt"
+    exit 1
+fi
+
+echo "--- Checking OpenSSL configuration directory ---"
+if [ -d "/opt/test/embedded/ssl/" ]; then
+    echo "SSL config directory found:"
+    ls -la /opt/test/embedded/ssl/ | head -10
+else
+    echo "SSL config directory not found"
+fi
+
+echo ""
+echo "--- Checking for provider modules ---"
+if [ -d "/opt/test/embedded/lib/ossl-modules/" ]; then
+    echo "Provider modules directory found:"
+    ls -la /opt/test/embedded/lib/ossl-modules/
+else
+    echo "Provider modules directory not found"
+fi
+
+echo ""
+echo "--- Testing provider loading with configuration ---"
+$OPENSSL_PATH list -providers -verbose
+
+echo ""
+echo "--- Testing legacy algorithms availability ---"
+if echo 'test' | $OPENSSL_PATH dgst -md5 > /dev/null 2>&1; then
+    echo "Legacy MD5 algorithm is available:"
+    echo 'test' | $OPENSSL_PATH dgst -md5
+else
+    echo "Legacy MD5 not available (may be expected if legacy provider not loaded)"
+fi
+
+echo ""
+echo "--- Testing modern algorithms ---"
+echo "SHA-256 algorithm test:"
+echo 'test' | $OPENSSL_PATH dgst -sha256
+
+echo ""
+echo "All OpenSSL provider configuration tests completed!"

--- a/test/validation/validate_openssl_ruby.rb
+++ b/test/validation/validate_openssl_ruby.rb
@@ -1,0 +1,100 @@
+#!/opt/test/embedded/bin/ruby
+
+# Check if the omnibus Ruby is installed (this should exist after build)
+# The test project installs to /opt/test
+omnibus_ruby = "/opt/test/embedded/bin/ruby"
+unless File.exist?(omnibus_ruby)
+  puts "ERROR: Omnibus Ruby not found at #{omnibus_ruby}"
+  puts "Build may not have completed successfully or Ruby installation failed"
+  puts "Checking alternative locations..."
+  begin
+    paths = Dir.glob("/opt/*/embedded/bin/ruby")
+    if paths.any?
+      puts "Found Ruby installations at: #{paths.join(", ")}"
+    else
+      puts "No omnibus Ruby installations found in /opt"
+    end
+  rescue => e
+    puts "Error searching for Ruby: #{e.message}"
+  end
+  exit 1
+end
+
+# Use the omnibus Ruby to run the actual tests
+exec(omnibus_ruby, "-e", <<~RUBY_CODE)
+  # Check if OpenSSL library exists
+  unless File.exist?("/opt/test/embedded/lib") && Dir.glob("/opt/test/embedded/lib/*ssl*").any?
+    puts "ERROR: OpenSSL libraries not found in /opt/test/embedded/lib"
+    puts "Build may not have completed successfully or OpenSSL installation failed"
+    exit 1
+  end
+
+  require "openssl"
+
+  # Get expected version from environment variable
+  expected_version = ENV['VERSION']
+
+  errors = []
+  puts "--- Ruby OpenSSL Library Version ---"
+  puts "OpenSSL::OPENSSL_LIBRARY_VERSION: \#{OpenSSL::OPENSSL_LIBRARY_VERSION}"
+  if expected_version && !OpenSSL::OPENSSL_LIBRARY_VERSION.include?(expected_version)
+    errors << "OpenSSL library version mismatch: expected to contain \#{expected_version}, got \#{OpenSSL::OPENSSL_LIBRARY_VERSION}"
+  end
+
+  puts "OpenSSL::OPENSSL_VERSION: \#{OpenSSL::OPENSSL_VERSION}"
+  puts "--- Testing FIPS mode capability ---"
+  begin
+    if OpenSSL.respond_to?(:fips_mode)
+      puts "FIPS mode available: \#{OpenSSL.fips_mode}"
+      puts "Attempting to enable FIPS mode..."
+      # Try to enable FIPS mode (may fail if FIPS provider not configured)
+      begin
+        OpenSSL.fips_mode = true
+        puts "FIPS mode enabled successfully: \#{OpenSSL.fips_mode}"
+        OpenSSL.fips_mode = false
+        puts "FIPS mode disabled successfully: \#{OpenSSL.fips_mode}"
+      rescue => e
+        puts "FIPS mode activation failed (expected if FIPS provider not configured): \#{e.message}"
+      end
+    else
+      puts "FIPS mode methods not available (OpenSSL < 3.0 or Ruby OpenSSL gem limitation)"
+      errors << "FIPS mode methods not available (OpenSSL < 3.0 or Ruby OpenSSL gem limitation)"
+    end
+  rescue => e
+    puts "Error testing FIPS mode: \#{e.message}"
+    errors << "Error testing FIPS mode: \#{e.message}"
+  end
+
+  puts "--- Testing basic cryptographic operations ---"
+  begin
+    # Test basic encryption/decryption
+    cipher = OpenSSL::Cipher.new("AES-256-CBC")
+    cipher.encrypt
+    key = cipher.random_key
+    iv = cipher.random_iv
+    encrypted = cipher.update("test data") + cipher.final
+  #{"  "}
+    cipher.decrypt
+    cipher.key = key
+    cipher.iv = iv
+    decrypted = cipher.update(encrypted) + cipher.final
+  #{"  "}
+    if decrypted == "test data"
+      puts "Basic AES-256-CBC encryption/decryption: PASS"
+    else
+      puts "Basic AES-256-CBC encryption/decryption: FAIL"
+      errors << "Basic AES-256-CBC encryption/decryption: FAIL"
+    end
+  rescue => e
+    puts "Cryptographic operation failed: \#{e.message}"
+    errors << "Cryptographic operation failed: \#{e.message}"
+  end
+
+  unless errors.empty?
+    puts "Errors encountered during OpenSSL validation:"
+    errors.each { |error| puts "- \#{error}" }
+    exit 1
+  end
+
+  puts "All OpenSSL Ruby integration tests passed!"
+RUBY_CODE


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
From https://github.com/chef/chef-workstation/pull/3305, adds openssl fips 3.0.9 with the possibility of a newer openssl.

TODO: 
- [X] validate the openssl build and fips provider

Left out:
- [ ] specifying a specific FIPS version

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
