### PR TITLE
Update Ruby to the latest release of each series

### DIFF
--- a/config/patches/ruby/ruby-faster-load_34.patch
+++ b/config/patches/ruby/ruby-faster-load_34.patch
@@ -1,0 +1,20 @@
+--- ruby-3.4.0/load.c.org	2026-09-08 00:00:00
++++ ruby-3.4.0/load.c	2026-09-08 00:00:01
+@@ -761,7 +761,7 @@
+ 
+             if (error == Qnil) {
+                 int error_state;
+-                iseq = pm_iseq_new_top(&result.node, rb_fstring_lit("<top (required)>"), fname, realpath_internal_cached(realpath_map, fname), NULL, &error_state);
++                iseq = pm_iseq_new_top(&result.node, rb_fstring_lit("<top (required)>"), fname, fname, NULL, &error_state);
+ 
+                 pm_parse_result_free(&result);
+ 
+@@ -786,7 +786,7 @@
+             ast = rb_ruby_ast_data_get(ast_value);
+ 
+             iseq = rb_iseq_new_top(ast_value, rb_fstring_lit("<top (required)>"),
+-                                   fname, realpath_internal_cached(realpath_map, fname), NULL);
++                                   fname, fname, NULL);
+             rb_ast_dispose(ast);
+         }
+ 

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -26,7 +26,7 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "3.1.3"
+default_version "3.1.7"
 
 dependency "zlib"
 dependency "openssl"
@@ -42,8 +42,12 @@ dependency "libyaml"
 dependency "ncurses" if freebsd?
 
 # version_list: url=https://cache.ruby-lang.org/pub/ruby/ filter=*.tar.gz
+version("4.0.6") { source sha256: "837d299e8f7ddf2be31a229a7a7e019d354979825117989acb3b32b1a9be262a" }
+version("3.4.10") { source sha256: "ecee2d072a14f2d14347dd56dfd8fe5c3130abf5117bfaacbda0f4ef9cc429ec" }
+version("3.3.12") { source sha256: "b06d63beae271933033e27f0a389bc582a009e7845357d44365c39de525a051b" }
 version("3.3.1") { source sha256: "8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99" }
 version("3.3.0") { source sha256: "96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d" }
+version("3.2.11") { source sha256: "b3eeabd6636f334531db3ffdc3229eb05e524740e6c84fdc043720573cf2f8b2" }
 version("3.2.2") { source sha256: "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" }
 version("3.2.0") { source sha256: "daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" }
 version("3.1.7") { source sha256: "0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b" }
@@ -53,6 +57,7 @@ version("3.1.4") { source sha256: "a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415d
 version("3.1.3") { source sha256: "5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" }
 version("3.1.2") { source sha256: "61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" }
 version("3.1.1") { source sha256: "fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" }
+version("3.0.7") { source sha256: "2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388" }
 version("3.0.6") { source sha256: "6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" }
 version("3.0.5") { source sha256: "9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" }
 version("3.0.4") { source sha256: "70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" }
@@ -135,7 +140,7 @@ build do
     case version
     when "3.0.1"
       patch source: "ruby-3.0.1-configure.patch", plevel: 1, env: patch_env
-    when "3.0.5", "3.0.6"
+    when "3.0.5", "3.0.6", "3.0.7"
       patch source: "ruby-3.0.5-configure.patch", plevel: 1, env: patch_env
     else
       patch source: "ruby-3.0.2-configure.patch", plevel: 1, env: patch_env
@@ -226,7 +231,12 @@ build do
   if version.satisfies?("~> 2.6.0")
     patch source: "ruby-faster-load_26.patch", plevel: 1, env: patch_env
   end
-  if version.satisfies?(">=3.3")
+  if version.satisfies?(">= 3.4")
+    # ruby 3.4 moved the top-level iseq construction and made prism the default
+    # parser, adding a second call site that ruby-faster-load_33.patch does not
+    # cover. the 3.4 patch removes the realpath lookup from both call sites.
+    patch source: "ruby-faster-load_34.patch", plevel: 1, env: patch_env
+  elsif version.satisfies?(">=3.3")
     patch source: "ruby-faster-load_33.patch", plevel: 1, env: patch_env
   else
     if version.satisfies?(">= 2.7")


### PR DESCRIPTION
## Description

Adds the newest release of every Ruby series this definition tracks, and extends it to cover 3.4 and 4.0:

| Series | Added | Previous newest here |
|---|---|---|
| 4.0 | **4.0.6** | *(series not tracked)* |
| 3.4 | **3.4.10** | *(series not tracked)* |
| 3.3 | **3.3.12** | 3.3.1 |
| 3.2 | **3.2.11** | 3.2.2 |
| 3.1 | — already at 3.1.7 | 3.1.7 |
| 3.0 | **3.0.7** | 3.0.6 |

Existing `version` entries are left untouched so anything pinned to them keeps resolving.

`default_version` moves `3.1.3` → `3.1.7`. That is the newest 3.1, deliberately staying in the same series it is on today, so unpinned consumers get 3.1 security fixes without being moved onto a new Ruby line by a version-list refresh.

## Two build fixes the new versions required

These are not cosmetic — without them the added versions would not build.

**1. Ruby 3.0.7 is routed to `ruby-3.0.5-configure.patch`.**

It would otherwise fall through to the `else` branch and receive `ruby-3.0.2-configure.patch`, which **fails 5 of its 9 hunks** against 3.0.7. The two patches target different autoconf output: the 3.0.2 one expects `$as_echo`, while 3.0.5/3.0.6 — and 3.0.7 — ship the newer `printf %s` / `$as_nop` form. Confirmed by inspecting the shipped `configure` in each tarball.

**2. Ruby 3.4+ gets a new `ruby-faster-load_34.patch`.**

`ruby-faster-load_33.patch` does not apply to 3.4 or 4.0 at all (1 of 1 hunk fails on `load.c`). Beyond the context move, **3.4 made prism the default parser and added a second top-level iseq call site**:

- `pm_iseq_new_top(...)` — prism path, the one that actually runs by default
- `rb_iseq_new_top(...)` — legacy path, the only one the 3.3 patch covers

A straight context-rebase of the 3.3 patch would therefore have left the optimization inert on the default code path. The new patch removes the realpath lookup from **both** call sites, preserving the intent described in the comment above that block. The relevant region of `load.c` is byte-identical in 3.4.10 and 4.0.6, so one patch serves both, gated on `>= 3.4`.

## Verification

- **Checksums**: every sha256 verified by downloading the tarball from `cache.ruby-lang.org` and hashing it — not copied from release metadata. All 6 match.
- **Patches**: every patch each new version actually receives was dry-run applied. All clean:
  - `3.0.7` → ruby-3.0.5-configure, ruby-fast-load_26, ruby-faster-load_27, ruby-mkmf
  - `3.2.11` → ruby-fast-load_31, ruby-faster-load_27, ruby-mkmf
  - `3.3.12` → ruby-fast-load_31, ruby-faster-load_33, ruby-mkmf
  - `3.4.10` / `4.0.6` → ruby-fast-load_31, ruby-faster-load_34, ruby-mkmf
- **Gating**: `ruby-faster-load_34.patch` confirmed *not* to apply to 3.3.12, so 3.3 correctly keeps its own patch. `Gem::Requirement` routing checked: `>= 3.4` matches 3.4.10 and 4.0.6, not 3.3.12.
- **Syntax**: `ruby -c config/software/ruby.rb` passes.

## What was NOT verified

**No omnibus build was run.** Everything above is checksum verification, patch-application testing, and version-routing checks — it does not prove Ruby 3.4/4.0 compile and package correctly under this definition on every platform, and 4.0 in particular has had no exposure here before.

I would specifically appreciate a maintainer eye on:

- whether dropping the realpath argument on the prism path in `ruby-faster-load_34.patch` is semantically what you want for 3.4+ (it mirrors what the 3.3 patch does for the legacy path)
- that `realpath_map` becoming unused inside that block is acceptable — this is the same situation `ruby-faster-load_33.patch` already produces today, so the warning profile is unchanged, but it is worth a conscious nod
- whether 4.0 should land here at all yet, or wait for a build validation pass. Happy to split it into its own PR if you would rather take 3.0/3.2/3.3/3.4 first.
