### PR TITLE
Do not apply ruby 3.1.6 patch for >= 3.2.0

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -171,7 +171,7 @@ build do
   if suse? && version.satisfies?("= 3.1.4")
     patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
   end
-  if suse? && version.satisfies?(">= 3.1.6")
+  if suse? && version.satisfies?("~> 3.1.6")
     patch source: "ruby-3.1.6-configure.patch", plevel: 1, env: patch_env
   end
 
@@ -188,7 +188,7 @@ build do
     if rhel? && platform_version.satisfies?(">=7")
       if version.satisfies?("= 3.1.4")
         patch source: "ruby-3.1.4-configure.patch", plevel: 1, env: patch_env
-      elsif version.satisfies?(">= 3.1.6")
+      elsif version.satisfies?("~> 3.1.6")
         patch source: "ruby-3.1.6-configure.patch", plevel: 1, env: patch_env
       end
     end


### PR DESCRIPTION
## Description
If I have a project with a ruby version of 3.2.0 or higher, and I build for CentOS/RHEL, I get the following error when it tries to apply the `ruby-3.1.6-configure.patch` patch:

```
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | Starting build
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | Version overridden from 3.1.3 to 3.3.6
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | Environment:
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   CFLAGS="-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   CPPFLAGS="-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   CXXFLAGS="-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   LDFLAGS="-Wl,-rpath,/opt/example/embedded/lib -L/opt/example/embedded/lib"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   LD_RUN_PATH="/opt/example/embedded/lib"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   OMNIBUS_INSTALL_DIR="/opt/example"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   PATH="/opt/example/bin:/opt/example/embedded/bin:/work/.vendor/bundle/ruby/3.3.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/omnibus-toolchain/bin:/opt/omnibus-toolchain/embedded/bin/"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 |   PKG_CONFIG_PATH="/opt/example/embedded/lib/pkgconfig"
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | $ patch -p1 -i /work/.vendor/bundle/ruby/3.3.0/bundler/gems/omnibus-software-50c78858b655/config/patches/ruby/ruby-3.1.6-configure.patch
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | Apply patch `ruby-3.1.6-configure.patch': 0.0196s
          [Builder: ruby] I | 2025-08-20T16:32:54+00:00 | Build ruby: 0.0199s
The following shell command exited with status 1:

    $ CFLAGS=-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe CPPFLAGS=-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe CXXFLAGS=-I/opt/example/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -O3 -g -pipe LDFLAGS=-Wl,-rpath,/opt/example/embedded/lib -L/opt/example/embedded/lib LD_RUN_PATH=/opt/example/embedded/lib OMNIBUS_INSTALL_DIR=/opt/example PATH=/opt/example/bin:/opt/example/embedded/bin:/work/.vendor/bundle/ruby/3.3.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/omnibus-toolchain/bin:/opt/omnibus-toolchain/embedded/bin/ PKG_CONFIG_PATH=/opt/example/embedded/lib/pkgconfig patch -p1 -i /work/.vendor/bundle/ruby/3.3.0/bundler/gems/omnibus-software-50c78858b655/config/patches/ruby/ruby-3.1.6-configure.patch

Output:

    patching file configure.ac
Hunk #1 FAILED at 363.
1 out of 1 hunk FAILED -- saving rejects to file configure.ac.rej
patching file thread_pthread.h
patch unexpectedly ends in middle of line
Hunk #1 FAILED at 72.
1 out of 1 hunk FAILED -- saving rejects to file thread_pthread.h.rej

Error:

    (nothing)
```

The project file looks something like this:
```ruby
name 'example'
override :ruby, version: '3.3.6', source: { sha256: '8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d' }
# ... and so on ...
```

This worked for us previously in 052b094265989414957369c4cc63f88e2ac1acf8. The diff shows that the constraint for this patch was changed from `= 3.1.6` to `>= 3.1.6`, despite the patch not being needed in `>= 3.2.0`
https://github.com/chef/omnibus-software/compare/052b094265989414957369c4cc63f88e2ac1acf8...50c78858b655f84c33d5cd89910561a77a421629#files_bucket

In Ruby 3.2.0, `configure.ac` already has the lines added by the patch: https://github.com/ruby/ruby/blob/v3_2_0/configure.ac#L369-L374

Also in `thread_pthread.h`:
https://github.com/ruby/ruby/blob/v3_2_0/thread_pthread.h#L93-L100


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
