### PR TITLE
change one-off uninstall to be an option on ruby software

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -347,9 +347,8 @@ build do
     command "#{install_dir}/embedded/bin/gem info openssl"
   end
 
-  # Remove typeprof gem for Ruby versions < 3.3.0 as it causes issues
-  if version.satisfies?("< 3.3.0")
-    command "#{install_dir}/embedded/bin/gem uninstall --all typeprof", returns: [0, 1]
+  (project.overrides.dig(:ruby, :unbundle_gems) || []).each do |gem|
+    command "#{install_dir}/embedded/bin/gem uninstall --all #{gem}", returns: [0, 1]
   end
 
   if windows?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There are various bundled gems in Ruby that are not necessarily required for end-user functionality, `typeprof` was the first, `rbs` is a second such case. Allow omnibus_overrides.rb to specify this so that omnibus-software doesn't need to be updated for every case.

Example for chef-foundation:
```ruby
  override :ruby, version: aix? ? "3.0.3" : ENV.fetch("RUBY_OVERRIDE", "3.1.7"), openssl_gem: "3.3.0", unbundle_gems: %w[rbs typeprof]
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
